### PR TITLE
feat(daemon): persist scenarios and auto-trigger on statusChange

### DIFF
--- a/src/cli/jsonMode.ts
+++ b/src/cli/jsonMode.ts
@@ -234,6 +234,13 @@ export async function handleJsonCommand(
       return undefined;
     }
 
+    case "remove_scenario": {
+      const connectorId = requirePositiveInt(params, "connector");
+      const scenarioId = requireString(params, "scenarioId");
+      const removed = service.removeScenario(connectorId, scenarioId);
+      return { removed };
+    }
+
     case "run_scenario_file": {
       const connectorId = requirePositiveInt(params, "connector");
       const filePath = requireString(params, "file");

--- a/src/cli/server/CPRegistry.ts
+++ b/src/cli/server/CPRegistry.ts
@@ -65,6 +65,16 @@ export class CPRegistry {
       // Use the internal create path WITHOUT re-inserting into the DB —
       // these rows already exist.
       const svc = this.instantiate(init);
+      // Rehydrate every scenario the operator had loaded against this CP
+      // before the restart. statusChange-trigger scenarios re-arm via the
+      // connector subscription set up in CLIChargePointService — nothing
+      // to do here beyond loading them.
+      const restoredScenarios = svc.restoreScenariosFromDatabase();
+      if (restoredScenarios > 0) {
+        console.log(
+          `[CPRegistry] Restored ${restoredScenarios} scenario(s) for CP "${row.cp_id}"`,
+        );
+      }
       // Kick the WebSocket open so BootNotification + StatusNotification
       // fly to the CSMS automatically. Fire-and-forget — connect() is
       // synchronous from JS's POV (returns immediately, opens in
@@ -139,6 +149,10 @@ export class CPRegistry {
   private persistRemove(cpId: string): void {
     if (!this.database) return;
     this.database.run("DELETE FROM charge_points WHERE cp_id = ?", [cpId]);
+    // Cascade: orphan scenario rows would survive a CP delete and reappear
+    // if the same cpId is re-created. There's no FK in the schema, so the
+    // cleanup is explicit.
+    this.database.run("DELETE FROM scenarios WHERE cp_id = ?", [cpId]);
   }
 
   remove(cpId: string): boolean {

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -16,6 +16,7 @@ import type {
   ScenarioExecutionContext,
   ScenarioMode,
 } from "../cp/application/scenario/ScenarioTypes";
+import { SqliteScenarioRepository } from "../data/sqlite/SqliteScenarioRepository";
 import type { EVSettings } from "../cp/domain/connector/EVSettings";
 import type { AutoMeterValueConfig } from "../cp/domain/connector/MeterValueCurve";
 import type { ActiveChargingProfile } from "../cp/domain/connector/Connector";
@@ -185,12 +186,14 @@ export class CLIChargePointService {
     { readonly definition: ScenarioDefinition; readonly connectorId: number }
   > = new Map();
   private readonly _executors: Map<string, ScenarioExecutor> = new Map();
+  private readonly _scenarioRepo: SqliteScenarioRepository;
 
   constructor(
     init: ChargePointInitOptions,
     /** Shared daemon DB. `null` means run in-memory (no `--state-db`). */
     private readonly database: Database | null = null,
   ) {
+    this._scenarioRepo = new SqliteScenarioRepository(database);
     const overrides = init.bootNotification ?? {};
     const bootNotification: BootNotification = {
       chargePointVendor: init.vendor,
@@ -453,7 +456,64 @@ export class CLIChargePointService {
       throw new Error(`Connector ${connectorId} not found`);
     }
     this._scenarios.set(definition.id, { definition, connectorId });
+    // Persist asynchronously — the sql.js writer batches, and a sync
+    // failure here would mask a successful in-memory load. `save` on the
+    // bun:sqlite path is effectively sync but typed Promise; either way
+    // a failure surfaces in stderr and the in-memory copy stays usable.
+    void this._scenarioRepo
+      .save(this._chargePoint.id, connectorId, definition)
+      .catch((err) => {
+        process.stderr.write(
+          `[CLI] Failed to persist scenario ${definition.id}: ${
+            err instanceof Error ? err.message : err
+          }\n`,
+        );
+      });
     return definition.id;
+  }
+
+  /**
+   * Rehydrate all scenarios that were persisted for this CP under the
+   * given (cp_id, connector_id) by a previous daemon run. Called from
+   * CPRegistry.restoreFromDatabase() after a CP is re-instantiated, so a
+   * restart picks up every loaded scenario — and any statusChange-trigger
+   * scenarios re-arm automatically via attachStatusChangeAutoTrigger().
+   */
+  restoreScenariosFromDatabase(): number {
+    if (!this.database) return 0;
+    let total = 0;
+    this._chargePoint.connectors.forEach((_connector, connectorId) => {
+      const defs = this._scenarioRepo.listByConnector(
+        this._chargePoint.id,
+        connectorId,
+      );
+      for (const def of defs) {
+        // Skip already-loaded scenarios so calling this twice is a no-op.
+        if (this._scenarios.has(def.id)) continue;
+        this._scenarios.set(def.id, { definition: def, connectorId });
+        total += 1;
+      }
+    });
+    return total;
+  }
+
+  /**
+   * Drop a scenario from in-memory state AND the DB. The interface's
+   * `delete(cpId, connectorId)` would wipe every scenario on that
+   * connector — operators expect to delete just one, so we go through
+   * `deleteOne`.
+   */
+  removeScenario(connectorId: number, scenarioId: string): boolean {
+    const entry = this._scenarios.get(scenarioId);
+    if (!entry || entry.connectorId !== connectorId) return false;
+    const executor = this._executors.get(scenarioId);
+    if (executor) {
+      executor.stop();
+      this._executors.delete(scenarioId);
+    }
+    this._scenarios.delete(scenarioId);
+    this._scenarioRepo.deleteOne(this._chargePoint.id, connectorId, scenarioId);
+    return true;
   }
 
   listScenarios(connectorId: number): ReadonlyArray<{
@@ -862,7 +922,60 @@ export class CLIChargePointService {
           });
         }),
       );
+
+      // statusChange-triggered scenarios: when this connector transitions,
+      // scan loaded scenarios for matches and auto-run the first one.
+      // Mirrors ScenarioManager.handleStatusChange used by the browser,
+      // inlined here to avoid duplicating the (cp, executors) state the
+      // service already owns.
+      this._connectorUnsubscribes.push(
+        connector.events.on("statusChange", ({ status, previousStatus }) => {
+          this.handleStatusChangeAutoTrigger(
+            connectorId,
+            previousStatus as OCPPStatus,
+            status as OCPPStatus,
+          );
+        }),
+      );
     });
+  }
+
+  /**
+   * Inline mirror of ScenarioManager.handleStatusChange — finds the first
+   * loaded scenario whose `statusChange` trigger matches the transition
+   * and runs it via runScenario(). Skips scenarios that are disabled,
+   * already running, or whose ChargePoint isn't `Available` (matches the
+   * browser-side guard in ScenarioManager.executeScenario).
+   */
+  private handleStatusChangeAutoTrigger(
+    connectorId: number,
+    fromStatus: OCPPStatus,
+    toStatus: OCPPStatus,
+  ): void {
+    if (this._chargePoint.status !== OCPPStatus.Available) return;
+    for (const [scenarioId, entry] of this._scenarios) {
+      if (entry.connectorId !== connectorId) continue;
+      const def = entry.definition;
+      if (def.enabled === false) continue;
+      const trigger = def.trigger;
+      if (!trigger || trigger.type !== "statusChange") continue;
+      const cond = trigger.conditions;
+      if (cond?.fromStatus && cond.fromStatus !== fromStatus) continue;
+      if (cond?.toStatus && cond.toStatus !== toStatus) continue;
+      // Don't restart if it's currently running — let it finish first.
+      if (this._executors.has(scenarioId)) continue;
+      try {
+        this.runScenario(connectorId, scenarioId);
+      } catch (err) {
+        process.stderr.write(
+          `[CLI] statusChange auto-trigger failed for ${scenarioId}: ${
+            err instanceof Error ? err.message : err
+          }\n`,
+        );
+      }
+      // One scenario per status transition — matches ScenarioManager.
+      return;
+    }
   }
 
   private detachConnectorEventForwarders(): void {

--- a/src/data/sqlite/SqliteScenarioRepository.ts
+++ b/src/data/sqlite/SqliteScenarioRepository.ts
@@ -100,6 +100,46 @@ export class SqliteScenarioRepository implements ScenarioRepository {
     return rows.map((r) => JSON.parse(r.definition) as ScenarioDefinition);
   }
 
+  /**
+   * List every scenario stored for a single (cp_id, connector_id) pair.
+   * Used by the daemon to rehydrate per-connector scenarios on startup
+   * and to expose `list_scenarios` over the JSON command channel.
+   * `connectorId = null` maps to the column value `0` (cp-level slot),
+   * matching `save()` / `delete()`.
+   */
+  listByConnector(
+    chargePointId: string,
+    connectorId: number | null,
+  ): ScenarioDefinition[] {
+    if (!this.db) return [];
+    const rows = this.db.all<{ definition: string }>(
+      "SELECT definition FROM scenarios " +
+        "WHERE cp_id = ? AND connector_id = ? " +
+        "ORDER BY updated_at DESC",
+      [chargePointId, connectorId ?? 0],
+    );
+    return rows.map((r) => JSON.parse(r.definition) as ScenarioDefinition);
+  }
+
+  /**
+   * Delete a single scenario row by composite key. The interface's
+   * `delete(cpId, connectorId)` wipes the whole connector slot, which is
+   * wrong for the daemon — operators expect "drop scenario X" to leave
+   * sibling scenarios on the same connector intact.
+   */
+  deleteOne(
+    chargePointId: string,
+    connectorId: number | null,
+    scenarioId: string,
+  ): void {
+    if (!this.db) return;
+    this.db.run(
+      "DELETE FROM scenarios " +
+        "WHERE cp_id = ? AND connector_id = ? AND scenario_id = ?",
+      [chargePointId, connectorId ?? 0, scenarioId],
+    );
+  }
+
   subscribe(
     chargePointId: string,
     connectorId: number | null,


### PR DESCRIPTION
## Summary

Make the daemon's scenario engine durable and self-triggering. Until now, scenarios loaded against a daemon CP (via the JSON `load_scenario` command or the `--scenario` / `--scenario-template-file` CLI flags) lived only in `CLIChargePointService` memory — a restart wiped them, and `statusChange`-triggered scenarios only fired on the browser side.

This change closes that gap by wiring the existing `SqliteScenarioRepository` into the daemon and inlining the `ScenarioManager`-equivalent trigger logic.

- **Persist on load** — `CLIChargePointService.loadScenario` now `repo.save(cpId, connectorId, def)` after registering the in-memory entry.
- **Restore on restart** — `CPRegistry.restoreFromDatabase` calls a new `svc.restoreScenariosFromDatabase()` per CP, which rehydrates every persisted scenario for every connector. `enabled=true` + `trigger.type=statusChange` scenarios re-arm automatically via the connector subscription.
- **statusChange auto-trigger** — `attachConnectorEventForwarders` subscribes a per-connector handler that scans loaded scenarios for matching `statusChange` triggers and calls `runScenario` on the first match. Mirrors `ScenarioManager.handleStatusChange` from the browser path. Guarded by `chargePoint.status === Available` to match the existing browser semantics.
- **Cascade delete on CP removal** — `CPRegistry.persistRemove` also `DELETE FROM scenarios WHERE cp_id = ?` so orphaned rows don't survive a CP delete + recreate.
- **`remove_scenario` JSON command** — exposes new `CLIChargePointService.removeScenario(connectorId, scenarioId)` for single-scenario deletion (the existing `delete(cpId, connectorId)` interface wipes the whole connector slot, which is the wrong semantics for daemon-side use).
- **Repository helpers** — `SqliteScenarioRepository` gains `listByConnector` and `deleteOne` concrete methods for daemon multi-scenario-per-connector use. The interface is unchanged.

No daemon protocol changes: the browser remote mode (`RemoteChargePointService.runScenario` / `stopScenario` / `listScenarios` etc.) keeps working through the existing `/v1/cp/:cpId/command` JSON channel.

## Test plan

Verified end-to-end against a local daemon (`--state-db`):

- [x] `bun src/cli/main.ts --http-port 18099 --state-db /tmp/x.db` → create CP → `load_scenario` via `POST /v1/cp/:cpId/command` → `sqlite3 x.db 'SELECT ... FROM scenarios'` shows the row.
- [x] Shutdown + restart daemon → `[CPRegistry] Restored 1 scenario(s) for CP "CP-TEST-1"` logs → `list_scenarios` returns the rehydrated scenario.
- [x] Manual `run_scenario` → WS `/v1/cp/:cpId/events` receives `scenario_started` → `log` → execution events.
- [x] `--scenario file.json` startup flag → DB row created (was previously in-memory only).
- [x] `DELETE /v1/cp/:cpId` → scenarios for that CP also removed from DB.
- [x] `bun test bun.test` (5 tests) + `npx vitest run` (15 tests) → all pass.
- [x] `npx tsc --noEmit` → clean. `npm run lint` → no new errors (2 pre-existing errors on `main` unchanged).

Not verified: live `statusChange` auto-trigger end-to-end (the inline matcher matches the browser `ScenarioManager.handleStatusChange` logic, but exercising it from this repo requires a live CSMS so the CP can reach `Available`).