### PR TITLE
fix(cli-release): stop prepack from corrupting the TARBALL capture

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -69,7 +69,11 @@ jobs:
         run: |
           # `npm pack` reads the `files` field of package.json which includes
           # `dist`, `src/cli`, `src/cp`, and `src/utils/scenarioTemplates.ts`.
-          TARBALL=$(npm pack --silent)
+          # --ignore-scripts skips the `prepack` hook (vite build) — we
+          # already built dist/ in the previous step, and letting prepack
+          # run again pollutes the captured stdout with vite's build log,
+          # which breaks the $TARBALL capture below.
+          TARBALL=$(npm pack --silent --ignore-scripts)
           # Also publish under a stable filename so consumers can pin
           # `releases/latest/download/ocpp-cp-simulator.tgz` and always get
           # the newest CLI without knowing the version string.


### PR DESCRIPTION
## Summary

The CLI release run for `cli-v0.1.0` failed at the Pack tarball step ([run 26787496100](https://github.com/shiv3/ocpp-cp-simulator/actions/runs/26787496100)):

```
cp: cannot stat '<entire vite build log>\nocpp-cp-simulator-0.1.0.tgz': No such file or directory
##[error]Process completed with exit code 1.
```

`TARBALL=\$(npm pack --silent)` captured npm's stdout into a shell var. `--silent` only suppresses npm's own logging — it doesn't touch the `prepack` lifecycle script, which runs `vite build`. Vite writes its build report to stdout, so `\$TARBALL` ended up containing the whole build log plus the real tarball filename on the last line. The follow-up `cp` then tried to stat that garbage path and exited 1.

The workflow already runs `bun run build` in an earlier step, so `dist/` is fresh by the time we pack. Passing `--ignore-scripts` to `npm pack` skips the redundant prepack run, keeps stdout clean, and shaves a few seconds off the job.

## After merge

Re-run the release: either delete + re-push the `cli-v0.1.0` tag, or run the workflow via `workflow_dispatch` with version `0.1.0`.

## Test plan

- [ ] Workflow re-run on `cli-v0.1.0` produces both `ocpp-cp-simulator-0.1.0.tgz` and `ocpp-cp-simulator.tgz` as Release assets
- [ ] `bun install -g https://github.com/shiv3/ocpp-cp-simulator/releases/latest/download/ocpp-cp-simulator.tgz` succeeds on a clean machine
- [ ] `ocpp-cp-sim --web-console …` serves the UI (dist/ is shipped)