### PR TITLE
feat(persistence): survive daemon restart mid-transaction via connector_runtime

### DIFF
--- a/src/cli/server/CPRegistry.ts
+++ b/src/cli/server/CPRegistry.ts
@@ -65,6 +65,20 @@ export class CPRegistry {
       // Use the internal create path WITHOUT re-inserting into the DB —
       // these rows already exist.
       const svc = this.instantiate(init);
+      // Restore per-connector runtime state (OCPP status, in-flight
+      // transaction, meter, soc) BEFORE wiring the WebSocket so the
+      // first StatusNotification we send carries the resumed status
+      // rather than a fresh Available. The snapshot is applied via
+      // Connector.restoreRuntimeSnapshot, which writes private fields
+      // without emitting statusChange — so the listeners on the new
+      // service won't trigger a duplicate persist or notification.
+      const restoredConnectors = svc.restoreConnectorRuntimeFromDatabase();
+      if (restoredConnectors > 0) {
+        console.log(
+          `[CPRegistry] Restored ${restoredConnectors} connector runtime ` +
+            `snapshot(s) for CP "${row.cp_id}"`,
+        );
+      }
       // Rehydrate every scenario the operator had loaded against this CP
       // before the restart. statusChange-trigger scenarios re-arm via the
       // connector subscription set up in CLIChargePointService — nothing
@@ -214,10 +228,11 @@ export class CPRegistry {
   private persistRemove(cpId: string): void {
     if (!this.database) return;
     this.database.run("DELETE FROM charge_points WHERE cp_id = ?", [cpId]);
-    // Cascade: orphan scenario rows would survive a CP delete and reappear
-    // if the same cpId is re-created. There's no FK in the schema, so the
-    // cleanup is explicit.
+    // Cascade: orphan rows in dependent tables would survive a CP delete
+    // and reappear if the same cpId is re-created. There's no FK in the
+    // schema, so the cleanup is explicit.
     this.database.run("DELETE FROM scenarios WHERE cp_id = ?", [cpId]);
+    this.database.run("DELETE FROM connector_runtime WHERE cp_id = ?", [cpId]);
   }
 
   remove(cpId: string): boolean {

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -19,6 +19,11 @@ import type {
 } from "../cp/application/scenario/ScenarioTypes";
 import { ScenarioNodeType } from "../cp/application/scenario/ScenarioTypes";
 import { SqliteScenarioRepository } from "../data/sqlite/SqliteScenarioRepository";
+import { SqliteConnectorRuntimeRepository } from "../data/sqlite/SqliteConnectorRuntimeRepository";
+import {
+  NoopConnectorRuntimeRepository,
+  type ConnectorRuntimeRepository,
+} from "../data/interfaces/ConnectorRuntimeRepository";
 import type { EVSettings } from "../cp/domain/connector/EVSettings";
 import type { AutoMeterValueConfig } from "../cp/domain/connector/MeterValueCurve";
 import type { ActiveChargingProfile } from "../cp/domain/connector/Connector";
@@ -189,6 +194,7 @@ export class CLIChargePointService {
   > = new Map();
   private readonly _executors: Map<string, ScenarioExecutor> = new Map();
   private readonly _scenarioRepo: SqliteScenarioRepository;
+  private readonly _runtimeRepo: ConnectorRuntimeRepository;
   // Keep the original init so the web console can prefill the "Edit CP"
   // modal without us having to round-trip the persisted SQL row back into
   // ChargePointInitOptions shape. Exposed via getInit() and the
@@ -202,6 +208,9 @@ export class CLIChargePointService {
   ) {
     this._init = init;
     this._scenarioRepo = new SqliteScenarioRepository(database);
+    this._runtimeRepo = database
+      ? new SqliteConnectorRuntimeRepository(database)
+      : new NoopConnectorRuntimeRepository();
     const overrides = init.bootNotification ?? {};
     const bootNotification: BootNotification = {
       chargePointVendor: init.vendor,
@@ -926,8 +935,84 @@ export class CLIChargePointService {
     );
   }
 
+  /**
+   * Persist the connector's current runtime snapshot to the daemon DB.
+   * Called from every event listener that touches a persisted field
+   * (status, availability, transaction, meter, soc). No-op when the
+   * daemon is running without `--state-db`. Errors are swallowed and
+   * logged: a transient SQLite write failure should not crash an
+   * in-flight OCPP transaction.
+   */
+  private persistConnectorRuntime(
+    connector: ReturnType<typeof this._chargePoint.connectors.get>,
+    connectorId: number,
+  ): void {
+    if (!connector) return;
+    try {
+      this._runtimeRepo.save(
+        this._init.cpId,
+        connectorId,
+        connector.snapshotRuntime(),
+      );
+    } catch (err) {
+      console.warn(
+        `[service] failed to persist connector_runtime for ` +
+          `${this._init.cpId}:${connectorId}`,
+        err,
+      );
+    }
+  }
+
+  /**
+   * Rehydrate every connector's runtime state from the DB. Called by
+   * the CP restore path after `instantiate()` but BEFORE the WebSocket
+   * is opened: the snapshot uses
+   * {@link Connector.restoreRuntimeSnapshot} which does NOT fire
+   * statusChange / meter events, so listeners on the new service won't
+   * accidentally push a duplicate StatusNotification to the CSMS the
+   * moment we connect.
+   *
+   * Returns the number of connectors that had a stored snapshot
+   * applied (i.e. were not at the default Available / 0 / null state).
+   */
+  restoreConnectorRuntimeFromDatabase(): number {
+    if (!this.database) return 0;
+    let restored = 0;
+    this._chargePoint.connectors.forEach((connector, connectorId) => {
+      const snapshot = this._runtimeRepo.load(this._init.cpId, connectorId);
+      if (!snapshot) return;
+      connector.restoreRuntimeSnapshot(snapshot);
+      restored += 1;
+    });
+    return restored;
+  }
+
   private attachConnectorEventForwarders(): void {
     this._chargePoint.connectors.forEach((connector, connectorId) => {
+      // Runtime persistence: every event that mutates a field in
+      // ConnectorRuntimeSnapshot triggers a full snapshot upsert.
+      // Snapshots are small (one row, ~10 columns) and writes are
+      // throttled naturally by event frequency, so we don't batch.
+      const persist = () =>
+        this.persistConnectorRuntime(connector, connectorId);
+      this._connectorUnsubscribes.push(
+        connector.events.on("statusChange", persist),
+      );
+      this._connectorUnsubscribes.push(
+        connector.events.on("availabilityChange", persist),
+      );
+      this._connectorUnsubscribes.push(
+        connector.events.on("transactionChange", persist),
+      );
+      this._connectorUnsubscribes.push(
+        connector.events.on("transactionIdChange", persist),
+      );
+      this._connectorUnsubscribes.push(
+        connector.events.on("meterValueChange", persist),
+      );
+      this._connectorUnsubscribes.push(
+        connector.events.on("socChange", persist),
+      );
       this._connectorUnsubscribes.push(
         connector.events.on("availabilityChange", ({ availability }) => {
           this.emit({

--- a/src/cp/domain/connector/Connector.ts
+++ b/src/cp/domain/connector/Connector.ts
@@ -77,6 +77,15 @@ export interface ActiveChargingProfile {
 
 export interface ConnectorEvents {
   statusChange: { status: OCPPStatus; previousStatus: OCPPStatus };
+  /**
+   * Fires when `beginTransaction` or `stopTransaction` flips the
+   * `transactionValue` field, distinct from `transactionIdChange`
+   * (which only fires when the CSMS confirms a real id on an
+   * already-active transaction). Persistence listeners use this to
+   * catch the "transaction object just started" / "just cleared" edges
+   * without needing a polling read.
+   */
+  transactionChange: { transaction: Transaction | null };
   transactionIdChange: { transactionId: number | null };
   meterValueChange: { meterValue: number };
   socChange: { soc: number | null };
@@ -160,6 +169,63 @@ export class Connector {
   private _autoResetToAvailable = true;
   private _evSettings: EVSettings = getDefaultEVSettings();
   private _chargingProfiles: ActiveChargingProfile[] = [];
+
+  /**
+   * Capture the runtime state needed to resume this connector after a
+   * daemon restart. Paired with {@link restoreRuntimeSnapshot}. The
+   * returned shape is a structural copy: callers can persist it and
+   * round-trip it through JSON without aliasing live connector state.
+   */
+  snapshotRuntime(): {
+    status: OCPPStatus;
+    availability: OCPPAvailability;
+    scheduledAvailability: OCPPAvailability | null;
+    transaction: Transaction | null;
+    meterValueWh: number;
+    socPercent: number | null;
+    lastAutoStartedScenarioKey: string | null;
+  } {
+    return {
+      status: this.statusValue,
+      availability: this.availabilityValue,
+      scheduledAvailability: this.scheduledAvailabilityValue,
+      transaction: this.transactionValue ? { ...this.transactionValue } : null,
+      meterValueWh: this.meterValueWh,
+      socPercent: this.socPercent,
+      lastAutoStartedScenarioKey: this.lastAutoStartedScenarioKeyValue,
+    };
+  }
+
+  /**
+   * Apply a snapshot captured before a daemon restart. Writes the
+   * private fields directly so we do NOT emit `statusChange` /
+   * `meterChange` / etc. — emitting on restore would cause the
+   * ChargePoint to push a duplicate StatusNotification or MeterValues
+   * before the WebSocket is even up, and would cause the auto-start
+   * dedup key to be cleared by re-triggering its setter.
+   *
+   * Restore is idempotent on already-default values: nulls and
+   * `meterValueWh = 0` simply rewrite the existing zero state.
+   */
+  restoreRuntimeSnapshot(snapshot: {
+    status: OCPPStatus;
+    availability: OCPPAvailability;
+    scheduledAvailability: OCPPAvailability | null;
+    transaction: Transaction | null;
+    meterValueWh: number;
+    socPercent: number | null;
+    lastAutoStartedScenarioKey: string | null;
+  }): void {
+    this.statusValue = snapshot.status;
+    this.availabilityValue = snapshot.availability;
+    this.scheduledAvailabilityValue = snapshot.scheduledAvailability;
+    this.transactionValue = snapshot.transaction
+      ? { ...snapshot.transaction }
+      : null;
+    this.meterValueWh = snapshot.meterValueWh;
+    this.socPercent = snapshot.socPercent;
+    this.lastAutoStartedScenarioKeyValue = snapshot.lastAutoStartedScenarioKey;
+  }
 
   constructor(
     private readonly connectorId: number,
@@ -567,11 +633,13 @@ export class Connector {
   beginTransaction(transaction: Transaction): void {
     this.transactionValue = transaction;
     this.startConfiguredMeterValue();
+    this.eventsEmitter.emit("transactionChange", { transaction });
   }
 
   stopTransaction(): void {
     this.meterScheduler.stop();
     this.transactionValue = null;
+    this.eventsEmitter.emit("transactionChange", { transaction: null });
   }
 
   startManualMeterStrategy(strategy: MeterValueStrategy): void {

--- a/src/cp/domain/persistence/__tests__/BunSqliteDatabase.bun.test.ts
+++ b/src/cp/domain/persistence/__tests__/BunSqliteDatabase.bun.test.ts
@@ -8,6 +8,9 @@ import {
   SchemaVersionMismatchError,
   runMigrations,
 } from "../schema";
+import { SqliteConnectorRuntimeRepository } from "../../../../data/sqlite/SqliteConnectorRuntimeRepository";
+import type { ConnectorRuntimeSnapshot } from "../../../../data/interfaces/ConnectorRuntimeRepository";
+import { OCPPStatus } from "../../types/OcppTypes";
 
 describe("BunSqliteDatabase", () => {
   it("opens an in-memory DB and applies the schema", () => {
@@ -26,6 +29,7 @@ describe("BunSqliteDatabase", () => {
           "configuration",
           "pending_messages",
           "kv",
+          "connector_runtime",
         ]),
       );
     } finally {
@@ -75,6 +79,98 @@ describe("BunSqliteDatabase", () => {
         ["cp1"],
       );
       expect(row?.soc_meter_sync).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("round-trips a connector runtime snapshot with active transaction", () => {
+    const db = BunSqliteDatabase.open(":memory:");
+    try {
+      const repo = new SqliteConnectorRuntimeRepository(db);
+      const startTime = new Date("2026-06-02T08:00:00.000Z");
+      const snapshot: ConnectorRuntimeSnapshot = {
+        status: OCPPStatus.Charging,
+        availability: "Operative",
+        scheduledAvailability: null,
+        transaction: {
+          id: 1583,
+          connectorId: 1,
+          tagId: "TAG001",
+          meterStart: 0,
+          meterStop: null,
+          startTime,
+          stopTime: null,
+          meterSent: false,
+        },
+        meterValueWh: 12345,
+        socPercent: 42.5,
+        lastAutoStartedScenarioKey: "essential-cp-behavior@1|oneshot",
+      };
+      repo.save("shiv3-cp7", 1, snapshot);
+      const loaded = repo.load("shiv3-cp7", 1);
+      expect(loaded).not.toBeNull();
+      expect(loaded?.status).toBe(OCPPStatus.Charging);
+      expect(loaded?.transaction?.id).toBe(1583);
+      expect(loaded?.transaction?.tagId).toBe("TAG001");
+      // Date round-trip: JSON.stringify reduces Date to ISO string;
+      // deserializeTransaction re-hydrates it. The instance identity
+      // changes (toMatchObject doesn't help) so just compare the epoch.
+      expect(loaded?.transaction?.startTime.getTime()).toBe(
+        startTime.getTime(),
+      );
+      expect(loaded?.meterValueWh).toBe(12345);
+      expect(loaded?.socPercent).toBe(42.5);
+      expect(loaded?.lastAutoStartedScenarioKey).toBe(
+        "essential-cp-behavior@1|oneshot",
+      );
+    } finally {
+      db.close();
+    }
+  });
+
+  it("clears a connector runtime row when transaction ends", () => {
+    const db = BunSqliteDatabase.open(":memory:");
+    try {
+      const repo = new SqliteConnectorRuntimeRepository(db);
+      const base: ConnectorRuntimeSnapshot = {
+        status: OCPPStatus.Available,
+        availability: "Operative",
+        scheduledAvailability: null,
+        transaction: null,
+        meterValueWh: 0,
+        socPercent: null,
+        lastAutoStartedScenarioKey: null,
+      };
+      repo.save("shiv3-cp7", 1, base);
+      const loaded = repo.load("shiv3-cp7", 1);
+      expect(loaded?.transaction).toBeNull();
+      expect(loaded?.status).toBe(OCPPStatus.Available);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("deleteByCpId removes every connector row for that CP", () => {
+    const db = BunSqliteDatabase.open(":memory:");
+    try {
+      const repo = new SqliteConnectorRuntimeRepository(db);
+      const snap: ConnectorRuntimeSnapshot = {
+        status: OCPPStatus.Available,
+        availability: "Operative",
+        scheduledAvailability: null,
+        transaction: null,
+        meterValueWh: 0,
+        socPercent: null,
+        lastAutoStartedScenarioKey: null,
+      };
+      repo.save("cp-a", 1, snap);
+      repo.save("cp-a", 2, snap);
+      repo.save("cp-b", 1, snap);
+      repo.deleteByCpId("cp-a");
+      expect(repo.load("cp-a", 1)).toBeNull();
+      expect(repo.load("cp-a", 2)).toBeNull();
+      expect(repo.load("cp-b", 1)).not.toBeNull();
     } finally {
       db.close();
     }

--- a/src/cp/domain/persistence/schema.ts
+++ b/src/cp/domain/persistence/schema.ts
@@ -13,7 +13,7 @@
  * persistence layer was localStorage and we explicitly do NOT carry it
  * forward (see plan).
  */
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 export const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS schema_meta (
@@ -125,6 +125,35 @@ CREATE TABLE IF NOT EXISTS charge_point_state (
   desired_connected INTEGER NOT NULL DEFAULT 0,
   updated_at        TEXT NOT NULL
 );
+
+-- Per-connector runtime state needed to survive a daemon restart in the
+-- middle of an OCPP transaction. Without this, a pod restart on
+-- Kubernetes (or any --state-db host where the process can die
+-- mid-charge) leaves the CSMS holding a Charging transaction while the
+-- simulator comes back up with every connector pinned to Available, and
+-- StatusNotification / MeterValues stop arriving until an operator
+-- manually intervenes.
+--
+-- Scope is deliberately small: just the OCPP-visible state plus the
+-- in-flight transaction JSON and the meter accumulator. Scenario
+-- execution position is NOT persisted yet (see follow-up), so a
+-- restored Charging connector won't keep advancing through scenario
+-- nodes on its own. It will, however, accept RemoteStopTransaction
+-- through the daemon's default handler and emit a correctly-numbered
+-- StopTransaction.req.
+CREATE TABLE IF NOT EXISTS connector_runtime (
+  cp_id                            TEXT NOT NULL,
+  connector_id                     INTEGER NOT NULL,
+  status                           TEXT NOT NULL,
+  availability                     TEXT NOT NULL,
+  scheduled_availability           TEXT,
+  transaction_json                 TEXT,
+  meter_value_wh                   INTEGER NOT NULL DEFAULT 0,
+  soc_percent                      REAL,
+  last_auto_started_scenario_key   TEXT,
+  updated_at                       TEXT NOT NULL,
+  PRIMARY KEY (cp_id, connector_id)
+);
 `;
 
 import type { Database } from "./Database";
@@ -154,9 +183,10 @@ export class SchemaVersionMismatchError extends Error {
  * `Database` is opened.
  *
  * Version handling:
- *   - DB version  < SCHEMA_VERSION → run all forward migrations (none
- *     defined yet because we're at v1; the CREATE TABLE IF NOT EXISTS
- *     in SCHEMA_SQL handles the "fresh DB" case).
+ *   - DB version  < SCHEMA_VERSION → run all forward migrations. The
+ *     v1 → v2 case (adding `connector_runtime`) needs no dedicated
+ *     branch because SCHEMA_SQL re-runs every call and uses
+ *     `CREATE TABLE IF NOT EXISTS`.
  *   - DB version == SCHEMA_VERSION → no-op aside from re-stamping.
  *   - DB version  > SCHEMA_VERSION → throw {@link SchemaVersionMismatchError}.
  *     Older simulator running against a DB the newer simulator wrote;

--- a/src/data/interfaces/ConnectorRuntimeRepository.ts
+++ b/src/data/interfaces/ConnectorRuntimeRepository.ts
@@ -1,0 +1,97 @@
+import type { Transaction } from "../../cp/domain/connector/Transaction";
+import type {
+  OCPPAvailability,
+  OCPPStatus,
+} from "../../cp/domain/types/OcppTypes";
+
+/**
+ * The slice of {@link Connector} runtime state we persist between daemon
+ * restarts. Kept deliberately small to avoid coupling persistence to the
+ * full Connector implementation: only fields that are needed to resume
+ * an in-flight transaction or hold a non-Available status across a
+ * restart are included.
+ *
+ * Notable exclusions, documented so a future expansion is a conscious
+ * choice rather than an oversight:
+ *
+ *   - Error code / error info / vendor error code: meaningful only while
+ *     the connector is in a non-Operative state mid-conversation with
+ *     the CSMS; resyncing them after a restart loses no information of
+ *     value to the operator.
+ *   - Scenario execution position: the daemon doesn't yet know how to
+ *     freeze and thaw a Robot3 service mid-flow, so we let scenarios
+ *     re-arm from the top on restart. A connector that was Charging
+ *     will resume the OCPP transaction (StopTransaction goes out
+ *     correctly on the next RemoteStop), but its scenario node
+ *     position is lost.
+ *   - Auto-meter scheduler state: the schedule itself is reproducible
+ *     from {@link ConnectorSettingsRepository}'s `auto_meter` row and
+ *     the restored `meterValueWh`, so we don't store the scheduler's
+ *     internal cursor.
+ */
+export interface ConnectorRuntimeSnapshot {
+  status: OCPPStatus;
+  availability: OCPPAvailability;
+  scheduledAvailability: OCPPAvailability | null;
+  /** Active OCPP transaction, or `null` when the connector is idle.
+   *  Stored verbatim — `startTime` / `stopTime` round-trip as ISO 8601
+   *  strings via `Transaction.toJSON()` semantics. */
+  transaction: Transaction | null;
+  meterValueWh: number;
+  socPercent: number | null;
+  /** Mirror of {@link Connector.lastAutoStartedScenarioKey}: prevents
+   *  the auto-start path from re-firing the same scenario after a
+   *  restart, which would otherwise reset the connector to the
+   *  scenario's first node. */
+  lastAutoStartedScenarioKey: string | null;
+}
+
+/**
+ * Storage for {@link ConnectorRuntimeSnapshot}s, keyed on
+ * `(cp_id, connector_id)`. Writes are idempotent: callers send the
+ * full snapshot every time a connector field changes, and the
+ * repository upserts the row.
+ */
+export interface ConnectorRuntimeRepository {
+  /** Read the last-saved runtime snapshot for `(cpId, connectorId)`, or
+   *  `null` if nothing is stored. Called during restore. */
+  load(cpId: string, connectorId: number): ConnectorRuntimeSnapshot | null;
+
+  /** Upsert the full snapshot. Intended to be called from a connector
+   *  event listener that fires on every OCPP-visible state change. */
+  save(
+    cpId: string,
+    connectorId: number,
+    snapshot: ConnectorRuntimeSnapshot,
+  ): void;
+
+  /** Drop the row for one connector — called when a CP is being torn
+   *  down via `DELETE /v1/cp/:cpId`. */
+  delete(cpId: string, connectorId: number): void;
+
+  /** Drop every row for a CP. Convenience for the cp-delete path so
+   *  callers don't have to enumerate connector ids. */
+  deleteByCpId(cpId: string): void;
+}
+
+/**
+ * No-op implementation for environments without a SQL database (browser
+ * local mode, daemon started without `--state-db`). Lets the rest of the
+ * code stay unconditional without sprinkling `if (repo)` everywhere.
+ */
+export class NoopConnectorRuntimeRepository
+  implements ConnectorRuntimeRepository
+{
+  load(): ConnectorRuntimeSnapshot | null {
+    return null;
+  }
+  save(): void {
+    /* no-op */
+  }
+  delete(): void {
+    /* no-op */
+  }
+  deleteByCpId(): void {
+    /* no-op */
+  }
+}

--- a/src/data/sqlite/SqliteConnectorRuntimeRepository.ts
+++ b/src/data/sqlite/SqliteConnectorRuntimeRepository.ts
@@ -1,0 +1,126 @@
+import type { Transaction } from "../../cp/domain/connector/Transaction";
+import type { Database } from "../../cp/domain/persistence/Database";
+import type {
+  OCPPAvailability,
+  OCPPStatus,
+} from "../../cp/domain/types/OcppTypes";
+import type {
+  ConnectorRuntimeRepository,
+  ConnectorRuntimeSnapshot,
+} from "../interfaces/ConnectorRuntimeRepository";
+
+interface ConnectorRuntimeRow {
+  status: string;
+  availability: string;
+  scheduled_availability: string | null;
+  transaction_json: string | null;
+  meter_value_wh: number;
+  soc_percent: number | null;
+  last_auto_started_scenario_key: string | null;
+}
+
+/**
+ * SQLite-backed {@link ConnectorRuntimeRepository}. One row per
+ * `(cp_id, connector_id)`. Transaction is serialised as JSON because the
+ * shape (especially the optional reservation/stop-reason/EV fields) is
+ * driven by OCPP and changes too often to track as relational columns.
+ */
+export class SqliteConnectorRuntimeRepository
+  implements ConnectorRuntimeRepository
+{
+  constructor(private readonly database: Database) {}
+
+  load(cpId: string, connectorId: number): ConnectorRuntimeSnapshot | null {
+    const row = this.database.get<ConnectorRuntimeRow>(
+      "SELECT status, availability, scheduled_availability, transaction_json, " +
+        "meter_value_wh, soc_percent, last_auto_started_scenario_key " +
+        "FROM connector_runtime WHERE cp_id = ? AND connector_id = ?",
+      [cpId, connectorId],
+    );
+    if (!row) return null;
+    return {
+      status: row.status as OCPPStatus,
+      availability: row.availability as OCPPAvailability,
+      scheduledAvailability:
+        row.scheduled_availability == null
+          ? null
+          : (row.scheduled_availability as OCPPAvailability),
+      transaction: deserializeTransaction(row.transaction_json),
+      meterValueWh: row.meter_value_wh,
+      socPercent: row.soc_percent,
+      lastAutoStartedScenarioKey: row.last_auto_started_scenario_key,
+    };
+  }
+
+  save(
+    cpId: string,
+    connectorId: number,
+    snapshot: ConnectorRuntimeSnapshot,
+  ): void {
+    this.database.run(
+      "INSERT INTO connector_runtime " +
+        "(cp_id, connector_id, status, availability, scheduled_availability, " +
+        " transaction_json, meter_value_wh, soc_percent, " +
+        " last_auto_started_scenario_key, updated_at) " +
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) " +
+        "ON CONFLICT (cp_id, connector_id) DO UPDATE SET " +
+        "  status = excluded.status, " +
+        "  availability = excluded.availability, " +
+        "  scheduled_availability = excluded.scheduled_availability, " +
+        "  transaction_json = excluded.transaction_json, " +
+        "  meter_value_wh = excluded.meter_value_wh, " +
+        "  soc_percent = excluded.soc_percent, " +
+        "  last_auto_started_scenario_key = " +
+        "    excluded.last_auto_started_scenario_key, " +
+        "  updated_at = excluded.updated_at",
+      [
+        cpId,
+        connectorId,
+        snapshot.status,
+        snapshot.availability,
+        snapshot.scheduledAvailability,
+        serializeTransaction(snapshot.transaction),
+        snapshot.meterValueWh,
+        snapshot.socPercent,
+        snapshot.lastAutoStartedScenarioKey,
+        new Date().toISOString(),
+      ],
+    );
+  }
+
+  delete(cpId: string, connectorId: number): void {
+    this.database.run(
+      "DELETE FROM connector_runtime WHERE cp_id = ? AND connector_id = ?",
+      [cpId, connectorId],
+    );
+  }
+
+  deleteByCpId(cpId: string): void {
+    this.database.run("DELETE FROM connector_runtime WHERE cp_id = ?", [cpId]);
+  }
+}
+
+function serializeTransaction(tx: Transaction | null): string | null {
+  if (!tx) return null;
+  // JSON.stringify hands Date instances to toISOString — sufficient for
+  // startTime / stopTime. We never round-trip Date instances through
+  // localStorage at this point, so collapsing them to strings is fine.
+  return JSON.stringify(tx);
+}
+
+function deserializeTransaction(raw: string | null): Transaction | null {
+  if (raw == null) return null;
+  try {
+    const parsed = JSON.parse(raw) as Transaction;
+    // Restore Date instances stripped by JSON.stringify above.
+    if (parsed.startTime && !(parsed.startTime instanceof Date)) {
+      parsed.startTime = new Date(parsed.startTime as unknown as string);
+    }
+    if (parsed.stopTime && !(parsed.stopTime instanceof Date)) {
+      parsed.stopTime = new Date(parsed.stopTime as unknown as string);
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

When the daemon dies mid-charging (kubernetes pod restart on a Cloud-Run-grade ephemeral filesystem, OOM, etc.) the CSMS keeps the transaction in `Charging` while the simulator comes back up with every connector reset to `Available`. StatusNotification and MeterValues stop arriving on the existing transaction id, and the operator ends up cleaning the orphan in the backend by hand.

This PR persists a small per-connector runtime snapshot — `status`, `availability`, the `Transaction` JSON, the meter accumulator, `soc`, and the auto-start-dedup key — so the daemon can resume the same OCPP-visible state across a restart. On the kubernetes deployment that lives under `cp-simulator.dev-dmm-ev-charge.com` (RWO PVC at `/data`), this means an active transaction survives an Autopilot pod migration.

## What's persisted

| Field | Why |
|---|---|
| `status` | First `StatusNotification.req` after resumed connect carries the right value (Charging stays Charging) |
| `availability` | `Operative` / `Inoperative` survives a restart while no transaction is open |
| `scheduledAvailability` | `ChangeAvailability` arrived during a transaction; we need to apply it on the next `StopTransaction` |
| `transaction` (JSON) | id, tagId, meterStart, startTime, optional reservation / stop reason / EV battery fields |
| `meterValueWh` | Accumulator continues from the last-emitted MeterValue rather than restarting at 0 |
| `socPercent` | Mirrors `meterValueWh` for the SoC side |
| `lastAutoStartedScenarioKey` | Stops the auto-start path from re-firing the same scenario after a restart, which would reset the connector to the scenario's first node |

## What's NOT persisted

Called out so a future reader doesn't think I forgot:

- **Scenario execution position.** The Robot3-driven flow restarts from the scenario's first node. For `essential-cp-behavior` the auto-start path replays \"wait for RemoteStart\" and the next `RemoteStopTransaction` from the CSMS lands on the default `RemoteStopTransactionHandler`, which emits a `StopTransaction.req` with the resumed transaction id — that's good enough to close the loop. A half-finished bespoke scenario won't pick back up from the current step. Restoring that needs a separate persistence layer for the executor's Robot3 service plus a way to make outgoing OCPP messages idempotent on replay; that's a much bigger PR.
- **Error code / error info / vendor error code.** Meaningful only mid-conversation with the CSMS; resyncing them after a restart loses no information of value to the operator.
- **Auto-meter scheduler cursor.** The schedule itself is reproducible from the existing `connector_settings.auto_meter` row and the restored `meterValueWh`.

## Schema

`SCHEMA_VERSION` bumps `1` -> `2`. The new table:

```sql
CREATE TABLE IF NOT EXISTS connector_runtime (
  cp_id                            TEXT NOT NULL,
  connector_id                     INTEGER NOT NULL,
  status                           TEXT NOT NULL,
  availability                     TEXT NOT NULL,
  scheduled_availability           TEXT,
  transaction_json                 TEXT,
  meter_value_wh                   INTEGER NOT NULL DEFAULT 0,
  soc_percent                      REAL,
  last_auto_started_scenario_key   TEXT,
  updated_at                       TEXT NOT NULL,
  PRIMARY KEY (cp_id, connector_id)
);
```

`runMigrations` re-runs the forward DDL on every open, so the `v1` -> `v2` case is handled by the same `CREATE TABLE IF NOT EXISTS` path that initializes a fresh DB. No dedicated migration branch.

## Connector API additions

- `snapshotRuntime(): ConnectorRuntimeSnapshot` — read current values, returns a structural copy that's safe to JSON round-trip.
- `restoreRuntimeSnapshot(snapshot)` — write the private fields directly. This deliberately does NOT fire `statusChange` / `meterValueChange` / `availabilityChange`. Two reasons:
  1. Emitting them would push a duplicate `StatusNotification` / `MeterValues` to the CSMS the instant the WebSocket comes up, on top of the one the resumed Charging status already triggers.
  2. The `lastAutoStartedScenarioKey` setter exists; calling it would clear the dedup token, and the daemon's auto-start logic would re-fire the scenario from its first node.
- New `transactionChange` event on `Connector.events`: fires from `beginTransaction` / `stopTransaction` so the persistence listener catches the \"transaction object just started / just cleared\" edges. The existing `transactionIdChange` only fires when the CSMS confirms a real id on an already-active transaction, which doesn't cover the begin/stop edges.

## Persistence wiring

`CLIChargePointService` keeps a `ConnectorRuntimeRepository` (SQLite when `--state-db` is set, no-op otherwise) and subscribes a single `persist()` closure to every connector event that touches a snapshot field:

```ts
const persist = () => this.persistConnectorRuntime(connector, connectorId);
connector.events.on(\"statusChange\", persist);
connector.events.on(\"availabilityChange\", persist);
connector.events.on(\"transactionChange\", persist);
connector.events.on(\"transactionIdChange\", persist);
connector.events.on(\"meterValueChange\", persist);
connector.events.on(\"socChange\", persist);
```

Snapshots are tiny single-row upserts; no batching needed. Errors are swallowed + logged so a transient SQLite write failure doesn't crash an in-flight OCPP transaction.

## Restore wiring

`CPRegistry.restoreFromDatabase` calls `svc.restoreConnectorRuntimeFromDatabase()` after `instantiate()` and **before** `connect()`. The new method iterates connectors, loads each row, and applies it via `Connector.restoreRuntimeSnapshot`. Because that path doesn't emit, the listeners on the freshly-instantiated service stay quiet during the restore itself.

`persistRemove` was already cascading the scenario table; extended it to also drop `connector_runtime` rows for the deleted CP.

## Test plan

- [x] `bun test bun.test` — schema test asserts `connector_runtime` is created; new round-trip test covers an active `Transaction` (id, tagId, `startTime` Date round-trip); `deleteByCpId` removes per-CP rows without touching siblings.
- [x] `npx vitest run` — 15/15 existing pass; no regressions.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual smoke against the dev kubernetes deployment: start a transaction, `kubectl delete pod -l app=ocpp-cp-simulator`, wait for the new pod to come up, confirm the connector reports `Charging` with the same transaction id on `/v1/cp/<cpId>` and that the next `RemoteStopTransaction` from the CSMS closes the same id.

## Migration note for existing `--state-db` users

The first run after upgrade applies the v2 schema additively (`CREATE TABLE IF NOT EXISTS`). No data loss. If you're rolling back to a v1 binary against a v2 DB, the existing `SchemaVersionMismatchError` guard refuses to open the file — you'll need to point `--state-db` at a fresh path or hand-edit `schema_meta` back to `1`.