### PR TITLE
fix: review for #54

### DIFF
--- a/src/cli/server/CPRegistry.ts
+++ b/src/cli/server/CPRegistry.ts
@@ -145,6 +145,14 @@ export class CPRegistry {
     if (!existing) {
       throw new Error(`cpId not found: ${init.cpId}`);
     }
+    // Snapshot the existing in-memory scenarios BEFORE cleanup wipes
+    // them. Without --state-db there's no `scenarios` table to rehydrate
+    // from, so `restoreScenariosFromDatabase` returns 0 and the operator
+    // loses every seeded / hand-loaded scenario each time they touch
+    // the CP's Edit form. With --state-db, restoreScenariosFromDatabase
+    // covers it too; the snapshot is still safe to feed in because
+    // loadScenario is an upsert keyed on scenario.id.
+    const scenarioSnapshot = existing.snapshotScenarios();
     existing.cleanup();
     this.unsubscribes.get(init.cpId)?.();
     this.unsubscribes.delete(init.cpId);
@@ -155,6 +163,17 @@ export class CPRegistry {
     // re-created service picks up the same set without the operator
     // having to reload them.
     svc.restoreScenariosFromDatabase();
+    for (const { connectorId, definition } of scenarioSnapshot) {
+      try {
+        svc.loadScenario(connectorId, definition);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[CPRegistry] Failed to re-attach scenario ${definition.id} to ${init.cpId}/connector ${connectorId} during update:`,
+          err,
+        );
+      }
+    }
     return svc;
   }
 

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -525,6 +525,25 @@ export class CLIChargePointService {
   }
 
   /**
+   * Snapshot of every loaded (connectorId, ScenarioDefinition) pair. Used
+   * by CPRegistry.update to carry the in-memory scenarios across a
+   * cleanup() → new instantiate() rebuild when the daemon is running
+   * without --state-db (no `scenarios` table to rehydrate from). The
+   * definitions are returned by-reference because they are read-only
+   * snapshots of the operator's last load; the new service's
+   * loadScenario clones them as needed.
+   */
+  snapshotScenarios(): ReadonlyArray<{
+    readonly connectorId: number;
+    readonly definition: ScenarioDefinition;
+  }> {
+    return Array.from(this._scenarios.values()).map((entry) => ({
+      connectorId: entry.connectorId,
+      definition: entry.definition,
+    }));
+  }
+
+  /**
    * Rehydrate all scenarios that were persisted for this CP under the
    * given (cp_id, connector_id) by a previous daemon run. Called from
    * CPRegistry.restoreFromDatabase() after a CP is re-instantiated, so a
@@ -775,6 +794,20 @@ export class CLIChargePointService {
         // statusChange-trigger case.
         if ((status as OCPPStatus) === OCPPStatus.Available) {
           this.handleConnectAutoStart();
+          // Connector statusChange events fired during BootNotification
+          // handling race ahead of the CP-level Available transition, so
+          // `handleStatusAutoStart` returns early via the
+          // `chargePoint.status !== Available` gate and any
+          // `triggerOn: "status"` scenario targeting the connector's
+          // current state never starts. Re-evaluate every connector here
+          // now that the gate is open. Dedup via lastAutoStartedScenarioKey
+          // keeps repeats of this branch from re-firing what's already up.
+          for (const connector of this._chargePoint.connectors.values()) {
+            this.handleStatusAutoStart(
+              connector.id,
+              connector.status as OCPPStatus,
+            );
+          }
         }
       }),
     );

--- a/src/components/TopPage.tsx
+++ b/src/components/TopPage.tsx
@@ -75,10 +75,17 @@ const TopPage: React.FC = () => {
 
   // Remote mode: the daemon owns CP configuration, so we derive the edit
   // form's prefill from the snapshot's `config` block (POST/PUT /v1/cp echo)
-  // rather than the local config store. Keyed on chargePoints (the daemon's
-  // CP roster) so adding/editing/removing a CP updates the list immediately.
+  // rather than the local config store. Keyed on the full snapshot of each
+  // CP's config (not just `id`) so a PUT edit that changes wsUrl / vendor /
+  // boot-notification fields without changing the cpId still invalidates
+  // the memo and rebuilds chargePointConfigs — otherwise the edit modal
+  // would reopen with the previous values and a follow-up save would
+  // silently revert the change.
   const chargePointsKey = useMemo(
-    () => chargePoints.map((c) => c.id).join("|"),
+    () =>
+      chargePoints
+        .map((c) => (c.config ? `${c.id}:${JSON.stringify(c.config)}` : c.id))
+        .join("|"),
     [chargePoints],
   );
 

--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -41,6 +41,11 @@ export class ScenarioExecutor {
   private eventEmitter?: EventEmitter<ScenarioEvents>;
   private forceSkipResolve: (() => void) | null = null;
   private remoteStartTagId: string | null = null;
+  // Reason captured from the most recent RemoteStopTrigger node, forwarded
+  // to the next Transaction Stop's StopTransaction.req so the CSMS sees
+  // "Remote" (§6.21) for RemoteStop-driven stops instead of a blank
+  // reason. Cleared as soon as the stop node consumes it.
+  private remoteStopReason: string | null = null;
 
   constructor(
     scenario: ScenarioDefinition,
@@ -555,7 +560,9 @@ export class ScenarioExecutor {
       }
     } else if (data.action === "stop") {
       if (this.callbacks.onStopTransaction) {
-        await this.callbacks.onStopTransaction();
+        const reason = this.remoteStopReason ?? undefined;
+        this.remoteStopReason = null;
+        await this.callbacks.onStopTransaction(reason);
       }
     }
   }
@@ -815,8 +822,14 @@ export class ScenarioExecutor {
     if (!this.callbacks.onWaitForRemoteStop) return;
 
     const timeout = data.timeout || 0;
+    // Wrap the resolved {transactionId, reason} so the next Transaction
+    // Stop node can pass `reason` through to StopTransaction.req. The
+    // runtime hard-codes "Remote" for the CSMS path (§6.21); we keep
+    // the wrapping here so it survives waitWithOptionalForceSkip.
     const wait = (): Promise<void> =>
-      this.callbacks.onWaitForRemoteStop!(timeout).then(() => undefined);
+      this.callbacks.onWaitForRemoteStop!(timeout).then((res) => {
+        this.remoteStopReason = res?.reason ?? null;
+      });
 
     if (!timeout || timeout === 0) {
       await this.waitWithOptionalForceSkip(wait());

--- a/src/cp/application/scenario/ScenarioRuntime.ts
+++ b/src/cp/application/scenario/ScenarioRuntime.ts
@@ -143,53 +143,63 @@ const waitForRemoteStart = (
 /** Mirror of waitForRemoteStart, but for the CSMS-initiated stop side.
  *  Registers a scenario-stop handler on the CP so the default
  *  RemoteStopTransactionHandler defers, then waits for the emitted
- *  `remoteStopReceived` event. Resolves with the transactionId from the
- *  CSMS request. Rejects on disconnect or timeout. */
+ *  `remoteStopReceived` event. Resolves with the transactionId AND the
+ *  OCPP §6.21 stop reason ("Remote" for the CSMS-initiated path) so the
+ *  subsequent Transaction Stop node can pass it through to
+ *  StopTransaction.req. Rejects on disconnect or timeout. */
 const waitForRemoteStop = (
   chargePoint: ChargePoint,
   connector: Connector,
   timeout?: number,
-): CancellableWait<number> => {
+): CancellableWait<{ transactionId: number; reason: string }> => {
   chargePoint.registerScenarioStopHandler(connector.id);
 
   let cleanupFn: (() => void) | null = null;
 
-  const promise = new Promise<number>((resolve, reject) => {
-    let timeoutId: NodeJS.Timeout | null = null;
-    let settled = false;
+  const promise = new Promise<{ transactionId: number; reason: string }>(
+    (resolve, reject) => {
+      let timeoutId: NodeJS.Timeout | null = null;
+      let settled = false;
 
-    const cleanup = () => {
-      if (settled) return;
-      settled = true;
-      if (timeoutId) clearTimeout(timeoutId);
-      chargePoint.events.off("remoteStopReceived", handler);
-      chargePoint.events.off("disconnected", disconnectHandler);
-      chargePoint.unregisterScenarioStopHandler(connector.id);
-    };
+      const cleanup = () => {
+        if (settled) return;
+        settled = true;
+        if (timeoutId) clearTimeout(timeoutId);
+        chargePoint.events.off("remoteStopReceived", handler);
+        chargePoint.events.off("disconnected", disconnectHandler);
+        chargePoint.unregisterScenarioStopHandler(connector.id);
+      };
 
-    cleanupFn = cleanup;
+      cleanupFn = cleanup;
 
-    const handler = (data: { connectorId: number; transactionId: number }) => {
-      if (data.connectorId !== connector.id) return;
-      cleanup();
-      resolve(data.transactionId);
-    };
-
-    const disconnectHandler = () => {
-      cleanup();
-      reject(new Error("Disconnected while waiting for remote stop"));
-    };
-
-    chargePoint.events.on("remoteStopReceived", handler);
-    chargePoint.events.on("disconnected", disconnectHandler);
-
-    if (timeout && timeout > 0) {
-      timeoutId = setTimeout(() => {
+      const handler = (data: {
+        connectorId: number;
+        transactionId: number;
+      }) => {
+        if (data.connectorId !== connector.id) return;
         cleanup();
-        reject(new Error(`Timeout waiting for remote stop (${timeout}s)`));
-      }, timeout * 1000);
-    }
-  });
+        // §6.21: CSMS-initiated stop → reason="Remote". Hard-code here
+        // since the request payload itself doesn't carry a reason field;
+        // the handler is what knows the provenance.
+        resolve({ transactionId: data.transactionId, reason: "Remote" });
+      };
+
+      const disconnectHandler = () => {
+        cleanup();
+        reject(new Error("Disconnected while waiting for remote stop"));
+      };
+
+      chargePoint.events.on("remoteStopReceived", handler);
+      chargePoint.events.on("disconnected", disconnectHandler);
+
+      if (timeout && timeout > 0) {
+        timeoutId = setTimeout(() => {
+          cleanup();
+          reject(new Error(`Timeout waiting for remote stop (${timeout}s)`));
+        }, timeout * 1000);
+      }
+    },
+  );
 
   return {
     promise,
@@ -299,8 +309,15 @@ export const createScenarioExecutorCallbacks = (
         initialSoc,
       );
     },
-    onStopTransaction: async () => {
-      chargePoint.stopTransaction(connector.id);
+    onStopTransaction: async (reason) => {
+      // The cast keeps stopTransaction's StopTransactionReason union
+      // happy without dragging the enum import into the callbacks
+      // declaration. ChargePoint.stopTransaction safely no-ops if there
+      // is no active transaction, so we don't guard here either.
+      chargePoint.stopTransaction(
+        connector.id,
+        reason as Parameters<typeof chargePoint.stopTransaction>[1],
+      );
     },
     onSetMeterValue: (value) => {
       chargePoint.setMeterValue(connector.id, value);

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -350,7 +350,15 @@ export interface ScenarioExecutorCallbacks {
     batteryCapacityKwh?: number,
     initialSoc?: number,
   ) => Promise<void>;
-  onStopTransaction?: () => Promise<void>;
+  onStopTransaction?: (
+    /** Optional OCPP §6.21 reason string. When a preceding
+     *  RemoteStopTrigger node captured a CSMS-initiated stop, the
+     *  scenario forwards "Remote" so StopTransaction.req carries the
+     *  same reason the daemon would have set on the default
+     *  RemoteStopTransactionHandler path. Other call sites can omit it
+     *  and the connector / charge point default applies. */
+    reason?: string,
+  ) => Promise<void>;
   onSetMeterValue?: (value: number) => void;
   onSendMeterValue?: () => Promise<void>;
   onStartAutoMeterValue?: (config: {
@@ -375,7 +383,12 @@ export interface ScenarioExecutorCallbacks {
    * RemoteStopTransactionHandler delegates instead of stopping the
    * transaction itself.
    */
-  onWaitForRemoteStop?: (timeout?: number) => Promise<number>;
+  /** Resolves with `{ transactionId, reason }` so the next Transaction
+   *  Stop node can pass the CSMS-supplied reason (defaults to "Remote")
+   *  through to StopTransaction.req. */
+  onWaitForRemoteStop?: (
+    timeout?: number,
+  ) => Promise<{ transactionId: number; reason: string }>;
   onWaitForStatus?: (
     targetStatus: OCPPStatus,
     timeout?: number,


### PR DESCRIPTION
## Summary

- **PUT edit no longer drops scenarios in in-memory mode.** `CPRegistry.update` called `existing.cleanup()` and then relied on `restoreScenariosFromDatabase()` to bring scenarios back; without \`--state-db\` that returns 0 and every loaded scenario silently disappeared each time the operator saved the Edit CP form. Now we snapshot the in-memory \`_scenarios\` before cleanup and re-\`loadScenario\` them into the new service. \`loadScenario\` is an upsert keyed on \`scenario.id\`, so the \`--state-db\` path stays idempotent.
- **RemoteStop-triggered transactions now carry `reason: \"Remote\"`.** When a scenario owns the RemoteStop path, the default \`RemoteStopTransactionHandler\` notifies and stops short of calling \`stopTransaction\` — but the scenario's \`Transaction Stop\` node was calling \`stopTransaction()\` with no reason, so \`StopTransaction.req\` went out blank for every CSMS-initiated stop that ran through \`RemoteStopTrigger\` (including the Essential CP Behavior template). Plumb the reason through: \`waitForRemoteStop\` resolves with \`{ transactionId, reason }\`, \`ScenarioExecutor\` caches it on \`remoteStopReason\` until the next \`Transaction Stop\` consumes it, and \`onStopTransaction(reason?)\` forwards it into \`chargePoint.stopTransaction(connectorId, reason)\`.
- **\`triggerOn: \"status\"\` scenarios now actually fire after boot.** \`handleConnectAutoStart\` runs when CP-level statusChange reports \`Available\`, but connector statusChange events during BootNotification arrive *before* \`ChargePoint.status\` flips, so \`tryAutoStartForConnector\`'s \`chargePoint.status !== Available\` gate returned early and \`triggerOn: \"status\"\` scenarios never started in remote mode. Now we re-evaluate every connector's \"status\"-mode scenarios from the CP Available branch too; \`lastAutoStartedScenarioKey\` dedups so this doesn't re-fire what's already up.
- **Remote Edit modal stops showing stale config.** \`TopPage.chargePointsKey\` was \`chargePoints.map(c => c.id).join(\"|\")\`, so a PUT edit that only changed wsUrl / vendor / boot fields didn't invalidate the \`useMemo\` — next open of the Edit CP modal pre-filled stale values and a follow-up save reverted the change. Include each \`cp.config\` snapshot in the key so the effect rebuilds \`chargePointConfigs\` whenever any remote-side field changes.

## Test plan

- [x] Daemon smoke: \`POST /v1/cp { cpId: \"E1\", connectors: 2 }\` → both connectors get the seeded \`essential-cp-behavior-E1-c{1,2}-…\` scenario.
- [x] \`PUT /v1/cp/E1 { wsUrl: \"ws://different/\", vendor: \"V2\" }\` → \`list_scenarios\` for both connectors still returns the same scenario ids (in-memory mode, no \`--state-db\`).
- [x] \`bunx vite build\` passes.
- [ ] Manual: in the web console, click Edit on a remote CP, change wsUrl, save, reopen — the new wsUrl shows (not the old one).
- [ ] Manual: load a scenario with a \`Start.triggerOn = \"status\"\` Start node + a CSMS that puts the connector into the target status, verify it auto-starts after boot.
- [ ] Manual against a CSMS: drive a transaction through Essential CP Behavior, send \`RemoteStopTransaction\`, observe \`StopTransaction.req\` payload carries \`reason: \"Remote\"\`.