### PR TITLE
fix(packaging,persistence): move CLI-needed repos under src/cp

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "src/cli",
     "src/cp",
     "src/utils/scenarioTemplates.ts",
+    "src/utils/scenarios",
     "dist"
   ],
   "scripts": {

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -18,12 +18,12 @@ import type {
   StartNodeData,
 } from "../cp/application/scenario/ScenarioTypes";
 import { ScenarioNodeType } from "../cp/application/scenario/ScenarioTypes";
-import { SqliteScenarioRepository } from "../data/sqlite/SqliteScenarioRepository";
-import { SqliteConnectorRuntimeRepository } from "../data/sqlite/SqliteConnectorRuntimeRepository";
+import { SqliteScenarioRepository } from "../cp/domain/persistence/SqliteScenarioRepository";
+import { SqliteConnectorRuntimeRepository } from "../cp/domain/persistence/SqliteConnectorRuntimeRepository";
 import {
   NoopConnectorRuntimeRepository,
   type ConnectorRuntimeRepository,
-} from "../data/interfaces/ConnectorRuntimeRepository";
+} from "../cp/domain/persistence/ConnectorRuntimeRepository";
 import type { EVSettings } from "../cp/domain/connector/EVSettings";
 import type { AutoMeterValueConfig } from "../cp/domain/connector/MeterValueCurve";
 import type { ActiveChargingProfile } from "../cp/domain/connector/Connector";

