### PR TITLE
docs(cli): ship a stable-named release tarball and point install at it

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -70,30 +70,44 @@ jobs:
           # `npm pack` reads the `files` field of package.json which includes
           # `dist`, `src/cli`, `src/cp`, and `src/utils/scenarioTemplates.ts`.
           TARBALL=$(npm pack --silent)
+          # Also publish under a stable filename so consumers can pin
+          # `releases/latest/download/ocpp-cp-simulator.tgz` and always get
+          # the newest CLI without knowing the version string.
+          cp "${TARBALL}" ocpp-cp-simulator.tgz
           echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
-          ls -lh "${TARBALL}"
+          ls -lh "${TARBALL}" ocpp-cp-simulator.tgz
 
       - name: Create / update release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: CLI ${{ steps.version.outputs.tag }}
-          files: ${{ steps.pack.outputs.tarball }}
+          files: |
+            ${{ steps.pack.outputs.tarball }}
+            ocpp-cp-simulator.tgz
           generate_release_notes: true
           body: |
             Prebuilt CLI bundle including the web console (`dist/`).
 
             ### Install
 
+            Pin to this release:
+
             ```sh
             bun install -g https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.tag }}/${{ steps.pack.outputs.tarball }}
+            ```
+
+            Or always pull the latest CLI release:
+
+            ```sh
+            bun install -g https://github.com/${{ github.repository }}/releases/latest/download/ocpp-cp-simulator.tgz
             ```
 
             Then run e.g.
 
             ```sh
-            cp-sim --http-port 5172 \
-                   --cp-id my-cp --connectors 5 \
-                   --web-console \
-                   --ws-url wss://example.com/chargepoint/
+            ocpp-cp-sim --http-port 5172 \
+                        --cp-id my-cp --connectors 5 \
+                        --web-console \
+                        --ws-url wss://example.com/chargepoint/
             ```

--- a/README.md
+++ b/README.md
@@ -26,13 +26,18 @@ bun src/cli/main.ts --ws-url ws://localhost:9000/ocpp --cp-id CP001
 ### Install as a global command (`ocpp-cp-sim`)
 
 ```bash
-# From a checkout
+# Prebuilt release tarball (includes the web-console bundle in dist/)
+bun install -g https://github.com/shiv3/ocpp-cp-simulator/releases/latest/download/ocpp-cp-simulator.tgz
+
+# Or pin to a specific CLI release
+bun install -g https://github.com/shiv3/ocpp-cp-simulator/releases/download/cli-v0.1.0/ocpp-cp-simulator-0.1.0.tgz
+
+# From a local checkout
 bun link              # in this repo
 bun link ocpp-cp-simulator   # in any other project
-
-# Or directly from git
-bun install -g github:shiv3/ocpp-cp-simulator
 ```
+
+> The release tarballs are produced by the `Release CLI` workflow on `cli-v*` tags. A bare `bun install -g github:shiv3/ocpp-cp-simulator` does **not** work — `dist/` is built at release time, not committed, and bun doesn't install devDependencies for global packages so the on-install `vite build` can't run.
 
 Then run from anywhere:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,17 +24,22 @@ npm run cli -- --ws-url ws://localhost:9000/ocpp --cp-id CP001
 The package exposes a `ocpp-cp-sim` bin so it can be invoked from anywhere once installed:
 
 ```bash
-# From a checkout
+# Prebuilt release tarball (recommended) — ships the web-console dist/
+bun install -g https://github.com/shiv3/ocpp-cp-simulator/releases/latest/download/ocpp-cp-simulator.tgz
+
+# Or pin to a specific CLI release
+bun install -g https://github.com/shiv3/ocpp-cp-simulator/releases/download/cli-v0.1.0/ocpp-cp-simulator-0.1.0.tgz
+
+# From a local checkout (dev)
 bun link
 bun link ocpp-cp-simulator    # in any consumer project
-
-# Or globally from git
-bun install -g github:shiv3/ocpp-cp-simulator
 
 # Then use ocpp-cp-sim anywhere
 ocpp-cp-sim --ws-url ws://localhost:9000/ocpp --cp-id CP001
 ocpp-cp-sim --daemon --http-port 9700
 ```
+
+> A plain `bun install -g github:shiv3/ocpp-cp-simulator` is **not** supported: the web-console `dist/` is built at release time (not committed to git), and bun doesn't install devDependencies for global packages so it can't run `vite build` on install. Use the prebuilt tarball URL above.
 
 All flags described below apply to both `ocpp-cp-sim ...` and `bun src/cli/main.ts ...`.
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "preview": "vite preview",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "husky || true && vite build",
+    "prepare": "husky || true",
     "prepack": "vite build",
     "postinstall": "node -e \"try{require('fs').chmodSync('src/cli/main.ts',0o755)}catch(e){}\"",
     "tauri": "tauri",


### PR DESCRIPTION
## Summary

- `bun install -g github:shiv3/ocpp-cp-simulator` is currently broken — `dist/` is built at release time (not committed) and bun doesn't install devDeps for global bin packages, so `vite build` can't run during install (and is blocked as untrusted anyway).
- The existing `cli-release.yml` workflow already builds and uploads a `npm pack` tarball as a Release asset. Three small tweaks make it the documented install path:
  - **`cli-release.yml`**: also publish under the stable filename `ocpp-cp-simulator.tgz` so users can pin `releases/latest/download/ocpp-cp-simulator.tgz` and always get the newest CLI.
  - **`package.json`**: drop the `&& vite build` half of `prepare` (never fired for consumers; duplicated `prepack` for devs).
  - **README.md / docs/cli.md**: replace the broken `bun install -g github:…` line with the prebuilt tarball URL (latest + pinned), and call out why the bare git URL doesn't work.

## Once merged

Push a `cli-v0.1.0` tag (or run the workflow via `workflow_dispatch`) to produce the first usable Release asset. After that:

```sh
bun install -g https://github.com/shiv3/ocpp-cp-simulator/releases/latest/download/ocpp-cp-simulator.tgz
```

## Test plan

- [ ] `npx vite build` green (verified locally)
- [ ] `npx vitest run` green (15/15 verified locally)
- [ ] After merge: `cli-v*` tag triggers `cli-release.yml` and uploads both `ocpp-cp-simulator-<ver>.tgz` and `ocpp-cp-simulator.tgz` to the Release
- [ ] `bun install -g <release-url>` then `ocpp-cp-sim --help` works on a clean machine
- [ ] `ocpp-cp-sim --web-console …` finds `dist/` and serves the UI