### PR TITLE
fix(provider): fall back to Local mode on /healthz non-2xx (incl. 404)

### DIFF
--- a/src/data/providers/DataProvider.tsx
+++ b/src/data/providers/DataProvider.tsx
@@ -153,10 +153,27 @@ export const DataProvider: React.FC<DataProviderProps> = ({
     let cancelled = false;
     const origin = window.location.origin;
     fetch(`${origin}/healthz`, { method: "GET", cache: "no-store" })
-      .then((res) => (res.ok ? res.json() : null))
+      .then(async (res) => {
+        // `fetch` does NOT reject on HTTP error status — a 404 (e.g. when
+        // the UI is served from GitHub Pages where no /healthz endpoint
+        // exists) resolves with res.ok=false. Treat any non-2xx as
+        // "no daemon here → Local" so we don't sit in the null-mode
+        // initialization gate forever.
+        if (!res.ok) return null;
+        try {
+          return (await res.json()) as unknown;
+        } catch {
+          return null;
+        }
+      })
       .then((body) => {
-        if (cancelled || !body || typeof body !== "object") return;
-        if ("ok" in body && (body as { ok?: unknown }).ok === true) {
+        if (cancelled) return;
+        if (
+          body &&
+          typeof body === "object" &&
+          "ok" in body &&
+          (body as { ok?: unknown }).ok === true
+        ) {
           setModeState("remote");
           setServerUrlState(origin);
         } else {
@@ -164,7 +181,7 @@ export const DataProvider: React.FC<DataProviderProps> = ({
         }
       })
       .catch(() => {
-        // No daemon at this origin — Local.
+        // Network error (CORS, offline, DNS, …) — also Local.
         if (!cancelled) setModeState("local");
       });
 


### PR DESCRIPTION
## Summary

The static GitHub Pages build at https://shiv3.github.io/ocpp-cp-simulator/ became unusable: the page hangs in the initialization gate, with `GET https://shiv3.github.io/healthz 404 (Not Found)` in the console.

The 404 itself is expected — there's no daemon on the page origin, the UI should fall back to Local mode. But the mode-detection chain in `DataProvider.tsx` mishandled the non-success branch:

```ts
.then((res) => (res.ok ? res.json() : null))
.then((body) => {
  if (cancelled || !body || typeof body !== "object") return;  // ← null short-circuits without setModeState
  …
})
.catch(() => { setModeState("local"); });  // ← never fires for 404 (fetch resolves)
```

`fetch` doesn't reject on HTTP error status, so a 404 resolves with `res.ok=false`, the response is mapped to `null`, the body check returns early, and `setModeState` is never called. `mode` sits at `null` forever and the initialization gate blocks rendering.

## Fix

Treat any non-2xx (or unparseable JSON) as "no daemon → Local", and keep the strict `{ ok: true }` check for the Remote branch so a GitHub Pages soft-404 HTML body can't accidentally hijack the mode.

## Test plan

- [ ] `npx vite build` green (verified locally)
- [ ] `npx vitest run` green (15/15 verified locally)
- [ ] After deploy: https://shiv3.github.io/ocpp-cp-simulator/ loads to the local-mode UI (no more init-gate hang)
- [ ] `ocpp-cp-sim --web-console …` still auto-detects Remote (healthz returns 200 + `{ok:true}`)