--- a/src/cp/domain/persistence/ConnectorRuntimeRepository.ts
+++ b/src/cp/domain/persistence/ConnectorRuntimeRepository.ts
@@ -1,8 +1,5 @@
-import type { Transaction } from "../../cp/domain/connector/Transaction";
-import type {
-  OCPPAvailability,
-  OCPPStatus,
-} from "../../cp/domain/types/OcppTypes";
+import type { Transaction } from "../connector/Transaction";
+import type { OCPPAvailability, OCPPStatus } from "../types/OcppTypes";
 
 /**
  * The slice of {@link Connector} runtime state we persist between daemon

--- a/src/cp/domain/persistence/ScenarioRepository.ts
+++ b/src/cp/domain/persistence/ScenarioRepository.ts
@@ -1,8 +1,15 @@
-import type { ScenarioDefinition } from "../../cp/application/scenario/ScenarioTypes";
+import type { ScenarioDefinition } from "../../application/scenario/ScenarioTypes";
 
 export interface ScenarioRepository {
-  load(chargePointId: string, connectorId: number | null): Promise<ScenarioDefinition | null>;
-  save(chargePointId: string, connectorId: number | null, scenario: ScenarioDefinition): Promise<void>;
+  load(
+    chargePointId: string,
+    connectorId: number | null,
+  ): Promise<ScenarioDefinition | null>;
+  save(
+    chargePointId: string,
+    connectorId: number | null,
+    scenario: ScenarioDefinition,
+  ): Promise<void>;
   delete(chargePointId: string, connectorId: number | null): Promise<void>;
   list(chargePointId: string): Promise<ScenarioDefinition[]>;
   subscribe(

--- a/src/cp/domain/persistence/SqliteConnectorRuntimeRepository.ts
+++ b/src/cp/domain/persistence/SqliteConnectorRuntimeRepository.ts
@@ -1,13 +1,10 @@
-import type { Transaction } from "../../cp/domain/connector/Transaction";
-import type { Database } from "../../cp/domain/persistence/Database";
-import type {
-  OCPPAvailability,
-  OCPPStatus,
-} from "../../cp/domain/types/OcppTypes";
+import type { Transaction } from "../connector/Transaction";
+import type { Database } from "./Database";
+import type { OCPPAvailability, OCPPStatus } from "../types/OcppTypes";
 import type {
   ConnectorRuntimeRepository,
   ConnectorRuntimeSnapshot,
-} from "../interfaces/ConnectorRuntimeRepository";
+} from "./ConnectorRuntimeRepository";
 
 interface ConnectorRuntimeRow {
   status: string;

--- a/src/cp/domain/persistence/SqliteScenarioRepository.ts
+++ b/src/cp/domain/persistence/SqliteScenarioRepository.ts
@@ -1,6 +1,6 @@
-import type { ScenarioDefinition } from "../../cp/application/scenario/ScenarioTypes";
-import type { Database } from "../../cp/domain/persistence/Database";
-import type { ScenarioRepository } from "../interfaces/ScenarioRepository";
+import type { ScenarioDefinition } from "../../application/scenario/ScenarioTypes";
+import type { Database } from "./Database";
+import type { ScenarioRepository } from "./ScenarioRepository";
 
 /**
  * SQLite-backed scenario repository. Persists definitions verbatim as a

--- a/src/cp/domain/persistence/__tests__/BunSqliteDatabase.bun.test.ts
+++ b/src/cp/domain/persistence/__tests__/BunSqliteDatabase.bun.test.ts
@@ -8,8 +8,8 @@ import {
   SchemaVersionMismatchError,
   runMigrations,
 } from "../schema";
-import { SqliteConnectorRuntimeRepository } from "../../../../data/sqlite/SqliteConnectorRuntimeRepository";
-import type { ConnectorRuntimeSnapshot } from "../../../../data/interfaces/ConnectorRuntimeRepository";
+import { SqliteConnectorRuntimeRepository } from "../SqliteConnectorRuntimeRepository";
+import type { ConnectorRuntimeSnapshot } from "../ConnectorRuntimeRepository";
 import { OCPPStatus } from "../../types/OcppTypes";
 
 describe("BunSqliteDatabase", () => {

--- a/src/data/local/LocalChargePointService.ts
+++ b/src/data/local/LocalChargePointService.ts
@@ -2,7 +2,7 @@ import { ChargePoint } from "../../cp/domain/charge-point/ChargePoint";
 import type { AutoMeterValueSetting } from "../../cp/domain/charge-point/ChargePoint";
 import type { Database } from "../../cp/domain/persistence/Database";
 import { resetSimulatorState } from "../../cp/domain/persistence/resetState";
-import { SqliteScenarioRepository } from "../sqlite/SqliteScenarioRepository";
+import { SqliteScenarioRepository } from "../../cp/domain/persistence/SqliteScenarioRepository";
 import { BootNotification, OCPPStatus } from "../../cp/domain/types/OcppTypes";
 import type {
   ChargePointEvent,

--- a/src/data/providers/DataProvider.tsx
+++ b/src/data/providers/DataProvider.tsx
@@ -12,7 +12,7 @@ import { createStore } from "jotai/vanilla";
 import type { RuntimeMode } from "../RuntimeMode";
 import { HEALTH_PATH } from "../healthPath";
 import type { ConfigRepository } from "../interfaces/ConfigRepository";
-import type { ScenarioRepository } from "../interfaces/ScenarioRepository";
+import type { ScenarioRepository } from "../../cp/domain/persistence/ScenarioRepository";
 import type { ConnectorSettingsRepository } from "../interfaces/ConnectorSettingsRepository";
 import type { ChargePointService } from "../interfaces/ChargePointService";
 import { LocalChargePointService } from "../local/LocalChargePointService";
@@ -21,7 +21,7 @@ import type { Database } from "../../cp/domain/persistence/Database";
 // SqlJsDatabase intentionally NOT imported eagerly — see the mode-gated
 // dynamic import below. Remote mode never needs it, so we keep the
 // ~650 KB WASM wrapper out of that path entirely.
-import { SqliteScenarioRepository } from "../sqlite/SqliteScenarioRepository";
+import { SqliteScenarioRepository } from "../../cp/domain/persistence/SqliteScenarioRepository";
 import { SqliteConfigRepository } from "../sqlite/SqliteConfigRepository";
 import { SqliteConnectorSettingsRepository } from "../sqlite/SqliteConnectorSettingsRepository";
 import {


### PR DESCRIPTION
## Summary

cli-v0.3.0's release tarball is unrunnable — \`bun install -g\` succeeds, but \`ocpp-cp-sim --help\` fails immediately with:

\`\`\`
error: Cannot find module '../data/sqlite/SqliteScenarioRepository'
    from '.../src/cli/service.ts'
\`\`\`

\`src/cli/service.ts\` grew imports for \`SqliteScenarioRepository\` (#51, daemon-scenario-persistence), \`SqliteConnectorRuntimeRepository\` / \`NoopConnectorRuntimeRepository\` (#57, connector-runtime persistence), and \`scenarioTemplates.ts\` now pulls \`src/utils/scenarios/*.json\` (#54 JSON extraction). The \`files\` list in \`package.json\` never grew to match; Docker copies every \`src/*\` path (PR #52/#55), so the gap only bit users installing from the published tarball.

The cheap fix is to pin specific paths inside \`src/data/\`. But that tree is otherwise React / sql.js / IndexedDB browser code, and pinning would just guarantee a repeat the next time the CLI grew a dependency. Instead, move the four files the daemon actually needs out from \`src/data/\` and into \`src/cp/domain/persistence/\`, where the abstract \`Database\` and \`BunSqliteDatabase\` already live:

| from | to |
|---|---|
| \`src/data/interfaces/ScenarioRepository.ts\` | \`src/cp/domain/persistence/ScenarioRepository.ts\` |
| \`src/data/interfaces/ConnectorRuntimeRepository.ts\` | \`src/cp/domain/persistence/ConnectorRuntimeRepository.ts\` |
| \`src/data/sqlite/SqliteScenarioRepository.ts\` | \`src/cp/domain/persistence/SqliteScenarioRepository.ts\` |
| \`src/data/sqlite/SqliteConnectorRuntimeRepository.ts\` | \`src/cp/domain/persistence/SqliteConnectorRuntimeRepository.ts\` |

Their imports only ever named the abstract \`Database\`, \`OcppTypes\`, and the \`Transaction\` domain object — all already in \`src/cp/\`. Browser consumers (\`DataProvider\`, \`LocalChargePointService\`) and the \`BunSqliteDatabase\` test were the only callers that needed import-path updates.

With the move in place, \`package.json\` \`files\` drops the per-file pinning back to:

\`\`\`json
\"files\": [
  \"src/cli\",
  \"src/cp\",
  \"src/utils/scenarioTemplates.ts\",
  \"src/utils/scenarios\",
  \"dist\"
]
\`\`\`

A future CLI import from \`src/data\` can no longer accidentally re-introduce the v0.3.0-style install break.

## Codex review

\`codex review --base main\` on the original packaging-only diff returned no correctness findings. The architectural placement of the moved files surfaced as a question from @shiv3 during review, which prompted the refactor in this revision.

## Test plan

- [x] \`vite build\` succeeds (browser bundle picks up the new paths).
- [x] \`bun test src/cp/domain/persistence/__tests__/BunSqliteDatabase.bun.test.ts\` passes (8/8).
- [x] \`npm pack --dry-run\` lists zero \`src/data/**\` files; the four moved files appear under \`src/cp/domain/persistence/\`.
- [x] Daemon smoke: \`POST /v1/cp\` seeds Essential CP Behavior on both connectors (\`essential-cp-behavior-E1-c{1,2}-…\`).
- [ ] After merge + \`cli-v0.3.1\` tag: \`bun install -g https://.../ocpp-cp-simulator-0.3.1.tgz\` succeeds and \`ocpp-cp-sim --help\` runs without a module resolution error.