### PR TITLE
fix: BootNotification must respect the OCPP specification

### DIFF
--- a/src/cp/ChargePoint.ts
+++ b/src/cp/ChargePoint.ts
@@ -209,10 +209,6 @@ export class ChargePoint {
     this._messageHandler.sendHeartbeat();
   }
 
-  public sendReset(): void {
-    this._messageHandler.sendReset();
-  }
-
   public startHeartbeat(period: number): void {
     this._logger.info("Setting heartbeat period to " + period + "s");
     if (this._heartbeat) {

--- a/src/cp/OCPPMessageHandler.ts
+++ b/src/cp/OCPPMessageHandler.ts
@@ -156,17 +156,6 @@ export class OCPPMessageHandler {
     );
   }
 
-  public sendReset(): void {
-    const messageId = this.generateMessageId();
-    const payload: request.ResetRequest = {type: "Hard"};
-    this.sendRequest(
-      OCPPMessageType.CALL,
-      OCPPAction.Reset,
-      messageId,
-      payload
-    );
-  }
-
   public sendMeterValue(transactionId:number|undefined,connectorId: number, meterValue: number): void {
     const messageId = this.generateMessageId();
     const payload: request.MeterValuesRequest = {
@@ -372,7 +361,6 @@ export class OCPPMessageHandler {
 
   private handleReset(payload: request.ResetRequest): response.ResetResponse {
     this._logger.log(`Reset request received: ${payload.type}`);
-    this._chargePoint.sendReset();
     return {status: "Accepted"};
   }
 

--- a/src/cp/OCPPMessageHandler.ts
+++ b/src/cp/OCPPMessageHandler.ts
@@ -2,7 +2,7 @@ import {OcppMessageRequestPayload, OcppMessageResponsePayload, OCPPWebSocket} fr
 import {ChargePoint} from "./ChargePoint";
 import {Transaction} from "./Transaction";
 import {Logger} from "./Logger";
-import {OCPPMessageType, OCPPAction, OCPPStatus, BootNotification} from "./OcppTypes";
+import {OCPPMessageType, OCPPAction, OCPPStatus, BootNotification, OCPPErrorCode} from "./OcppTypes";
 
 import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
 import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
@@ -464,7 +464,7 @@ export class OCPPMessageHandler {
 
   private sendCallError(
     messageId: string,
-    errorCode: string,
+    errorCode: OCPPErrorCode,
     errorDescription: string
   ): void {
     const errorDetails = {

--- a/src/cp/OCPPMessageHandler.ts
+++ b/src/cp/OCPPMessageHandler.ts
@@ -1,4 +1,4 @@
-import {OCPPWebSocket} from "./OCPPWebSocket";
+import {OcppMessageRequestPayload, OcppMessageResponsePayload, OCPPWebSocket} from "./OCPPWebSocket";
 import {ChargePoint} from "./ChargePoint";
 import {Transaction} from "./Transaction";
 import {Logger} from "./Logger";
@@ -126,11 +126,22 @@ export class OCPPMessageHandler {
 
   public sendBootNotification(bootPayload: BootNotification): void {
     const messageId = this.generateMessageId();
+    const payload: request.BootNotificationRequest = {
+      chargePointVendor: bootPayload.ChargePointVendor,
+      chargePointModel: bootPayload.ChargePointModel,
+      chargePointSerialNumber: bootPayload.ChargePointSerialNumber,
+      chargeBoxSerialNumber: bootPayload.ChargeBoxSerialNumber,
+      firmwareVersion: bootPayload.FirmwareVersion,
+      iccid: bootPayload.Iccid,
+      imsi: bootPayload.Imsi,
+      meterType: bootPayload.MeterType,
+      meterSerialNumber: bootPayload.MeterSerialNumber,
+    };
     this.sendRequest(
       OCPPMessageType.CALL,
       OCPPAction.BootNotification,
       messageId,
-      bootPayload
+      payload,
     );
   }
 
@@ -195,7 +206,7 @@ export class OCPPMessageHandler {
     type: OCPPMessageType,
     action: OCPPAction,
     id: string,
-    payload: OcppMessagePayload,
+    payload: OcppMessageRequestPayload,
     connectorId?: number
   ): void {
     this._requests.add({type, action, id, payload, connectorId});
@@ -231,7 +242,7 @@ export class OCPPMessageHandler {
     action: OCPPAction,
     payload: OcppMessagePayloadCall
   ): void {
-    let response;
+    let response: OcppMessageResponsePayload;
     switch (action) {
       case OCPPAction.RemoteStartTransaction:
         response = this.handleRemoteStartTransaction(
@@ -454,7 +465,7 @@ export class OCPPMessageHandler {
     this._logger.log(`Status notification sent successfully: ${JSON.stringify(payload)}`);
   }
 
-  private sendCallResult(messageId: string, payload: OcppMessagePayload): void {
+  private sendCallResult(messageId: string, payload: OcppMessageResponsePayload): void {
     this._webSocket.send(
       OCPPMessageType.CALL_RESULT,
       messageId,

--- a/src/cp/OCPPWebSocket.ts
+++ b/src/cp/OCPPWebSocket.ts
@@ -1,19 +1,25 @@
 import {Logger} from "./Logger";
 import {OCPPAction, OCPPMessageType} from "./OcppTypes";
 import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
+import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
 
-export type OcppMessagePayload =
-  | request.StartTransactionRequest
-  | request.StopTransactionRequest
+export type OcppMessagePayload = OcppMessageRequestPayload | OcppMessageResponsePayload;
+
+export type OcppMessageRequestPayload =
   | request.AuthorizeRequest
+  | request.BootNotificationRequest
   | request.HeartbeatRequest
   | request.MeterValuesRequest
+  | request.StartTransactionRequest
   | request.StatusNotificationRequest
-  | request.GetDiagnosticsRequest
-  | request.TriggerMessageRequest
-  | request.ResetRequest
-  | request.RemoteStartTransactionRequest
-  | request.RemoteStopTransactionRequest
+  | request.StopTransactionRequest;
+
+export type OcppMessageResponsePayload =
+  | response.GetDiagnosticsResponse
+  | response.RemoteStartTransactionResponse
+  | response.RemoteStopTransactionResponse
+  | response.ResetResponse
+  | response.TriggerMessageResponse;
 
 type MessageHandler = (
   messageType: OCPPMessageType,

--- a/src/cp/OCPPWebSocket.ts
+++ b/src/cp/OCPPWebSocket.ts
@@ -1,9 +1,9 @@
 import {Logger} from "./Logger";
-import {OCPPAction, OCPPMessageType} from "./OcppTypes";
+import {OCPPAction, OCPPErrorCode, OCPPMessageType} from "./OcppTypes";
 import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
 import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
 
-export type OcppMessagePayload = OcppMessageRequestPayload | OcppMessageResponsePayload;
+export type OcppMessagePayload = OcppMessageRequestPayload | OcppMessageResponsePayload | OcppMessageErrorPayload;
 
 export type OcppMessageRequestPayload =
   | request.AuthorizeRequest
@@ -20,6 +20,12 @@ export type OcppMessageResponsePayload =
   | response.RemoteStopTransactionResponse
   | response.ResetResponse
   | response.TriggerMessageResponse;
+
+export type OcppMessageErrorPayload = {
+  readonly errorCode: OCPPErrorCode;
+  readonly errorDescription: string;
+  readonly errorDetails?: object;
+};
 
 type MessageHandler = (
   messageType: OCPPMessageType,

--- a/src/cp/OcppTypes.ts
+++ b/src/cp/OcppTypes.ts
@@ -1,3 +1,5 @@
+import {ErrorCode} from "@voltbras/ts-ocpp/dist/ws";
+
 export enum OCPPStatus {
   Available = "Available",
   Preparing = "Preparing",
@@ -38,6 +40,8 @@ export enum OCPPAction {
   Authorize = "Authorize",
   Reset = "Reset",
 }
+
+export type OCPPErrorCode = ErrorCode;
 
 export interface BootNotification {
   ChargeBoxSerialNumber: string;


### PR DESCRIPTION
The issue comes from `request.BootNotificationRequest` which is an empty object and then tsc accept everything instead of "empty object only".