### PR TITLE
fix(reconnect): keep heartbeat callback + active-tx status across WS close

### DIFF
--- a/src/cp/application/services/HeartbeatService.ts
+++ b/src/cp/application/services/HeartbeatService.ts
@@ -117,9 +117,26 @@ export class HeartbeatService {
     this.emitState();
   }
 
+  /**
+   * Stop the idle timer. Called from `ChargePoint.teardownAfterClose` on
+   * WebSocket close so a stale timer doesn't try to send a Heartbeat onto
+   * a half-open connection.
+   *
+   * Note we deliberately do NOT clear `_sendHeartbeatCallback`: that
+   * callback is set ONCE in the `ChargePoint` constructor and is wired
+   * to the stable `OCPPMessageHandler` instance, which lives for the
+   * lifetime of the `ChargePoint`. Nulling it here would break the
+   * reconnect path — `BootNotificationResultHandler` calls
+   * `startHeartbeat(interval)` on the very same `HeartbeatService`
+   * instance, the timer rearms, fires after `interval` seconds, calls
+   * `sendHeartbeat()`, and would crash with "Heartbeat callback not
+   * set" because nothing re-installs the callback. The CSMS then
+   * disconnects on its PingWait (60s with no inbound traffic) and the
+   * cycle repeats every minute. See shiv3-cp7's logs around
+   * 2026-06-02T09:25-09:31 for the symptom.
+   */
   cleanup(): void {
     this.clearTimer();
-    this._sendHeartbeatCallback = null;
   }
 
   private armTimer(): void {

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -620,6 +620,17 @@ export class ChargePoint {
       this._connectors.forEach((connector) => {
         const previousStatus = connector.status;
         if (previousStatus === OCPPStatus.Unavailable) return;
+        // Don't clobber a connector mid-transaction. The most common
+        // caller is `teardownAfterClose` (WebSocket close), and writing
+        // Unavailable here would race with the connector_runtime
+        // persistence hook — the last snapshot before shutdown would
+        // record Unavailable, and on the next daemon restart the
+        // restore would resurrect the transaction inside an Unavailable
+        // shell, divergent from the CSMS view that still thinks
+        // Charging. Leave the per-connector status alone; the eventual
+        // StopTransaction (CSMS-issued or scenario-driven) will move
+        // it through Finishing → Available normally.
+        if (connector.transaction !== null) return;
         connector.status = OCPPStatus.Unavailable;
         this._events.emit("connectorStatusChange", {
           connectorId: connector.id,

--- a/src/cp/infrastructure/transport/handlers/callresult/BootNotificationResultHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/callresult/BootNotificationResultHandler.ts
@@ -34,7 +34,20 @@ export class BootNotificationResultHandler
         // Send connector 0 (charge point level) status first
         context.chargePoint.updateConnectorStatus(0, OCPPStatus.Available);
         context.chargePoint.connectors.forEach((connector) => {
-          if (connector.autoResetToAvailable) {
+          // Reset to Available only when this is a fresh post-boot state —
+          // i.e. autoReset is enabled AND no transaction is in flight. A
+          // connector that was restored from `connector_runtime` with an
+          // active transaction must keep its persisted status (typically
+          // Preparing → Charging) so the CSMS-side view stays consistent
+          // with the resumed transaction id; otherwise the CSMS sees us
+          // bounce Charging → Available and the transaction is orphaned.
+          // (See `restoreConnectorRuntimeFromDatabase` for the persisted
+          // shape and `Connector.restoreRuntimeSnapshot` for how the
+          // private fields are restored ahead of this StatusNotification.)
+          if (
+            connector.autoResetToAvailable &&
+            connector.transaction === null
+          ) {
             context.chargePoint.updateConnectorStatus(
               connector.id,
               OCPPStatus.Available,


### PR DESCRIPTION
Two fixes that together let the simulator survive a daemon restart mid-transaction (the kubernetes Autopilot pod migration use case `connector_runtime` was introduced for in #57).

## #1 — Heartbeat callback survives WebSocket close

`HeartbeatService.cleanup()` was nulling `_sendHeartbeatCallback` in addition to clearing the timer. `ChargePoint.teardownAfterClose` calls `cleanup()` on every WebSocket close, but the callback is wired **once** in the `ChargePoint` constructor. On the next reconnect:

1. `BootNotificationResultHandler.handle` reads `conf.interval=30s` and calls `chargePoint.startHeartbeat(30)` on the same `HeartbeatService` instance — the timer arms.
2. 30s later the timer fires → `sendHeartbeat()` → "Heartbeat callback not set" error, no Heartbeat.req leaves the sim.
3. CSMS sees no inbound traffic for `PingWait` (60s in the dev cluster's ocpp-cs deploy) and closes the WebSocket with code 1006.
4. Sim reconnects, repeats — every ~70 seconds, forever.

Saw this against dev as shiv3-cp7 around `2026-06-02T09:25-09:31`:

```
09:25:14.478  INFO  Periodic Heartbeat enabled at 30s interval
09:25:54.479  ERROR Heartbeat callback not set
09:26:32.059  ERROR Heartbeat callback not set
09:27:03      WebSocket closed: code=1006, reason=Connection ended
09:27:03      Reconnecting in 1s... → Boot → repeat
```

Fix: leave the callback alone. The timer is the only thing that needs tearing down on close; the closure captures the stable `OCPPMessageHandler` that lives for the entire `ChargePoint` lifecycle.

## #2 — Status of an in-flight transaction isn't clobbered on close/boot

Two paths in the close → reconnect cycle were overwriting the per-connector status, which broke the `connector_runtime` resume from #57:

### a. `ChargePoint.set status(Unavailable)` cascade

Called by `teardownAfterClose` on every WS close. The setter cascades Unavailable to **every** connector — including ones with an active transaction. With the persistence hook from #57 watching `statusChange`, the last snapshot before shutdown ended up recording Unavailable for connectors that were Preparing/Charging just a moment earlier. On the next daemon start the restore resurrected the transaction inside an Unavailable shell — fine for the simulator's own view, but divergent from the CSMS which still thinks the transaction is in progress.

### b. `BootNotificationResultHandler.handle` Available reset

After `BootNotification.conf` Accepted, the handler forces every `autoResetToAvailable` connector to Available before `StatusNotification.req` goes out. After the resume in #57 this means the very first StatusNotification on the resumed WebSocket announces Available for a connector whose CSMS-side transaction is still Charging — the CSMS treats us as having ended charging out-of-band and starts trying to clean up the orphan.

Both sites now check `connector.transaction !== null` and leave the per-connector status alone in that case. The cascade still applies to idle connectors (UI-integrity reason for cascading Unavailable is unchanged for those), and the boot-time Available reset still applies to fresh connectors. Only the resume case is left untouched, which is what the original §4.9-independence note allows.

## Test plan

- [x] `bun test bun.test` → 8/8 pass
- [x] `npx vitest run` → 15/15 pass
- [x] `npx tsc --noEmit` → clean
- [x] Local recipe with `--state-db /tmp/sim-state/state.db`:

  ```
  Before kill : c1 status=Preparing tx={id=0 tag=TAG-RESTORE-FINAL} meter=55555
  After kill  : connector_runtime row → status=Preparing
                (was Unavailable before this commit; teardown cascade overwrote it)
  After start : c1 status=Preparing tx=0 meter=55555 tag=TAG-RESTORE-FINAL
                StatusNotification(connectorId:1, status:"Preparing") goes out
                immediately after Boot accept.
  ```

- [x] Heartbeat fix verified separately against dev's `cs.dev-dmm-ev-charge.com`: 6 Heartbeat.req in 3 minutes, no `callback not set` errors, no WS close.

- [ ] Roll the resulting image into the dev cluster and confirm shiv3-cp7's loop stops, AND that killing the pod mid-transaction lets the new pod pick up the Charging state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)