### PR TITLE
feat(tauri): boot daemon as sidecar and serve the full web console

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,21 @@ jobs:
       - name: Install frontend dependencies
         run: npm install
 
+      - name: Setup Bun (for sidecar compile)
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build CLI sidecar (Bun --compile → src-tauri/binaries/)
+        # The Tauri build step below picks up the sidecar via
+        # `bundle.externalBin`. Tauri expects the suffix to match the
+        # rust target triple, which is what scripts/build-tauri-sidecar.sh
+        # produces. Bun handles cross-compile internally.
+        shell: bash
+        env:
+          TAURI_TARGET: ${{ matrix.target }}
+        run: bash scripts/build-tauri-sidecar.sh
+
       - name: Generate app icon
         run: |
           cd src-tauri

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ dist-ssr
 src-tauri/target/
 src-tauri/Cargo.lock
 src-tauri/gen/
+
+# Tauri sidecar — Bun-compiled CLI per target triple, produced at build
+# time by scripts/build-tauri-sidecar.sh. Never committed.
+src-tauri/binaries/

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Both the browser UI and the daemon back their state with SQLite — sql.js + Ind
 
 The browser UI auto-detects which mode to run in by probing `/healthz` at its own origin:
 
-- Served by `ocpp-cp-sim --web-console` (or the Docker image) → **Remote**: every operation is proxied to the daemon over HTTP/WS.
-- Static build (GitHub Pages, `bun run dev`, Tauri) → **Local**: charge points run entirely in-browser, persistence via sql.js.
+- Served by `ocpp-cp-sim --web-console`, the Docker image, or the **Tauri desktop app** (which bundles the daemon as a sidecar) → **Remote**: every operation is proxied to the daemon over HTTP/WS.
+- Static build (GitHub Pages, `bun run dev`) → **Local**: charge points run entirely in-browser, persistence via sql.js.
 
 There is no toggle — the mode is decided once on page load and never overridden.
 

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -6,7 +6,19 @@ React + TypeScript web application with Flowbite/Tailwind UI. Also available as 
 
 https://shiv3.github.io/ocpp-cp-simulator/
 
+The hosted web version runs in **Local mode** — every charge point lives in the browser tab, persisting to IndexedDB via sql.js. Closing the tab keeps the data; clearing site data drops it.
+
 ## Desktop Application
+
+The desktop app is **not** a wrapper around the static Local-mode build. On launch it spins up the bundled simulator daemon as a sidecar, waits for `/healthz`, then opens the full web console served by that daemon — so you get the same Remote-mode UX as `ocpp-cp-sim --web-console`, without having to install anything else.
+
+- State (`state.db`) is written to the OS-standard app data dir:
+  - macOS: `~/Library/Application Support/com.ocpp.cp-simulator/state.db`
+  - Linux: `~/.local/share/com.ocpp.cp-simulator/state.db`
+  - Windows: `%APPDATA%\com.ocpp.cp-simulator\state.db`
+- The daemon binds an ephemeral port on `127.0.0.1` — no firewall prompt.
+- Closing the window terminates the daemon (SIGTERM) so the next launch starts from a clean process.
+- Multiple-launch is squashed by `tauri-plugin-single-instance`: the second invocation focuses the existing window instead of starting a second daemon.
 
 ### Download
 
@@ -60,16 +72,23 @@ npm install
 # Web dev server
 npm run dev
 
-# Desktop dev mode (requires Rust)
+# Desktop dev mode (requires Rust + Bun)
+#   In debug builds the desktop shell spawns `bun src/cli/main.ts ...`
+#   directly, so iteration on the daemon stays fast — no need to
+#   re-compile the sidecar between edits.
 npm run tauri:dev
 
 # Production build
