### PR TITLE
fix(docker): copy src/data into runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY package.json bun.lock ./
 # Only the files the CLI / daemon needs at runtime.
 COPY src/cli ./src/cli
 COPY src/cp ./src/cp
+COPY src/data ./src/data
 COPY src/utils/scenarioTemplates.ts ./src/utils/scenarioTemplates.ts
 
 # Built-in scenario examples — kept handy under /app/docs.


### PR DESCRIPTION
## Summary
- `src/cli/service.ts` imports modules from `src/data`, but the Dockerfile only copied `src/cli` and `src/cp`, so the runtime image was missing required source files.
- Add `COPY src/data ./src/data` alongside the other runtime source copies so the daemon image works out of the box.

## Test plan
- [ ] `docker build -t ocpp-cp-simulator .` succeeds
- [ ] Container starts and the daemon serves the web console without missing-module errors