### PR TITLE
feat(server): make health-check path configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,19 @@
 #       --scenario-connector all
 
 ARG BUN_VERSION=1
+# Health-check URL path. Same value is baked into the UI bundle at build
+# time (as VITE_HEALTH_PATH) and re-applied at runtime as the daemon's
+# --health-path flag, so the browser's remote-mode auto-detect probe and
+# the platform's HTTP liveness probe hit the same endpoint. Override with
+# `docker build --build-arg HEALTH_PATH=/your/path .` when deploying
+# behind a proxy that reserves the default (e.g. Google Front End in
+# front of Cloud Run returning 404 on certain reserved paths).
+ARG HEALTH_PATH=/v1/healthz
 
 
 # ----- Stage 1: build the browser UI (Vite -> dist/) -----------------
 FROM oven/bun:${BUN_VERSION}-alpine AS ui
+ARG HEALTH_PATH
 WORKDIR /app
 
 # Need every dep (including devDependencies: vite, plugins, tailwind).
@@ -42,6 +51,10 @@ COPY tailwind.config.js postcss.config.js ./
 COPY public ./public
 COPY src ./src
 
+# VITE_HEALTH_PATH is read by src/data/healthPath.ts at build time and
+# inlined into the bundle so the static UI knows which path to probe for
+# Remote-mode auto-detect (and for the Navbar's health poll).
+ENV VITE_HEALTH_PATH=$HEALTH_PATH
 RUN bun run build
 
 
@@ -106,6 +119,13 @@ ENV HTTP_PORT=9700
 # `-e STATE_DB=:memory:` for ephemeral, or `-e STATE_DB=` to drop the
 # flag entirely.
 ENV STATE_DB=/data/state.db
+# Re-export the build-time HEALTH_PATH as a runtime env so the entrypoint
+# can forward it to `--health-path` and so this default is documented next
+# to HTTP_PORT / STATE_DB. Override at run time with
+# `-e HEALTH_PATH=/your/path` IF the UI bundle was built with the same
+# value — they must match for the browser's auto-detect probe to land.
+ARG HEALTH_PATH
+ENV HEALTH_PATH=$HEALTH_PATH
 EXPOSE 9700
 
 # Entrypoint:
@@ -120,4 +140,4 @@ ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD []
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget -qO- "http://127.0.0.1:${HTTP_PORT}/healthz" >/dev/null 2>&1 || exit 1
+  CMD wget -qO- "http://127.0.0.1:${HTTP_PORT}${HEALTH_PATH}" >/dev/null 2>&1 || exit 1

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Both the browser UI and the daemon back their state with SQLite — sql.js + Ind
 
 ## Local vs Remote mode (browser)
 