+#   The beforeBuildCommand chains `npm run build` and
+#   `scripts/build-tauri-sidecar.sh`, so `dist/` + the Bun-compiled
+#   sidecar both land in `src-tauri/` before tauri bundles the app.
 npm run tauri:build
 ```
 
 ### Prerequisites
 
 - Node.js (v18 or later)
+- Bun (used to compile the CLI sidecar for `tauri:build`; needed for `tauri:dev` too since the desktop shell spawns `bun src/cli/main.ts`)
 - Rust (latest stable, desktop only)
 - Platform-specific dependencies:
   - **Linux**: `libwebkit2gtk-4.1-dev`, `libappindicator3-dev`, `librsvg2-dev`, `patchelf`

--- a/public/splash.html
+++ b/public/splash.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OCPP CP Simulator</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 1.5rem;
+        background: #0b1220;
+        color: #e2e8f0;
+      }
+      .spinner {
+        width: 48px;
+        height: 48px;
+        border-radius: 50%;
+        border: 4px solid #1e293b;
+        border-top-color: #38bdf8;
+        animation: spin 0.9s linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      .title {
+        font-size: 1.05rem;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+      }
+      .subtitle {
+        font-size: 0.85rem;
+        color: #94a3b8;
+      }
+      .error {
+        color: #f87171;
+        text-align: center;
+        max-width: 80%;
+        line-height: 1.4;
+      }
+      code {
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        background: #1e293b;
+        padding: 0.1rem 0.35rem;
+        border-radius: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="spinner" id="spinner"></div>
+    <div class="title" id="title">Starting OCPP CP Simulator…</div>
+    <div class="subtitle" id="subtitle">Spinning up the daemon</div>
+
+    <script>
+      // The splash page lives at tauri://localhost/splash.html. Once the
+      // bundled daemon answers /healthz we redirect the same webview to
+      // http://127.0.0.1:<port>/ where the full web console takes over.
+      const POLL_INTERVAL_MS = 200;
+      const POLL_TIMEOUT_MS = 30_000;
+
+      async function waitForDaemon() {
+        const url = await window.__TAURI__.core.invoke("get_daemon_url");
+        const started = Date.now();
+        while (Date.now() - started < POLL_TIMEOUT_MS) {
+          try {
+            const res = await fetch(`${url}/healthz`, { cache: "no-store" });
+            if (res.ok) {
+              const body = await res.json().catch(() => null);
+              if (body && body.ok === true) {
+                window.location.replace(`${url}/`);
+                return;
+              }
+            }
+          } catch {
+            // network error, daemon not bound yet — keep polling
+          }
+          await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+        }
+        showError(url);
+      }
+
+      function showError(url) {
+        document.getElementById("spinner").style.display = "none";
+        document.getElementById("title").textContent =
+          "Daemon failed to start";
+        const sub = document.getElementById("subtitle");
+        sub.classList.add("error");
+        sub.innerHTML =
+          `The bundled daemon at <code>${url}</code> didn't answer ` +
+          `<code>/healthz</code> within 30 s. ` +
+          "Check the app log for spawn failures.";
+      }
+
+      // The splash boots inside the Tauri webview, so __TAURI__ is always
+      // present — but be defensive: if someone opens splash.html directly
+      // in a browser, fail loudly instead of silently hanging.
+      if (window.__TAURI__ && window.__TAURI__.core) {
+        waitForDaemon();
+      } else {
+        document.getElementById("spinner").style.display = "none";
+        document.getElementById("title").textContent =
+          "Splash page is for the Tauri shell only";
+        document.getElementById("subtitle").textContent =
+          "Run the desktop app or `bun run tauri dev`.";
+      }
+    </script>
+  </body>
+</html>

