### PR TITLE
fix(docker): copy src/utils/ so built-in template JSONs ship

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,12 @@ COPY package.json bun.lock ./
 COPY src/cli ./src/cli
 COPY src/cp ./src/cp
 COPY src/data ./src/data
-COPY src/utils/scenarioTemplates.ts ./src/utils/scenarioTemplates.ts
+# scenarioTemplates.ts statically imports built-in templates from
+# src/utils/scenarios/*.json (extracted in PR #54). Copying the whole utils/
+# subtree keeps those imports resolvable at runtime — copying only
+# scenarioTemplates.ts left the daemon crashing on boot with
+# "Cannot find module './scenarios/essential-cp-behavior.json'".
+COPY src/utils ./src/utils
 
 # Built-in scenario examples — kept handy under /app/docs.
 COPY docs/examples/scenarios ./docs/examples/scenarios


### PR DESCRIPTION
## Summary

PR #54 extracted the six built-in scenario templates from `scenarioTemplates.ts` into `src/utils/scenarios/*.json`. The Dockerfile still only copies `scenarioTemplates.ts`, so the runtime stage is missing the JSONs and the daemon crashes immediately on import:

```
error: Cannot find module './scenarios/essential-cp-behavior.json' from '/app/src/utils/scenarioTemplates.ts'
```

Repro: deploy `ghcr.io/shiv3/ocpp-cp-simulator:latest` (post-#54) to Cloud Run with a 9700 startup probe — every revision fails with `Container called exit(1)`. Same crash on a local `docker run --rm ghcr.io/shiv3/ocpp-cp-simulator:latest --http-port 9700`.

Fix: copy the whole `src/utils/` subtree in the runtime stage. There's nothing else in `src/utils/` that hurts to include, and adding individual `COPY` lines per JSON would regress the next time a template is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)