-The browser UI auto-detects which mode to run in by probing `/healthz` at its own origin:
+The browser UI auto-detects which mode to run in by probing `/v1/healthz` at its own origin (path configurable, see [docs/server.md → Health](docs/server.md#health)):
 
 - Served by `ocpp-cp-sim --web-console`, the Docker image, or the **Tauri desktop app** (which bundles the daemon as a sidecar) → **Remote**: every operation is proxied to the daemon over HTTP/WS.
 - Static build (GitHub Pages, `bun run dev`) → **Local**: charge points run entirely in-browser, persistence via sql.js.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # HEALTH_PATH is baked into the UI bundle at build time and
+        # re-applied at runtime as the daemon's --health-path. Override
+        # both here (build) and in `environment` below when deploying
+        # behind a proxy that reserves the default path — e.g. Google
+        # Front End in front of Cloud Run.
+        HEALTH_PATH: "${HEALTH_PATH:-/v1/healthz}"
     image: ocpp-cp-sim
     container_name: ocpp-cp-sim
     restart: unless-stopped
@@ -23,6 +30,10 @@ services:
       # Default is a file under the /data volume; set to ":memory:" to
       # run fully ephemeral (state wiped on container exit).
       STATE_DB: "/data/state.db"
+      # The image's ENTRYPOINT passes --health-path $HEALTH_PATH to
+      # ocpp-cp-sim. Must match the build-time arg above so the static UI
+      # bundle's auto-detect probe lines up with the daemon endpoint.
+      HEALTH_PATH: "${HEALTH_PATH:-/v1/healthz}"
     volumes:
       # Mount the example scenarios read-only so you can point
       # --scenario-template-file at one from the command override.
@@ -55,11 +66,12 @@ services:
       # - --log-format
       # - json
     healthcheck:
+      # CMD-SHELL so the $$HEALTH_PATH (escaped from compose-time) expands
+      # at container runtime against the image's env, matching whatever
+      # the daemon was told to serve.
       test:
-        - CMD
-        - wget
-        - -qO-
-        - "http://127.0.0.1:9700/healthz"
+        - CMD-SHELL
+        - 'wget -qO- "http://127.0.0.1:9700$$HEALTH_PATH" >/dev/null 2>&1 || exit 1'
       interval: 30s
       timeout: 3s
       start_period: 5s

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,9 +16,15 @@
 #   4. Compose the CLI flag bundle:
 #        --http-host 0.0.0.0 --unix-socket none --web-console $HTTP_PORT
 #        (--state-db $STATE_DB only when STATE_DB is non-empty).
+#        (--health-path $HEALTH_PATH only when HEALTH_PATH is non-empty).
 #
 # Set STATE_DB=:memory: at runtime to opt out of persistence; set it to
 # the empty string to drop the flag entirely.
+#
+# HEALTH_PATH must match the value passed at image build time as
+# `--build-arg HEALTH_PATH=…` because the UI bundle inlines it as
+# VITE_HEALTH_PATH; setting only the runtime env will move the daemon
+# endpoint but leave the browser probe targeting the build-time default.
 set -e
 
 if [ -d /data ] && [ "$(stat -c %u /data 2>/dev/null)" != "1000" ]; then
@@ -33,6 +39,9 @@ fi
 ARGS="--http-host 0.0.0.0 --unix-socket none --web-console ${HTTP_PORT}"
 if [ -n "${STATE_DB}" ]; then
   ARGS="${ARGS} --state-db ${STATE_DB}"
+fi
+if [ -n "${HEALTH_PATH}" ]; then
+  ARGS="${ARGS} --health-path ${HEALTH_PATH}"
 fi
 
 exec su-exec bun:bun bun src/cli/main.ts ${ARGS} "$@"

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -10,7 +10,7 @@ The hosted web version runs in **Local mode** — every charge point lives in th
 
 ## Desktop Application
 
-The desktop app is **not** a wrapper around the static Local-mode build. On launch it spins up the bundled simulator daemon as a sidecar, waits for `/healthz`, then opens the full web console served by that daemon — so you get the same Remote-mode UX as `ocpp-cp-sim --web-console`, without having to install anything else.
+The desktop app is **not** a wrapper around the static Local-mode build. On launch it spins up the bundled simulator daemon as a sidecar, waits for `/v1/healthz`, then opens the full web console served by that daemon — so you get the same Remote-mode UX as `ocpp-cp-sim --web-console`, without having to install anything else.
 
 - State (`state.db`) is written to the OS-standard app data dir:
   - macOS: `~/Library/Application Support/com.ocpp.cp-simulator/state.db`

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -72,14 +72,15 @@ HTTP_PORT=5172 CP_ID=my-cp CONNECTORS=5 \
 
 Variables read by the compose file (all optional):
 
-| Variable      | Default                              | Purpose                       |
-| ------------- | ------------------------------------ | ----------------------------- |
-| `HTTP_PORT`   | `9700`                               | Host port forwarded to 9700/c |
-| `CP_ID`       | `cp1`                                | Bootstrap charge point id     |
-| `CONNECTORS`  | `1`                                  | Number of connectors          |
-| `WS_URL`      | `wss://example.invalid/chargepoint/` | CSMS WebSocket URL            |
-| `CORS_ORIGIN` | _(empty → any origin)_               | Restrict CORS (see comments)  |
-| `STATE_DB`    | `/data/state.db`                     | SQLite path inside container  |
+| Variable      | Default                              | Purpose                                                                                                                                                                                                                                                                                        |
+| ------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HTTP_PORT`   | `9700`                               | Host port forwarded to 9700/c                                                                                                                                                                                                                                                                  |
+| `CP_ID`       | `cp1`                                | Bootstrap charge point id                                                                                                                                                                                                                                                                      |
+| `CONNECTORS`  | `1`                                  | Number of connectors                                                                                                                                                                                                                                                                           |
+| `WS_URL`      | `wss://example.invalid/chargepoint/` | CSMS WebSocket URL                                                                                                                                                                                                                                                                             |
+| `CORS_ORIGIN` | _(empty → any origin)_               | Restrict CORS (see comments)                                                                                                                                                                                                                                                                   |
+| `STATE_DB`    | `/data/state.db`                     | SQLite path inside container                                                                                                                                                                                                                                                                   |
+| `HEALTH_PATH` | `/v1/healthz`                        | Daemon health endpoint path. Compose passes it both as `--build-arg` (baked into the UI bundle as `VITE_HEALTH_PATH`) and as a runtime env (forwarded to `--health-path`). Set both sides when a fronting proxy reserves the default — e.g. Cloud Run / GFE returning 404 on the default path. |
 
 ## Mounting a scenario template
 
@@ -116,7 +117,7 @@ See [server.md → Log format](server.md#log-format) for the schema and the rela
 | Default user      | `bun` (non-root)                                                                                                        |
 | Exposed port      | `9700`                                                                                                                  |
 | Volumes           | `/data` (state DB)                                                                                                      |
-| Healthcheck       | `GET /healthz` every 30s                                                                                                |
+| Healthcheck       | `GET $HEALTH_PATH` every 30s (default `/v1/healthz`; override via build-arg + env)                                      |
 | Bundled scenarios | `/app/docs/examples/scenarios/` (point `--scenario-template-file` at one of these or mount your own under `/scenarios`) |
 
 The image **doesn't** contain Vite / Tauri / dev dependencies — Vite builds the browser UI in a separate stage and only `dist/` ships in the runtime layer.
@@ -130,3 +131,23 @@ docker run --rm -p 9700:9700 -v "$PWD/.state:/data" ocpp-cp-sim:dev \
 ```
 
 The build is fully self-contained (no host node_modules required); first build ≈ 60 s, subsequent rebuilds hit the Bun install cache for ≈ 10 s.
+
+## Custom health-check path
+
+The daemon's health endpoint defaults to `/v1/healthz`. Override the path when deploying behind a reverse proxy that reserves the default — e.g. Google Front End in front of Cloud Run returning 404 directly on certain paths before the request reaches the container. The same value must be set both at build time (it's inlined into the UI bundle for the browser's Remote-mode auto-detect probe) and at runtime (forwarded to the daemon's `--health-path`):
+
+```sh
+# 1) Build with the custom path baked into the UI bundle.
+docker build \
+  --build-arg HEALTH_PATH=/internal/healthz \
+  -t ocpp-cp-sim:custom-health .
+
+# 2) Run with the same path exported as env so the entrypoint passes
+#    `--health-path /internal/healthz` to ocpp-cp-sim.
+docker run --rm -p 9700:9700 \
+  -e HEALTH_PATH=/internal/healthz \
+  ocpp-cp-sim:custom-health \
+  --cp-id CP001 --ws-url wss://example.invalid/chargepoint/
+```
+
+With compose, the same `HEALTH_PATH` env on the host machine flows to both the build args and the container env (see [`docker-compose.yml`](../docker-compose.yml)).

--- a/docs/server.md
+++ b/docs/server.md
@@ -87,7 +87,7 @@ Both paths also drop every in-memory CP first so live WebSockets don't keep writ
 
 ### Browser
 
-Browser mode uses the same schema, backed by sql.js + IndexedDB. Each browser profile keeps one DB blob under the `ocpp-cp-simulator` IndexedDB database; clearing site data wipes simulator state. sql.js is only loaded when the page determines it's in Local mode (via `/healthz` probe at the page origin) — Remote mode skips the WASM download entirely.
+Browser mode uses the same schema, backed by sql.js + IndexedDB. Each browser profile keeps one DB blob under the `ocpp-cp-simulator` IndexedDB database; clearing site data wipes simulator state. sql.js is only loaded when the page determines it's in Local mode (via a `/v1/healthz` probe at the page origin — path configurable, see [Health endpoint](#health)) — Remote mode skips the WASM download entirely.
 
 ## Log format
 
@@ -161,7 +161,7 @@ Notes:
 
 - The ENTRYPOINT pins `--http-host 0.0.0.0 --unix-socket none --web-console $HTTP_PORT`. `--web-console` starts the HTTP server on the given port and serves the bundled UI from the same origin (resolved from the `dist/` shipped next to the CLI).
 - After `docker run …` open `http://localhost:9700/` to use the browser UI. It talks to the daemon on the same origin, so CORS / dev-server routing is a non-issue.
-- The image's `HEALTHCHECK` hits `/healthz`, so `docker ps` shows `healthy` / `unhealthy` once the daemon is up.
+- The image's `HEALTHCHECK` hits `$HEALTH_PATH` (default `/v1/healthz`), so `docker ps` shows `healthy` / `unhealthy` once the daemon is up.
 - Override the bound port by setting the `HTTP_PORT` env var (e.g. `-e HTTP_PORT=8080`). The published host port via `-p` is independent.
 
 ## HTTP API
@@ -171,9 +171,11 @@ All responses are JSON. Command responses follow the same `{ ok, data?, error? }
 ### Health
 
 ```
-GET /healthz
+GET /v1/healthz
 → { "ok": true, "cps": 2 }
 ```
+
+The path is configurable via `--health-path <path>` (default `/v1/healthz`). Change it when a reverse proxy in front of the daemon reserves the default path — e.g. Google Front End in front of Cloud Run will return 404 directly on certain reserved paths before the request hits the container. The browser UI's Remote-mode auto-detect and the `RemoteChargePointService.ping` poll both target the path that was inlined at UI build time via the `VITE_HEALTH_PATH` env var (same default); the two values must match for the UI's "Remote" green-dot status to light up.
 
 ### Charge Point Registry
 

--- a/public/splash.html
+++ b/public/splash.html
@@ -68,17 +68,21 @@
 
     <script>
       // The splash page lives at tauri://localhost/splash.html. Once the
-      // bundled daemon answers /healthz we redirect the same webview to
-      // http://127.0.0.1:<port>/ where the full web console takes over.
+      // bundled daemon answers its health endpoint we redirect the same
+      // webview to http://127.0.0.1:<port>/ where the full web console
+      // takes over. The path must match the daemon's --health-path
+      // (default /v1/healthz); the sidecar is spawned without that flag,
+      // so the default applies.
       const POLL_INTERVAL_MS = 200;
       const POLL_TIMEOUT_MS = 30_000;
+      const HEALTH_PATH = "/v1/healthz";
 
       async function waitForDaemon() {
         const url = await window.__TAURI__.core.invoke("get_daemon_url");
         const started = Date.now();
         while (Date.now() - started < POLL_TIMEOUT_MS) {
           try {
-            const res = await fetch(`${url}/healthz`, { cache: "no-store" });
+            const res = await fetch(`${url}${HEALTH_PATH}`, { cache: "no-store" });
             if (res.ok) {
               const body = await res.json().catch(() => null);
               if (body && body.ok === true) {
@@ -102,7 +106,7 @@
         sub.classList.add("error");
         sub.innerHTML =
           `The bundled daemon at <code>${url}</code> didn't answer ` +
-          `<code>/healthz</code> within 30 s. ` +
+          `<code>${HEALTH_PATH}</code> within 30 s. ` +
           "Check the app log for spawn failures.";
       }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@
 //!      exist yet; fall back to `bun src/cli/main.ts` so devs can
 //!      iterate without re-running the build script.
 //!   3. Splash window (`splash.html`) opens immediately, asks Rust for
-//!      the daemon URL via `get_daemon_url`, polls `/healthz`, then
+//!      the daemon URL via `get_daemon_url`, polls `/v1/healthz`, then
 //!      navigates the same webview to `http://127.0.0.1:<port>/`.
 //!   4. On window close the child is killed.
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -64,6 +64,7 @@ function parseArgs(argv: string[]): CLIOptions {
   let webConsoleExplicitPort: number | null = null;
   let stateDb: string | null = null;
   let logFormat: "plain" | "json" = "plain";
+  let healthPath = "/v1/healthz";
   const corsOrigins: string[] = [];
 
   for (let i = 2; i < argv.length; i++) {
@@ -179,6 +180,16 @@ function parseArgs(argv: string[]): CLIOptions {
           process.exit(1);
         }
         logFormat = next;
+        i++;
+        break;
+      case "--health-path":
+        if (!next || next.startsWith("--") || !next.startsWith("/")) {
+          process.stderr.write(
+            "Error: --health-path requires an absolute path starting with '/'\n",
+          );
+          process.exit(1);
+        }
+        healthPath = next;
         i++;
         break;
       case "--web-console":
@@ -323,6 +334,7 @@ function parseArgs(argv: string[]): CLIOptions {
     webConsolePort,
     stateDb,
     logFormat,
+    healthPath,
   };
 }
 
@@ -383,10 +395,16 @@ Options:
   --log-format <fmt>       "plain" (default) or "json" — output one JSON
                            object per stderr line for structured-log
                            collectors (Loki, jq, etc.).
+  --health-path <path>     Absolute path the health-check JSON is served on
+                           (default: /v1/healthz). Change this when running
+                           behind a proxy that reserves the default path
+                           (e.g. Cloud Run / GFE). The browser UI build must
+                           be given the matching VITE_HEALTH_PATH so its
+                           remote-mode auto-detect probe lines up.
   -h, --help               Show this help
 
 HTTP API (see docs/server.md):
-  GET    /healthz
+  GET    /v1/healthz       (or whatever --health-path is set to)
   GET    /v1/cp
   POST   /v1/cp
   GET    /v1/cp/:cpId
@@ -509,6 +527,7 @@ async function main(): Promise<void> {
       staticDir: options.serveStatic,
       webConsolePort: options.webConsolePort,
       stateDb: options.stateDb,
+      healthPath: options.healthPath,
     });
     return;
   }

--- a/src/cli/server/httpServer.ts
+++ b/src/cli/server/httpServer.ts
@@ -156,11 +156,15 @@ export function createHttpHandlers(deps: {
   staticDir?: string | null;
   /** Daemon state DB; needed so POST /v1/state/reset can truncate it. */
   database?: Database | null;
+  /** Absolute URL path the health-check JSON is served on. Defaults to
+   *  `/v1/healthz`. */
+  healthPath?: string;
 }): HttpHandlers {
   const { registry, bus, lifecycle } = deps;
   const cors: CorsPolicy = deps.cors ?? { kind: "any" };
   const staticDir = deps.staticDir ?? null;
   const database = deps.database ?? null;
+  const healthPath = deps.healthPath ?? "/v1/healthz";
 
   return {
     fetch(req, server) {
@@ -247,8 +251,8 @@ export function createHttpHandlers(deps: {
       return ok ? undefined : new Response("upgrade failed", { status: 400 });
     }
 
-    // GET /healthz
-    if (req.method === "GET" && url.pathname === "/healthz") {
+    // GET <healthPath>  (default /v1/healthz; configurable via --health-path)
+    if (req.method === "GET" && url.pathname === healthPath) {
       return Response.json({ ok: true, cps: registry.list().length });
     }
 

--- a/src/cli/server/startServer.ts
+++ b/src/cli/server/startServer.ts
@@ -65,6 +65,9 @@ export interface ServerOptions {
   /** Filesystem path for the SQLite state DB. `null` means run in memory
    *  — handy for tests / one-off CSMS probes; durable persistence is off. */
   readonly stateDb: string | null;
+  /** Absolute URL path the health-check JSON is served on. Defaults to
+   *  `/v1/healthz` (set by the CLI). */
+  readonly healthPath: string;
 }
 
 export async function startServer(opts: ServerOptions): Promise<void> {
@@ -113,6 +116,7 @@ export async function startServer(opts: ServerOptions): Promise<void> {
     lifecycle,
     cors: opts.cors,
     database,
+    healthPath: opts.healthPath,
   });
   const consoleHandlers = opts.staticDir
     ? createHttpHandlers({
@@ -122,11 +126,13 @@ export async function startServer(opts: ServerOptions): Promise<void> {
         cors: opts.cors,
         staticDir: opts.staticDir,
         database,
+        healthPath: opts.healthPath,
       })
     : apiHandlers;
   if (opts.staticDir) {
     serverLog(`Web console: ${opts.staticDir}`);
   }
+  serverLog(`Health endpoint: GET ${opts.healthPath}`);
   const servers: AnyServer[] = [];
 
   if (opts.unixSocket) {

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -44,6 +44,13 @@ export interface CLIOptions {
    *  `[timestamp] [LEVEL] [TYPE] message` lines; `"json"` writes one JSON
    *  object per line for structured-log collectors. */
   readonly logFormat: "plain" | "json";
+  /** Absolute path the daemon serves the health-check JSON on. Default
+   *  `/v1/healthz`. Made configurable so deployments behind a proxy that
+   *  reserves specific paths (e.g. Google Front End in front of Cloud Run)
+   *  can move the endpoint off a conflicting path. The same value must be
+   *  set as `VITE_HEALTH_PATH` at UI build time so the browser auto-detect
+   *  probe targets the same endpoint. */
+  readonly healthPath: string;
 }
 
 export interface ChargePointInitOptions {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -13,8 +13,10 @@ const Navbar: React.FC = () => {
   const isRemote = mode === "remote";
   const [health, setHealth] = useState<RemoteHealth>("checking");
 
-  // Poll the daemon's /healthz every 5s while we're in remote mode. Local
-  // mode has no remote to watch, so skip the timer entirely.
+  // Poll the daemon's health endpoint every 5s while we're in remote mode
+  // (the path is whatever the build / daemon were configured with — see
+  // src/data/healthPath.ts). Local mode has no remote to watch, so skip
+  // the timer entirely.
   useEffect(() => {
     if (!isRemote || !chargePointService.ping) {
       setHealth("checking");

--- a/src/data/healthPath.ts
+++ b/src/data/healthPath.ts
@@ -1,0 +1,31 @@
+// URL path the browser uses for daemon health checks:
+//   * DataProvider auto-detects Remote mode by probing this path at the
+//     page origin (a 2xx with `{ ok: true }` means a daemon is on the
+//     other end).
+//   * Navbar polls the same path via RemoteChargePointService.ping() to
+//     show the green/red connection dot while in Remote mode.
+//
+// Must match the daemon's `--health-path` flag (default `/v1/healthz`).
+// Override at UI build time via `VITE_HEALTH_PATH=/custom/path` when the
+// daemon is deployed behind a proxy that reserves the default path —
+// e.g. Google Front End in front of Cloud Run returns 404 for certain
+// reserved paths before the request ever reaches the container.
+
+const DEFAULT_HEALTH_PATH = "/v1/healthz";
+
+function readBuildTimeHealthPath(): string | null {
+  if (typeof import.meta === "undefined") return null;
+  const meta = import.meta as unknown;
+  if (typeof meta !== "object" || meta === null || !("env" in meta)) {
+    return null;
+  }
+  const env = (meta as { env?: Record<string, unknown> }).env;
+  const raw = env?.VITE_HEALTH_PATH;
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("/")) return null;
+  return trimmed;
+}
+
+export const HEALTH_PATH: string =
+  readBuildTimeHealthPath() ?? DEFAULT_HEALTH_PATH;

--- a/src/data/providers/DataProvider.tsx
+++ b/src/data/providers/DataProvider.tsx
@@ -10,6 +10,7 @@ import { Provider as JotaiProvider } from "jotai";
 import { createStore } from "jotai/vanilla";
 
 import type { RuntimeMode } from "../RuntimeMode";
+import { HEALTH_PATH } from "../healthPath";
 import type { ConfigRepository } from "../interfaces/ConfigRepository";
 import type { ScenarioRepository } from "../interfaces/ScenarioRepository";
 import type { ConnectorSettingsRepository } from "../interfaces/ConnectorSettingsRepository";
@@ -68,9 +69,10 @@ function readStorage(key: string): string | null {
 }
 
 interface DataContextValue {
-  /** Current runtime mode — auto-detected from the page origin's /healthz
-   *  probe, no manual toggle. `remote` when served by the daemon's
-   *  --web-console; `local` for static builds. */
+  /** Current runtime mode — auto-detected from the page origin's health
+   *  probe (see HEALTH_PATH; default `/v1/healthz`), no manual toggle.
+   *  `remote` when served by the daemon's --web-console; `local` for
+   *  static builds. */
   mode: RuntimeMode;
   serverUrl: string;
   /** Browser-side user-configured default EV settings.
@@ -97,7 +99,7 @@ export const DataProvider: React.FC<DataProviderProps> = ({
   serverUrlOverride,
 }) => {
   // Mode resolution. We never assume a mode at first render — `mode` is
-  // null until /healthz tells us whether we're local or remote. That gate
+  // null until the health probe tells us whether we're local or remote. That gate
   // is important because we only spin up sql.js (~650 KB WASM + IndexedDB
   // read) for the local path; remote mode talks to the daemon's own
   // SQLite via the API and has no use for a browser-side store.
@@ -109,7 +111,7 @@ export const DataProvider: React.FC<DataProviderProps> = ({
   // Server URL: prefer the explicit prop, else the current page origin.
   // The legacy localStorage value is intentionally ignored — Remote mode is
   // only entered through origin auto-detection, which sets the URL to the
-  // origin that successfully answered /healthz.
+  // origin that successfully answered the health probe (HEALTH_PATH).
   const initialServerUrl = useMemo<string>(() => {
     if (serverUrlOverride) return serverUrlOverride;
     if (typeof window !== "undefined") return window.location.origin;
@@ -141,7 +143,7 @@ export const DataProvider: React.FC<DataProviderProps> = ({
   };
 
   // Origin-based mode detection: the only way the UI ever enters Remote
-  // mode. If /healthz at the current origin answers ok, the UI was served
+  // mode. If HEALTH_PATH at the current origin answers ok, the UI was served
   // by `ocpp-cp-sim --web-console` (or the Docker image) and we point the
   // RemoteChargePointService at that same origin. Otherwise we stay Local
   // — true for static builds (GitHub Pages, `bun run dev`, Tauri). No
@@ -152,10 +154,10 @@ export const DataProvider: React.FC<DataProviderProps> = ({
 
     let cancelled = false;
     const origin = window.location.origin;
-    fetch(`${origin}/healthz`, { method: "GET", cache: "no-store" })
+    fetch(`${origin}${HEALTH_PATH}`, { method: "GET", cache: "no-store" })
       .then(async (res) => {
         // `fetch` does NOT reject on HTTP error status — a 404 (e.g. when
-        // the UI is served from GitHub Pages where no /healthz endpoint
+        // the UI is served from GitHub Pages where no health endpoint
         // exists) resolves with res.ok=false. Treat any non-2xx as
         // "no daemon here → Local" so we don't sit in the null-mode
         // initialization gate forever.

--- a/src/data/remote/RemoteChargePointService.ts
+++ b/src/data/remote/RemoteChargePointService.ts
@@ -25,6 +25,7 @@ import type {
   HistoryOptions,
   StateHistoryEntry,
 } from "../../cp/application/services/types/StateSnapshot";
+import { HEALTH_PATH } from "../healthPath";
 
 interface ServerCpListItem {
   cpId: string;
@@ -818,7 +819,7 @@ export class RemoteChargePointService implements ChargePointService {
   }
 
   async ping(): Promise<{ ok: boolean; cps: number }> {
-    return this.fetchJson<{ ok: boolean; cps: number }>("GET", "/healthz");
+    return this.fetchJson<{ ok: boolean; cps: number }>("GET", HEALTH_PATH);
   }
 
   async resetAllState(): Promise<void> {


### PR DESCRIPTION
## Summary

- Make the daemon's health-check path configurable so deployments behind a proxy that reserves the default path (e.g. Google Front End in front of Cloud Run returning 404 directly before requests reach the container) can move the endpoint somewhere reachable.
- Change the default from `/healthz` to `/v1/healthz` so it lives under the existing `/v1/*` API namespace, which proxies are less likely to reserve.
- Three knobs all stay in lockstep with a single value: the CLI `--health-path` flag, the Docker `HEALTH_PATH` (build-arg + runtime env), and the UI build-time `VITE_HEALTH_PATH`.

## Details

- **Server** — New `--health-path <path>` flag (must start with `/`, default `/v1/healthz`), plumbed through `startServer` into `createHttpHandlers`. The chosen endpoint is logged at startup as `[server] Health endpoint: GET <path>`.
- **Browser** — New `src/data/healthPath.ts` exposes a single `HEALTH_PATH` constant sourced from `import.meta.env.VITE_HEALTH_PATH` (default `/v1/healthz`). `DataProvider`'s Remote-mode auto-detect, the `Navbar` health poll, and `RemoteChargePointService.ping` all read it.
- **Docker** — A `HEALTH_PATH` build-arg flows into both the UI stage (as `VITE_HEALTH_PATH`, inlined into the bundle) and the runtime ENV. `HEALTHCHECK` and `entrypoint.sh` forward the same env to `--health-path`. `docker-compose.yml` reads the host's `HEALTH_PATH` env and injects it into the build args and the container env in one shot.
- **Tauri** — The sidecar is spawned without `--health-path`, so it uses the new default `/v1/healthz`. `public/splash.html`'s polling loop and the doc comment in `src-tauri/src/lib.rs` are updated to match.
- **Docs** — `README.md`, `docs/server.md`, `docs/docker.md`, and `docs/browser.md` are updated; `docs/docker.md` gains a "Custom health-check path" section showing the Cloud Run flow (`docker build --build-arg HEALTH_PATH=… && docker run -e HEALTH_PATH=…`).

## Breaking change

- The default health endpoint moves from `/healthz` to `/v1/healthz`. External health checks that target `/healthz` directly (Cloud Run, k8s probes, monitoring, etc.) need either (a) their probe path updated to `/v1/healthz`, or (b) `--health-path /healthz` to restore the old behavior.

## Test plan

- [x] `bun src/cli/main.ts --help` lists `--health-path`.
- [x] `--http-port 19712` (defaults) → `GET /v1/healthz` returns `200 {"ok":true,"cps":0}`; `/healthz` returns `404`.
- [x] `--http-port 19711 --health-path /custom/health` → `/custom/health` returns `200`; both `/healthz` and `/v1/healthz` return `404`.
- [x] `--health-path no-slash` fails validation and exits with code 1.
- [ ] `docker build` → `docker run` reports `HEALTHCHECK` as healthy.
- [ ] `docker compose up --build` (default `HEALTH_PATH`) lights the Navbar's green Remote dot in the browser.
- [ ] `HEALTH_PATH=/internal/healthz docker compose build && HEALTH_PATH=/internal/healthz docker compose up` still lights the Remote dot with the custom path.
- [ ] The Tauri desktop app boots: splash clears and the UI takes over.