--- a/scripts/build-tauri-sidecar.sh
+++ b/scripts/build-tauri-sidecar.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Build a Bun-compiled CLI binary for use as a Tauri sidecar.
+#
+# Tauri's external-bin convention is "<base-name>-<rust-target-triple>[.exe]".
+# In CI we know the triple via $TAURI_TARGET (set by the workflow). Locally,
+# without an argument, we detect the host triple.
+#
+#   scripts/build-tauri-sidecar.sh                       # auto-detect host
+#   scripts/build-tauri-sidecar.sh aarch64-apple-darwin  # explicit
+#
+# The output lands at src-tauri/binaries/ocpp-cp-sim-<triple>[.exe], which is
+# what tauri.conf.json's `bundle.externalBin` expects.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Resolve target triple (CLI arg → $TAURI_TARGET → host auto-detect).
+TARGET="${1:-${TAURI_TARGET:-}}"
+if [ -z "$TARGET" ]; then
+  case "$(uname -sm)" in
+    "Darwin arm64")  TARGET="aarch64-apple-darwin" ;;
+    "Darwin x86_64") TARGET="x86_64-apple-darwin" ;;
+    "Linux aarch64") TARGET="aarch64-unknown-linux-gnu" ;;
+    "Linux x86_64")  TARGET="x86_64-unknown-linux-gnu" ;;
+    *) echo "Unable to auto-detect rust target triple from $(uname -sm); pass it as an arg." >&2; exit 1 ;;
+  esac
+fi
+
+EXT=""
+case "$TARGET" in
+  aarch64-apple-darwin)        BUN_TARGET="bun-darwin-arm64" ;;
+  x86_64-apple-darwin)         BUN_TARGET="bun-darwin-x64" ;;
+  aarch64-unknown-linux-gnu)   BUN_TARGET="bun-linux-arm64" ;;
+  x86_64-unknown-linux-gnu)    BUN_TARGET="bun-linux-x64" ;;
+  x86_64-pc-windows-msvc)      BUN_TARGET="bun-windows-x64"; EXT=".exe" ;;
+  aarch64-pc-windows-msvc)     BUN_TARGET="bun-windows-x64"; EXT=".exe" ;;
+  *) echo "Unsupported target triple: $TARGET" >&2; exit 1 ;;
+esac
+
+OUT_DIR="src-tauri/binaries"
+OUT="$OUT_DIR/ocpp-cp-sim-${TARGET}${EXT}"
+mkdir -p "$OUT_DIR"
+
+echo "Building Bun sidecar for $TARGET ($BUN_TARGET) → $OUT"
+bun build --compile --target="$BUN_TARGET" --outfile="$OUT" src/cli/main.ts
+
+# Ensure the bin is executable on macOS/Linux. Bun does this for us in
+# practice, but be explicit so a fresh CI checkout never trips on a
+# permissions edge case.
+if [ "$EXT" = "" ]; then
+  chmod +x "$OUT"
+fi
+
+echo "Done: $(ls -lh "$OUT" | awk '{print $5, $9}')"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,5 +15,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
+tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["sync", "time"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,4 +18,3 @@ tauri-plugin-shell = "2"
 tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["sync", "time"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Permissions for the main window: invoke our own commands and let the shell plugin spawn the daemon (bundled sidecar in release, `bun src/cli/main.ts` in dev).",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "core:window:default",
+    "core:window:allow-close",
+    "core:window:allow-set-focus",
+    "core:window:allow-show",
+    "shell:default",
+    "shell:allow-kill",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        {
+          "name": "binaries/ocpp-cp-sim",
+          "sidecar": true,
+          "args": true
+        },
+        {
+          "name": "bun",
+          "cmd": "bun",
+          "args": true
+        }
+      ]
+    }
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,186 @@
+//! Tauri entry point — boots the simulator daemon as a sidecar so the
+//! desktop app delivers the full `--web-console` UX instead of the
+//! static Local-mode-only build.
+//!
+//! Flow on startup:
+//!   1. Pick a free TCP port on 127.0.0.1.
+//!   2. Spawn `ocpp-cp-sim` (the Bun-compiled sidecar from
+//!      `src-tauri/binaries/`) with `--http-port <port> --web-console
+//!      --state-db <app-data-dir>/state.db --log-format json`.
+//!      In `cargo run` / `tauri dev` builds the sidecar binary may not
+//!      exist yet; fall back to `bun src/cli/main.ts` so devs can
+//!      iterate without re-running the build script.
+//!   3. Splash window (`splash.html`) opens immediately, asks Rust for
+//!      the daemon URL via `get_daemon_url`, polls `/healthz`, then
+//!      navigates the same webview to `http://127.0.0.1:<port>/`.
+//!   4. On window close the child is killed.
+
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use tauri::{AppHandle, Manager};
+use tauri_plugin_shell::process::{CommandChild, CommandEvent};
+use tauri_plugin_shell::ShellExt;
+
+/// Cached during setup so the `get_daemon_url` Tauri command can return it
+/// without re-doing port selection on every invocation.
+struct DaemonUrl(String);
+
+/// Child handle is held under a Mutex<Option<…>> so we can take() it out
+/// during the close handler without needing interior-mutability tricks.
+struct DaemonChild(Mutex<Option<CommandChild>>);
+
+#[tauri::command]
+fn get_daemon_url(state: tauri::State<'_, DaemonUrl>) -> String {
+    state.0.clone()
+}
+
+fn find_free_port() -> Result<u16, std::io::Error> {
+    // Bind to port 0, ask the OS for an ephemeral port, then release.
+    // There's a small TOCTOU window before the daemon binds, but the
+    // window is short and any clash would just surface as a startup
+    // failure (which we'd see in the splash error path).
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+fn state_db_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("could not resolve app_data_dir: {e}"))?;
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("could not create app_data_dir {dir:?}: {e}"))?;
+    Ok(dir.join("state.db"))
+}
+
+/// Spawn the daemon. Production builds invoke the bundled sidecar via
+/// `tauri-plugin-shell`; dev builds (`cargo run`, `tauri dev`) drop back
+/// to `bun src/cli/main.ts` so the loop stays tight without having to
+/// re-build a 60 MB compiled binary every iteration.
+fn spawn_daemon(
+    app: &AppHandle,
+    port: u16,
+    state_db: &str,
+) -> Result<(tauri::async_runtime::Receiver<CommandEvent>, CommandChild), String> {
+    let args = [
+        "--http-host",
+        "127.0.0.1",
+        "--http-port",
+        &port.to_string(),
+        "--unix-socket",
+        "none",
+        "--web-console",
+        "--state-db",
+        state_db,
+        "--log-format",
+        "json",
+    ];
+
+    // In debug builds, prefer `bun src/cli/main.ts` so contributors don't
+    // need a sidecar binary to iterate. The path is resolved at compile
+    // time from CARGO_MANIFEST_DIR (= src-tauri/) so it works no matter
+    // what cwd Tauri spawns us with. In release builds, only the sidecar
+    // exists.
+    #[cfg(debug_assertions)]
+    {
+        let main_ts: String = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("src/cli/main.ts")
+            .to_string_lossy()
+            .into_owned();
+        match app
+            .shell()
+            .command("bun")
+            .args(std::iter::once(main_ts.as_str()).chain(args.iter().copied()))
+            .spawn()
+        {
+            Ok(handle) => return Ok(handle),
+            Err(err) => {
+                eprintln!(
+                    "[tauri] `bun src/cli/main.ts` spawn failed ({err}); falling back to sidecar"
+                );
+            }
+        }
+    }
+
+    app.shell()
+        .sidecar("ocpp-cp-sim")
+        .map_err(|e| format!("sidecar lookup failed: {e}"))?
+        .args(args)
+        .spawn()
+        .map_err(|e| format!("sidecar spawn failed: {e}"))
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            // 2nd invocation: focus the existing window instead of
+            // starting a 2nd daemon (which would clash on state.db).
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+        }))
         .plugin(tauri_plugin_shell::init())
