### PR TITLE
Fix: Improve WebSocket message logging to show actual payload

### DIFF
--- a/src/cp/OCPPWebSocket.ts
+++ b/src/cp/OCPPWebSocket.ts
@@ -153,7 +153,7 @@ export class OCPPWebSocket {
   }
 
   private handleMessage(ev: MessageEvent): void {
-    this._logger.log(`Received: ${JSON.stringify(ev)}`);
+    this._logger.log(`Received: ${ev.data}`);
     try {
       const messageArray = JSON.parse(ev.data.toString());
       const len = messageArray.length;


### PR DESCRIPTION
The previous implementation of message logging in `OCPPWebSocket.ts` used:

  this._logger.log(`Received: ${JSON.stringify(ev)}`);

This resulted in unclear log output such as:

  [DEBUG] Received: {"isTrusted":true}

This commit updates it to:

  this._logger.log(`Received message: ${ev.data}`);

Now the logger correctly displays the actual WebSocket payload received, e.g.:

  [DEBUG] Received message: [3,"msg-id",{"status":"Accepted"}]

This change improves debugging and clarity during development and testing.