### PR TITLE
docs(readme): add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OCPP CP Simulator
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/shiv3/ocpp-cp-simulator)
+
 OCPP 1.6J charge point simulator with three interfaces: a browser-based UI, a legacy web version (v1), and a headless CLI for automation.
 
 | Interface     | Description                                              | Docs                               |


### PR DESCRIPTION
Surfaces the DeepWiki Q&A entry point at the top of the README so visitors notice it before scrolling. The link itself was already mentioned in the docs section — this just promotes it to a clickable badge under the title.