+        .invoke_handler(tauri::generate_handler![get_daemon_url])
+        .setup(|app| {
+            let port = find_free_port()
+                .map_err(|e| format!("could not find a free TCP port: {e}"))?;
+            let daemon_url = format!("http://127.0.0.1:{port}");
+            app.manage(DaemonUrl(daemon_url.clone()));
+
+            let state_db = state_db_path(&app.handle())?;
+            let state_db_str = state_db
+                .to_str()
+                .ok_or_else(|| format!("state.db path is not valid UTF-8: {state_db:?}"))?
+                .to_owned();
+
+            let (mut rx, child) = spawn_daemon(&app.handle(), port, &state_db_str)?;
+            app.manage(DaemonChild(Mutex::new(Some(child))));
+
+            // Drain the daemon's stdout/stderr into the app log so a
+            // crash isn't silent. The daemon already speaks JSON-line
+            // logs (we passed `--log-format json`), so this is plenty
+            // grep-friendly.
+            tauri::async_runtime::spawn(async move {
+                while let Some(event) = rx.recv().await {
+                    match event {
+                        CommandEvent::Stdout(line) | CommandEvent::Stderr(line) => {
+                            eprintln!("[daemon] {}", String::from_utf8_lossy(&line).trim_end());
+                        }
+                        CommandEvent::Terminated(payload) => {
+                            eprintln!("[daemon] exited: {:?}", payload);
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+            });
+
+            Ok(())
+        })
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { .. } = event {
+                // Daemon owns the only writer to state.db, so killing it
+                // before the window closes avoids a lock the next launch
+                // would have to wait on. `kill` translates to SIGTERM on
+                // Unix / TerminateProcess on Windows; the daemon's SIGTERM
+                // handler triggers `lifecycle.requestShutdown` for a clean
+                // exit.
+                if let Some(state) = window.app_handle().try_state::<DaemonChild>() {
+                    if let Ok(mut guard) = state.0.lock() {
+                        if let Some(child) = guard.take() {
+                            let _ = child.kill();
+                        }
+                    }
+                }
+            }
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,14 +6,16 @@
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:5173",
-    "beforeBuildCommand": "npm run build",
+    "beforeBuildCommand": "npm run build && bash scripts/build-tauri-sidecar.sh",
     "frontendDist": "../dist"
   },
   "app": {
     "withGlobalTauri": true,
     "windows": [
       {
+        "label": "main",
         "title": "OCPP Charge Point Simulator",
+        "url": "splash.html",
         "width": 1200,
         "height": 800,
         "resizable": true,
@@ -27,6 +29,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "externalBin": ["binaries/ocpp-cp-sim"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,14 @@ import react from "@vitejs/plugin-react-swc";
 export default defineConfig({
   plugins: [react()],
   base: process.env.VITE_BASE_URL || "./",
+  // The Tauri dev shell pins its devUrl to this port; if some unrelated
+  // Vite server already holds 5173 we don't want to silently float to
+  // 5174/5175 because Tauri would then end up loading the wrong app.
+  // `strictPort` makes the failure loud so the conflict is obvious.
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
   test: {
     environment: "node",
     // bun:sqlite is a runtime built-in that vite can't resolve. Tests


### PR DESCRIPTION
## Summary

The Tauri desktop app used to load the static React build (Local mode only — sql.js in IndexedDB, no `--web-console` features). This PR turns it into a desktop shell around `ocpp-cp-sim --web-console`, so the desktop experience matches the Docker-hosted / `ocpp-cp-sim --web-console` deployment one-for-one.

## Boot flow

1. Pick a free TCP port on `127.0.0.1`.
2. Spawn the CLI as a Tauri sidecar (`tauri-plugin-shell`) with `--http-host 127.0.0.1 --http-port <port> --unix-socket none --web-console --state-db <app-data-dir>/state.db --log-format json`.
3. The webview opens `splash.html` — a 60-line polling page that asks Rust for the daemon URL via `get_daemon_url`, polls `/healthz`, and on the first 2xx response navigates the same webview to `http://127.0.0.1:<port>/`.
4. From there the bundled React UI in `dist/` is served straight from the daemon — the UI auto-detects Remote mode and proxies every operation over HTTP/WS, identical to the Docker / `--web-console` deployments.
5. Closing the window kills the sidecar (SIGTERM → daemon's `lifecycle.requestShutdown`), so `state.db` is closed cleanly.
6. `tauri-plugin-single-instance` squashes second launches by focusing the existing window — avoids two daemons fighting over the same `state.db`.

State (`state.db`) location:
- macOS: `~/Library/Application Support/com.ocpp.cp-simulator/state.db`
- Linux: `~/.local/share/com.ocpp.cp-simulator/state.db`
- Windows: `%APPDATA%\com.ocpp.cp-simulator\state.db`

## Pieces

- `scripts/build-tauri-sidecar.sh` — maps Rust target triple to bun-compile target, produces `src-tauri/binaries/ocpp-cp-sim-<triple>` via `bun build --compile`. Auto-detects the host triple if no arg.
- `.github/workflows/release.yml` — adds a per-platform "Setup Bun" + sidecar build step (passing `$TAURI_TARGET`) before the existing `tauri-action` invocation, so every released bundle ships the matching sidecar.
- `src-tauri/tauri.conf.json` — declares `bundle.externalBin: ["binaries/ocpp-cp-sim"]`, labels the window `main`, switches its initial URL to `splash.html`, chains `npm run build && bash scripts/build-tauri-sidecar.sh` in `beforeBuildCommand`.
- `src-tauri/Cargo.toml` — adds `tauri-plugin-single-instance` and `tokio` time feature.
- `src-tauri/src/lib.rs` — full rewrite. Picks free port, spawns sidecar, exposes `get_daemon_url`, kills child on `CloseRequested`, registers single-instance plugin. Debug builds prefer `bun src/cli/main.ts` resolved via `CARGO_MANIFEST_DIR` so devs don't need to rebuild the sidecar to iterate.
- `src-tauri/capabilities/default.json` — new capability allowing `shell:allow-execute` for the sidecar (`binaries/ocpp-cp-sim`, `sidecar: true`) + `bun` (dev only) + `shell:allow-kill` for clean shutdown.
- `public/splash.html` — minimal HTML+JS bootstrap. Spinner + polls `/healthz` every 200 ms with a 30 s budget; surfaces a readable error if the daemon never answers.
- `vite.config.ts` — pin dev server to `port: 5173, strictPort: true`. Tauri's `devUrl` is hardcoded to 5173; floating to 5174/5175 when another Vite holds the port silently loads the wrong app.
- `docs/browser.md`, `README.md` — document desktop = Remote-mode, per-OS `state.db` paths, new Bun prereq.

## Verification done

- `cargo check` clean on macOS arm64 (with rustup just-installed in-session).
- `scripts/build-tauri-sidecar.sh` (host auto-detect) produces a 61 MB binary; `--help` runs.
- `bun run tauri dev` boots:
  - sidecar logs `Listening on http://127.0.0.1:<ephemeral>` + `Web console: …/dist`
  - `state.db` materialises in `~/Library/Application Support/com.ocpp.cp-simulator/`
  - `GET /healthz` returns `{"ok":true,"cps":0}`
  - `GET /` returns the bundled UI (HTML 475 B)
- Visual confirmation of splash → redirect couldn't be captured in-session because an unrelated Vite was holding port 5173 (the new `strictPort` flag is exactly so this surfaces loudly next time).

## Test plan

- [ ] `bun run tauri dev` opens the desktop window; splash shows briefly then the full web console renders against `http://127.0.0.1:<port>/`.
- [ ] Closing the window terminates the daemon (no orphan process listening on the chosen port).
- [ ] Second `tauri dev` invocation focuses the existing window without starting a second daemon.
- [ ] Restart preserves scenarios / `state.db` rows.
- [ ] Release CI: each platform's job builds the sidecar then bundles successfully (4 platforms × tauri-action).
- [ ] Downloaded `.dmg` / `.msi` / `.AppImage` from the released artefact boots end-to-end the same way.