### PR TITLE
fix: add 404.html for GitHub Pages SPA routing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,8 @@ jobs:
         run: npm install && npm install -g vite
       - name: Build
         run: VITE_BASE_URL="/ocpp-cp-simulator" npm run build
+      - name: Copy index.html to 404.html for SPA routing
+        run: cp dist/index.html dist/404.html
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
This pull request introduces an improvement to the deployment workflow for the project by addressing client-side routing issues in single-page applications (SPA) when deploying to GitHub Pages.

Deployment workflow update:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R23-R24): Added a step to copy `dist/index.html` to `dist/404.html` during the build process to ensure SPA routing works correctly on GitHub Pages.