### PR TITLE
feat(ui): per-connector Start/Stop with global TagID profiles + full WS URL auth parsing

### DIFF
--- a/src/components/ChargePoint.tsx
+++ b/src/components/ChargePoint.tsx
@@ -12,6 +12,12 @@ import { useDataContext } from "../data/providers/DataProvider";
 interface ChargePointProps {
   cpId: string;
   TagID: string;
+  /**
+   * All RFID tag IDs configured for this CP (from ChargePointConfig.tagIds).
+   * Drives the per-connector TagID picker on the connector list. Falls back
+   * to [TagID] when omitted to keep older callers working.
+   */
+  tagIDs?: string[];
 }
 
 // Panel width constants (in vw)
@@ -20,7 +26,9 @@ const PANEL_DEFAULT_WIDTH = 50; // 50vw default — keeps the home tab list
 // wider when they want more room for the scenario canvas.
 const PANEL_COLLAPSED_WIDTH_PX = 60; // px for collapsed
 
-const ChargePoint: React.FC<ChargePointProps> = ({ cpId, TagID }) => {
+const ChargePoint: React.FC<ChargePointProps> = ({ cpId, TagID, tagIDs }) => {
+  const availableTagIds =
+    tagIDs && tagIDs.length > 0 ? tagIDs : TagID ? [TagID] : [];
   const {
     status: cpStatus,
     error: cpError,
@@ -168,6 +176,7 @@ const ChargePoint: React.FC<ChargePointProps> = ({ cpId, TagID }) => {
             connectorIds={connectorIds}
             cpId={cpId}
             TagID={TagID}
+            tagIDs={availableTagIds}
             selectedConnector={selectedConnector}
             onConnectorSelect={handleConnectorSelect}
           />
@@ -199,6 +208,7 @@ const ChargePoint: React.FC<ChargePointProps> = ({ cpId, TagID }) => {
             cpId={cpId}
             connectorId={selectedConnector}
             idTag={TagID}
+            tagIds={availableTagIds}
             onClose={handleClosePanel}
             isCollapsed={isPanelCollapsed}
             onToggleCollapse={handleToggleCollapse}
@@ -225,6 +235,7 @@ interface ConnectorGridProps {
   connectorIds: number[];
   cpId: string;
   TagID: string;
+  tagIDs: string[];
   selectedConnector: number | null;
   onConnectorSelect: (connectorId: number) => void;
 }
@@ -240,6 +251,7 @@ const ConnectorGrid: React.FC<ConnectorGridProps> = ({
   connectorIds,
   cpId,
   TagID,
+  tagIDs,
   selectedConnector,
   onConnectorSelect,
 }) => {
@@ -267,6 +279,7 @@ const ConnectorGrid: React.FC<ConnectorGridProps> = ({
           id={connectorId}
           cpId={cpId}
           idTag={TagID}
+          tagIds={tagIDs}
           isSelected={selectedConnector === connectorId}
           onSelect={() => onConnectorSelect(connectorId)}
         />

--- a/src/components/ChargePointConfigModal.tsx
+++ b/src/components/ChargePointConfigModal.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
 import { Save, X } from "lucide-react";
+import { buildFullOcppUrl, parseFullOcppUrl } from "../utils/ocppUrl";
 import {
   Dialog,
   DialogContent,
@@ -39,7 +40,6 @@ export interface ChargePointConfig {
   meterType: string;
   iccid: string;
   imsi: string;
-  tagIds: string[];
 }
 
 interface ChargePointConfigModalProps {
@@ -75,7 +75,6 @@ export const defaultChargePointConfig: ChargePointConfig = {
   meterType: "",
   iccid: "",
   imsi: "",
-  tagIds: ["123456"],
 };
 
 const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
@@ -106,6 +105,51 @@ const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
   ) => {
     setConfig({ ...config, [key]: value });
   };
+
+  // Full WebSocket URL field — built from wsURL + basic auth on display,
+  // and parsed back into those fields on paste/Enter/blur. `fullUrlDraft`
+  // lets the user type without each keystroke fighting the composed value.
+  const composedFullUrl = useMemo(
+    () =>
+      buildFullOcppUrl(config.wsURL, {
+        enabled: config.basicAuthEnabled,
+        username: config.basicAuthUsername,
+        password: config.basicAuthPassword,
+      }),
+    [
+      config.wsURL,
+      config.basicAuthEnabled,
+      config.basicAuthUsername,
+      config.basicAuthPassword,
+    ],
+  );
+  const [fullUrlDraft, setFullUrlDraft] = useState<string | null>(null);
+  const [fullUrlError, setFullUrlError] = useState<string | null>(null);
+  const displayFullUrl = fullUrlDraft ?? composedFullUrl;
+
+  const applyFullUrl = useCallback((raw: string): boolean => {
+    const parsed = parseFullOcppUrl(raw);
+    if (!parsed) {
+      setFullUrlError(
+        "Invalid WebSocket URL. Use a full ws:// or wss:// URL (optionally with user:password@host for basic auth).",
+      );
+      return false;
+    }
+    setConfig((prev) => ({
+      ...prev,
+      wsURL: parsed.wsURL,
+      basicAuthEnabled: parsed.basicAuthEnabled || prev.basicAuthEnabled,
+      basicAuthUsername: parsed.basicAuthEnabled
+        ? parsed.basicAuthUsername
+        : prev.basicAuthUsername,
+      basicAuthPassword: parsed.basicAuthEnabled
+        ? parsed.basicAuthPassword
+        : prev.basicAuthPassword,
+    }));
+    setFullUrlDraft(null);
+    setFullUrlError(null);
+    return true;
+  }, []);
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -161,6 +205,49 @@ const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
                 />
               </div>
               <div className="col-span-2">
+                <Label htmlFor="fullWsURL" className="mb-2 logger-label">
+                  Full WebSocket URL
+                </Label>
+                <Input
+                  id="fullWsURL"
+                  type="url"
+                  value={displayFullUrl}
+                  onChange={(e) => {
+                    setFullUrlDraft(e.target.value);
+                    setFullUrlError(null);
+                  }}
+                  onBlur={() => {
+                    if (fullUrlDraft !== null) applyFullUrl(fullUrlDraft);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      if (fullUrlDraft !== null) applyFullUrl(fullUrlDraft);
+                    }
+                  }}
+                  onPaste={(e) => {
+                    const text = e.clipboardData.getData("text").trim();
+                    if (!text) return;
+                    e.preventDefault();
+                    setFullUrlDraft(text);
+                    applyFullUrl(text);
+                  }}
+                  placeholder="wss://user:password@host:8080/path/"
+                  className="logger-input font-mono text-sm"
+                  spellCheck={false}
+                />
+                <p className="text-xs text-muted mt-1">
+                  Composed from WebSocket URL + Basic Auth below. Paste a full
+                  URL to autofill those fields (basic auth from
+                  user:password@host).
+                </p>
+                {fullUrlError && (
+                  <p className="text-xs text-red-600 dark:text-red-400 mt-1">
+                    {fullUrlError}
+                  </p>
+                )}
+              </div>
+              <div className="col-span-2">
                 <Label htmlFor="wsURL" className="mb-2 logger-label">
                   WebSocket URL
                 </Label>
@@ -188,29 +275,6 @@ const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
                     <SelectItem value="OCPP-1.6J">OCPP 1.6J</SelectItem>
                   </SelectContent>
                 </Select>
-              </div>
-              <div className="col-span-2">
-                <Label htmlFor="tagIds" className="mb-2 logger-label">
-                  RFID Tag IDs (comma-separated)
-                </Label>
-                <Input
-                  id="tagIds"
-                  type="text"
-                  value={config.tagIds.join(", ")}
-                  onChange={(e) => {
-                    const tags = e.target.value
-                      .split(",")
-                      .map((s) => s.trim())
-                      .filter((s) => s.length > 0);
-                    updateConfig("tagIds", tags.length > 0 ? tags : ["123456"]);
-                  }}
-                  placeholder="e.g., 123456, ABCDEF, TAG001"
-                  className="logger-input"
-                />
-                <p className="text-xs text-muted mt-1">
-                  Enter one or more RFID tag IDs separated by commas. These tags
-                  can be used for starting transactions.
-                </p>
               </div>
             </div>
           </div>

--- a/src/components/Connector.tsx
+++ b/src/components/Connector.tsx
@@ -18,6 +18,8 @@ interface ConnectorProps {
   id: number;
   cpId: string;
   idTag: string;
+  /** All tag IDs configured on this CP. Drives the per-card TagID picker. */
+  tagIds?: string[];
   isSelected?: boolean;
   onSelect?: () => void;
 }
@@ -68,6 +70,8 @@ ConnectorAvailability.displayName = "ConnectorAvailability";
 const Connector: React.FC<ConnectorProps> = ({
   id: connector_id,
   cpId,
+  idTag,
+  tagIds,
   isSelected = false,
   onSelect,
 }) => {
@@ -95,6 +99,44 @@ const Connector: React.FC<ConnectorProps> = ({
   // template in scenarioTemplates — operators reach for it from the
   // template picker when they want it, and a fresh connector starts with
   // a genuinely empty canvas.
+
+  // Per-card TagID picker. Defaults to the CP-level idTag (which is the
+  // first configured tag from ChargePointConfig.tagIds). When the parent
+  // supplies a tagIds[] array, the card renders a select so the operator
+  // can switch between configured profiles before pressing Start.
+  const availableTagIds =
+    tagIds && tagIds.length > 0 ? tagIds : idTag ? [idTag] : [];
+  const [selectedTagId, setSelectedTagId] = useState<string>(
+    availableTagIds[0] ?? idTag ?? "",
+  );
+  // Keep the selection valid when the parent's tag list changes (CP config
+  // edited). Prefer to keep the user's pick if it's still in the new list.
+  useEffect(() => {
+    if (availableTagIds.length === 0) return;
+    if (!availableTagIds.includes(selectedTagId)) {
+      setSelectedTagId(availableTagIds[0]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [availableTagIds.join("|")]);
+
+  // One toggle button drives both directions. Reading `isCharging` from
+  // the live status keeps the label/style in sync if the transaction is
+  // started/stopped elsewhere (side panel, scenario, remote start).
+  const handleTransactionToggle = useCallback(
+    (e: React.MouseEvent, isChargingNow: boolean) => {
+      e.stopPropagation();
+      if (isChargingNow) {
+        void chargePointService.stopTransaction(cpId, connector_id);
+      } else if (selectedTagId) {
+        void chargePointService.startTransaction(
+          cpId,
+          connector_id,
+          selectedTagId,
+        );
+      }
+    },
+    [chargePointService, cpId, connector_id, selectedTagId],
+  );
 
   const [scenario, setScenario] = useState<ScenarioDefinition | null>(null);
   const [, setScenarioExecutionContext] =
@@ -449,6 +491,59 @@ const Connector: React.FC<ConnectorProps> = ({
               </div>
             </div>
           </div>
+        </div>
+
+        {/* Transaction controls — TagID is always a select sourced from the
+            CP profile's `tagIds`, and one toggle button covers Start/Stop
+            (label flips based on isCharging). stopPropagation keeps card
+            clicks from also fighting the controls. */}
+        <div className="border-t border-gray-200 dark:border-gray-700 pt-3 space-y-2">
+          <div className="flex items-center gap-2">
+            <label
+              htmlFor={`connector-tag-${cpId}-${connector_id}`}
+              className="text-xs text-muted whitespace-nowrap"
+            >
+              TagID
+            </label>
+            <select
+              id={`connector-tag-${cpId}-${connector_id}`}
+              value={
+                availableTagIds.includes(selectedTagId)
+                  ? selectedTagId
+                  : (availableTagIds[0] ?? "")
+              }
+              onClick={(e) => e.stopPropagation()}
+              onChange={(e) => {
+                e.stopPropagation();
+                setSelectedTagId(e.target.value);
+              }}
+              disabled={isCharging || availableTagIds.length === 0}
+              className="flex-1 min-w-0 text-xs border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 font-mono disabled:opacity-60"
+              title="Switch RFID tag profile before starting a transaction"
+            >
+              {availableTagIds.length === 0 ? (
+                <option value="">No TagIDs configured</option>
+              ) : (
+                availableTagIds.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))
+              )}
+            </select>
+          </div>
+          <button
+            type="button"
+            onClick={(e) => handleTransactionToggle(e, isCharging)}
+            disabled={!isCharging && !selectedTagId}
+            className={`w-full text-sm py-1.5 px-3 font-medium text-white rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${
+              isCharging
+                ? "bg-yellow-500 hover:bg-yellow-600"
+                : "bg-green-500 hover:bg-green-600"
+            }`}
+          >
+            {isCharging ? "Stop" : "Start"}
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/ConnectorSidePanel.tsx
+++ b/src/components/ConnectorSidePanel.tsx
@@ -136,6 +136,9 @@ interface ConnectorSidePanelProps {
   cpId: string;
   connectorId: number;
   idTag: string;
+  /** RFID tag IDs configured for this CP. Drives the Transaction TagID
+   *  picker; falls back to a single-item list of `idTag` when empty. */
+  tagIds?: string[];
   onClose: () => void;
   isCollapsed: boolean;
   onToggleCollapse: () => void;
@@ -214,6 +217,7 @@ const FullPanelContent: React.FC<{
   cpId: string;
   connectorId: number;
   idTag: string;
+  tagIds?: string[];
   onCollapse: () => void;
   onClose: () => void;
   onResizeStart: (e: React.MouseEvent) => void;
@@ -226,6 +230,7 @@ const FullPanelContent: React.FC<{
   cpId,
   connectorId,
   idTag,
+  tagIds,
   onCollapse,
   onClose,
   onResizeStart,
@@ -277,7 +282,21 @@ const FullPanelContent: React.FC<{
   const connector = localCp ? localCp.getConnector(connectorId) : null;
   const [meterValueInput, setMeterValueInput] =
     useState<number>(liveMeterValue);
-  const [tagIdInput, setTagIdInput] = useState<string>(idTag);
+  // Transaction TagID is always picked from the CP profile's configured
+  // tagIds. Falls back to the single `idTag` when the parent didn't pass a
+  // list (older callers / standalone usage).
+  const availableTagIds =
+    tagIds && tagIds.length > 0 ? tagIds : idTag ? [idTag] : [];
+  const [tagIdInput, setTagIdInput] = useState<string>(
+    availableTagIds[0] ?? idTag ?? "",
+  );
+  useEffect(() => {
+    if (availableTagIds.length === 0) return;
+    if (!availableTagIds.includes(tagIdInput)) {
+      setTagIdInput(availableTagIds[0]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [availableTagIds.join("|")]);
   const [duration, setDuration] = useState<string>("00:00:00");
   const [transactionStartTime, setTransactionStartTime] = useState<string>("");
   const [isCurveModalOpen, setIsCurveModalOpen] = useState(false);
@@ -670,14 +689,19 @@ const FullPanelContent: React.FC<{
     };
   }, [mode, cpId, connectorId, chargePointService]);
 
-  // Handlers
-  const handleStartTransaction = useCallback(() => {
-    void chargePointService.startTransaction(cpId, connectorId, tagIdInput);
-  }, [chargePointService, cpId, connectorId, tagIdInput]);
-
-  const handleStopTransaction = useCallback(() => {
-    void chargePointService.stopTransaction(cpId, connectorId);
-  }, [chargePointService, cpId, connectorId]);
+  // Handlers — single toggle drives both directions to match the connector
+  // card. We read the live `isCharging` at click time (passed in) so the
+  // label and action stay consistent if state changed elsewhere.
+  const handleTransactionToggle = useCallback(
+    (isChargingNow: boolean) => {
+      if (isChargingNow) {
+        void chargePointService.stopTransaction(cpId, connectorId);
+      } else if (tagIdInput) {
+        void chargePointService.startTransaction(cpId, connectorId, tagIdInput);
+      }
+    },
+    [chargePointService, cpId, connectorId, tagIdInput],
+  );
 
   const handleIncreaseMeterValue = useCallback(() => {
     const nextValue = meterValueInput + 10;
@@ -937,35 +961,46 @@ const FullPanelContent: React.FC<{
                 </div>
               )}
 
-              {/* Transaction — full-width section so the Tag input and
-                  Start/Stop buttons have room to breathe. */}
+              {/* Transaction — TagID is always a select sourced from the CP
+                  profile's `tagIds`, and one toggle button covers Start/Stop
+                  (label/style flips with isCharging). Matches the connector
+                  card so operators get the same controls in both surfaces. */}
               <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3 space-y-2">
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
                   Transaction
                 </h4>
-                <input
-                  type="text"
-                  value={tagIdInput}
+                <select
+                  value={
+                    availableTagIds.includes(tagIdInput)
+                      ? tagIdInput
+                      : (availableTagIds[0] ?? "")
+                  }
                   onChange={(e) => setTagIdInput(e.target.value)}
-                  className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
-                  placeholder="ID Tag"
-                />
-                <div className="grid grid-cols-2 gap-2">
-                  <button
-                    onClick={handleStartTransaction}
-                    disabled={isCharging}
-                    className="text-sm py-2 px-3 font-medium bg-green-500 hover:bg-green-600 text-white rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                  >
-                    Start
-                  </button>
-                  <button
-                    onClick={handleStopTransaction}
-                    disabled={!isCharging}
-                    className="text-sm py-2 px-3 font-medium bg-yellow-500 hover:bg-yellow-600 text-white rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                  >
-                    Stop
-                  </button>
-                </div>
+                  disabled={isCharging || availableTagIds.length === 0}
+                  className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 disabled:opacity-60"
+                  title="Switch RFID tag profile before starting a transaction"
+                >
+                  {availableTagIds.length === 0 ? (
+                    <option value="">No TagIDs configured</option>
+                  ) : (
+                    availableTagIds.map((t) => (
+                      <option key={t} value={t}>
+                        {t}
+                      </option>
+                    ))
+                  )}
+                </select>
+                <button
+                  onClick={() => handleTransactionToggle(isCharging)}
+                  disabled={!isCharging && !tagIdInput}
+                  className={`w-full text-sm py-2 px-3 font-medium text-white rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${
+                    isCharging
+                      ? "bg-yellow-500 hover:bg-yellow-600"
+                      : "bg-green-500 hover:bg-green-600"
+                  }`}
+                >
+                  {isCharging ? "Stop" : "Start"}
+                </button>
               </div>
 
               {/* Battery — unified card combining Live SoC (% — battery
@@ -1463,6 +1498,7 @@ export const ConnectorSidePanel: React.FC<ConnectorSidePanelProps> = ({
   cpId,
   connectorId,
   idTag,
+  tagIds,
   onClose,
   isCollapsed,
   onToggleCollapse,
@@ -1533,6 +1569,7 @@ export const ConnectorSidePanel: React.FC<ConnectorSidePanelProps> = ({
       cpId={cpId}
       connectorId={connectorId}
       idTag={idTag}
+      tagIds={tagIds}
       onCollapse={onToggleCollapse}
       onClose={onClose}
       onResizeStart={handleResizeStart}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useConfig } from "../data/hooks/useConfig";
+import { useGlobalTagIds } from "../data/hooks/useGlobalTagIds";
 import { useDataContext } from "../data/providers/DataProvider";
 import {
   type EVSettings,
@@ -28,6 +29,30 @@ const Settings: React.FC = () => {
   const [draftEv, setDraftEv] = useState<EVSettings>(
     defaultEvSettings ?? { ...defaultEVSettings },
   );
+  const { tagIds: globalTagIds, setTagIds: persistGlobalTagIds } =
+    useGlobalTagIds();
+  // Draft string for the comma-separated input so the user can type literal
+  // commas/spaces without each keystroke being eaten by split→filter→join.
+  const [tagIdsDraft, setTagIdsDraft] = useState<string>("");
+  const [tagIdsDirty, setTagIdsDirty] = useState<boolean>(false);
+  useEffect(() => {
+    if (!tagIdsDirty) {
+      setTagIdsDraft(globalTagIds.join(", "));
+    }
+  }, [globalTagIds, tagIdsDirty]);
+  const parseTagIdsDraft = (raw: string): string[] =>
+    raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  const handleApplyTagIds = async () => {
+    const tags = parseTagIdsDraft(tagIdsDraft);
+    await persistGlobalTagIds(tags);
+    setTagIdsDraft(tags.join(", "));
+    setTagIdsDirty(false);
+    setSuccess("RFID Tag IDs saved.");
+    setTimeout(() => setSuccess(""), 3000);
+  };
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -384,6 +409,60 @@ const Settings: React.FC = () => {
               ? "User override is active. New connectors will start from these values."
               : "No override. New connectors start from the built-in Generic EV defaults (75 kWh / 80 % target)."}
           </p>
+        </CardContent>
+      </Card>
+
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>RFID Tag IDs</CardTitle>
+          <p className="text-muted-foreground text-sm mt-2">
+            Tag profiles shared across every charge point. Pick one from the
+            connector card's TagID dropdown before Start Transaction. Stored
+            globally — not per-CP.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <label
+            htmlFor="global-tag-ids"
+            className="block text-sm font-semibold"
+          >
+            Tag IDs (comma-separated)
+          </label>
+          <input
+            id="global-tag-ids"
+            type="text"
+            value={tagIdsDraft}
+            onChange={(e) => {
+              setTagIdsDraft(e.target.value);
+              setTagIdsDirty(true);
+            }}
+            onBlur={() => {
+              const tags = parseTagIdsDraft(tagIdsDraft);
+              setTagIdsDraft(tags.join(", "));
+            }}
+            placeholder="e.g., 123456, ABCDEF, TAG001"
+            className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 font-mono"
+          />
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={() => void handleApplyTagIds()}
+              size="sm"
+              disabled={
+                !tagIdsDirty &&
+                parseTagIdsDraft(tagIdsDraft).join("|") ===
+                  globalTagIds.join("|")
+              }
+            >
+              Apply
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              {globalTagIds.length === 0
+                ? "No tags configured yet."
+                : `${globalTagIds.length} tag${
+                    globalTagIds.length === 1 ? "" : "s"
+                  } active.`}
+            </span>
+          </div>
         </CardContent>
       </Card>
 

--- a/src/components/TopPage.tsx
+++ b/src/components/TopPage.tsx
@@ -17,42 +17,21 @@ import {
 import { useConfig } from "../data/hooks/useConfig";
 import { useChargePoints } from "../data/hooks/useChargePoints";
 import { useDataContext } from "../data/providers/DataProvider";
+import { useGlobalTagIds } from "../data/hooks/useGlobalTagIds";
 import type { ChargePointSnapshot } from "../data/interfaces/ChargePointService";
 import { getTemplateById } from "../utils/scenarioTemplates";
 import type { Config } from "../store/store";
 
-const REMOTE_TAG_IDS_KEY = "ocpp-cp.remote.tagIds";
 const DEFAULT_TAG_ID = "TAG001";
-
-function readRemoteTagIds(): string[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = window.localStorage.getItem(REMOTE_TAG_IDS_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed)
-      ? parsed.filter((v) => typeof v === "string")
-      : [];
-  } catch {
-    return [];
-  }
-}
-
-function writeRemoteTagIds(ids: string[]): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(REMOTE_TAG_IDS_KEY, JSON.stringify(ids));
-  } catch {
-    // best effort
-  }
-}
 
 const TopPage: React.FC = () => {
   const { mode, chargePointService, scenarioRepository } = useDataContext();
   const { config, setConfig: persistConfig, isLoading } = useConfig();
-  const [tagIDs, setTagIDs] = useState<string[]>(() =>
-    typeof window === "undefined" ? [] : readRemoteTagIds(),
-  );
+  // Tag IDs live globally now — managed from the Settings page, not per-CP.
+  // useGlobalTagIds picks the right backing store (config.Experimental in
+  // local mode, a jotai atom in remote mode) and re-renders this tree when
+  // Settings writes a new list.
+  const { tagIds: tagIDs } = useGlobalTagIds();
   const [chargePointConfigs, setChargePointConfigs] = useState<
     ChargePointConfig[]
   >([]);
@@ -120,7 +99,6 @@ const TopPage: React.FC = () => {
           meterType: bn?.meterType ?? "",
           iccid: bn?.iccid ?? "",
           imsi: bn?.imsi ?? "",
-          tagIds: tagIDs.length > 0 ? tagIDs : ["123456"],
         };
       });
       setChargePointConfigs(remoteConfigs);
@@ -128,12 +106,9 @@ const TopPage: React.FC = () => {
     }
 
     if (isLoading || !config || !config.Experimental) {
-      setTagIDs([]);
       setChargePointConfigs([]);
       return;
     }
-
-    setTagIDs(config.Experimental.TagIDs ?? []);
 
     const configs: ChargePointConfig[] = config.Experimental.ChargePointIDs.map(
       (cp) => ({
@@ -159,7 +134,6 @@ const TopPage: React.FC = () => {
         meterType: config.BootNotification?.meterType || "",
         iccid: config.BootNotification?.iccid || "",
         imsi: config.BootNotification?.imsi || "",
-        tagIds: config.Experimental.TagIDs ?? ["123456"],
       }),
     );
     setChargePointConfigs(configs);
@@ -178,12 +152,6 @@ const TopPage: React.FC = () => {
 
   const handleSaveChargePoint = async (cpConfig: ChargePointConfig) => {
     if (mode === "remote") {
-      // Remote mode: persist tag IDs locally so future sessions / Authorize
-      // / Start Transaction have a default to send.
-      if (cpConfig.tagIds.length > 0) {
-        setTagIDs(cpConfig.tagIds);
-        writeRemoteTagIds(cpConfig.tagIds);
-      }
       try {
         // Re-use the same shape for create and update; the only difference
         // is which daemon endpoint we hit. Editing an existing CP goes to
@@ -280,14 +248,13 @@ const TopPage: React.FC = () => {
       updatedConfigs.push(cpConfig);
     }
     setChargePointConfigs(updatedConfigs);
-    setTagIDs(cpConfig.tagIds);
 
     const newConfig: Config = {
       ...(config || {}),
       wsURL: cpConfig.wsURL,
       connectorNumber: cpConfig.connectorNumber,
       ChargePointID: cpConfig.cpId,
-      tagID: cpConfig.tagIds[0] || "123456",
+      tagID: tagIDs[0] || "123456",
       ocppVersion: cpConfig.ocppVersion,
       basicAuthSettings: {
         enabled: cpConfig.basicAuthEnabled,
@@ -315,7 +282,7 @@ const TopPage: React.FC = () => {
           ChargePointID: cfg.cpId,
           ConnectorNumber: cfg.connectorNumber,
         })),
-        TagIDs: cpConfig.tagIds,
+        TagIDs: tagIDs,
       },
     };
     updateConfig(newConfig);
@@ -585,7 +552,11 @@ const ExperimentalView: React.FC<ExperimentalProps> = ({
         </TabsList>
         {cps.map((cp) => (
           <TabsContent key={cp.id} value={cp.id}>
-            <ChargePoint cpId={cp.id} TagID={tagIDs[0] ?? "TAG001"} />
+            <ChargePoint
+              cpId={cp.id}
+              TagID={tagIDs[0] ?? "TAG001"}
+              tagIDs={tagIDs}
+            />
           </TabsContent>
         ))}
       </Tabs>

--- a/src/data/hooks/useGlobalTagIds.ts
+++ b/src/data/hooks/useGlobalTagIds.ts
@@ -1,0 +1,93 @@
+import { useCallback } from "react";
+import { atom, useAtom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+import { useDataContext } from "../providers/DataProvider";
+import { useConfig } from "./useConfig";
+
+/**
+ * Global RFID Tag IDs are managed at the simulator level, not per-CP — the
+ * same tag profiles are reused across every charge point. Local mode stores
+ * them in `config.Experimental.TagIDs` (so they ride along with the rest of
+ * the saved local config); remote mode keeps them in a small localStorage
+ * key that the daemon never sees (the daemon doesn't have an opinion on
+ * which tags the UI hands to startTransaction). The jotai atom makes the
+ * remote-mode list reactive across components in the same tab without
+ * needing a custom event bus.
+ */
+
+const REMOTE_TAG_IDS_KEY = "ocpp-cp.remote.tagIds";
+
+const remoteTagIdsBackedAtom = atomWithStorage<string[]>(
+  REMOTE_TAG_IDS_KEY,
+  [],
+  undefined,
+  { getOnInit: true },
+);
+
+/** Sanitizes whatever localStorage returns into a `string[]` — older builds
+ *  wrote non-array JSON and we don't want to crash the page on that. */
+const remoteTagIdsAtom = atom(
+  (get) => {
+    const v = get(remoteTagIdsBackedAtom);
+    return Array.isArray(v)
+      ? v.filter((s): s is string => typeof s === "string")
+      : [];
+  },
+  (_get, set, next: string[]) => set(remoteTagIdsBackedAtom, next),
+);
+
+export interface UseGlobalTagIdsResult {
+  tagIds: string[];
+  setTagIds: (next: string[]) => Promise<void>;
+}
+
+export function useGlobalTagIds(): UseGlobalTagIdsResult {
+  const { mode } = useDataContext();
+  const { config, setConfig } = useConfig();
+  const [remoteTagIds, setRemoteTagIds] = useAtom(remoteTagIdsAtom);
+
+  const localTagIds = config?.Experimental?.TagIDs ?? [];
+
+  const setLocalTagIds = useCallback(
+    async (next: string[]): Promise<void> => {
+      const base = config;
+      const prevExperimental = base?.Experimental;
+      const nextExperimental = {
+        ChargePointIDs: prevExperimental?.ChargePointIDs ?? [],
+        TagIDs: next,
+      };
+      if (!base) {
+        // No saved config yet — synthesize a minimal one so the user can set
+        // tags before adding any CP. The empty wsURL/CP id is fine; they get
+        // populated when the user creates a CP.
+        await setConfig({
+          wsURL: "",
+          ChargePointID: "",
+          connectorNumber: 1,
+          tagID: next[0] ?? "",
+          ocppVersion: "OCPP-1.6J",
+          basicAuthSettings: { enabled: false, username: "", password: "" },
+          autoMeterValueSetting: { enabled: false, interval: 0, value: 0 },
+          Experimental: nextExperimental,
+          BootNotification: null,
+        });
+        return;
+      }
+      await setConfig({ ...base, Experimental: nextExperimental });
+    },
+    [config, setConfig],
+  );
+
+  const setRemote = useCallback(
+    async (next: string[]): Promise<void> => {
+      setRemoteTagIds(next);
+    },
+    [setRemoteTagIds],
+  );
+
+  if (mode === "remote") {
+    return { tagIds: remoteTagIds, setTagIds: setRemote };
+  }
+  return { tagIds: localTagIds, setTagIds: setLocalTagIds };
+}

--- a/src/utils/ocppUrl.test.ts
+++ b/src/utils/ocppUrl.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+
+import { buildFullOcppUrl, parseFullOcppUrl } from "./ocppUrl";
+
+describe("buildFullOcppUrl", () => {
+  it("returns the plain URL when basic auth is disabled", () => {
+    expect(
+      buildFullOcppUrl("wss://csms.example.com/ocpp/", {
+        enabled: false,
+        username: "ignored",
+        password: "ignored",
+      }),
+    ).toBe("wss://csms.example.com/ocpp/");
+  });
+
+  it("embeds userinfo when basic auth is enabled", () => {
+    expect(
+      buildFullOcppUrl("wss://csms.example.com/ocpp/", {
+        enabled: true,
+        username: "CP001",
+        password: "secret",
+      }),
+    ).toBe("wss://CP001:secret@csms.example.com/ocpp/");
+  });
+
+  it("strips existing userinfo when basic auth is disabled", () => {
+    expect(
+      buildFullOcppUrl("wss://stale:creds@csms.example.com/ocpp/", {
+        enabled: false,
+        username: "",
+        password: "",
+      }),
+    ).toBe("wss://csms.example.com/ocpp/");
+  });
+
+  it("percent-encodes special characters in username/password", () => {
+    const url = buildFullOcppUrl("wss://csms.example.com/ocpp/", {
+      enabled: true,
+      username: "user@domain",
+      password: "p@ss/word",
+    });
+    const parsed = new URL(url);
+    expect(decodeURIComponent(parsed.username)).toBe("user@domain");
+    expect(decodeURIComponent(parsed.password)).toBe("p@ss/word");
+  });
+
+  it("returns empty string when wsURL is blank", () => {
+    expect(
+      buildFullOcppUrl("   ", {
+        enabled: true,
+        username: "u",
+        password: "p",
+      }),
+    ).toBe("");
+  });
+
+  it("returns the raw text when the URL is malformed", () => {
+    expect(
+      buildFullOcppUrl("not-a-url", {
+        enabled: false,
+        username: "",
+        password: "",
+      }),
+    ).toBe("not-a-url");
+  });
+});
+
+describe("parseFullOcppUrl", () => {
+  it("extracts userinfo into basic auth fields", () => {
+    expect(
+      parseFullOcppUrl("wss://CP001:secret@csms.example.com/ocpp/"),
+    ).toEqual({
+      wsURL: "wss://csms.example.com/ocpp/",
+      basicAuthEnabled: true,
+      basicAuthUsername: "CP001",
+      basicAuthPassword: "secret",
+    });
+  });
+
+  it("decodes percent-encoded userinfo", () => {
+    expect(
+      parseFullOcppUrl(
+        "wss://user%40domain:p%40ss%2Fword@csms.example.com/ocpp/",
+      ),
+    ).toEqual({
+      wsURL: "wss://csms.example.com/ocpp/",
+      basicAuthEnabled: true,
+      basicAuthUsername: "user@domain",
+      basicAuthPassword: "p@ss/word",
+    });
+  });
+
+  it("returns disabled basic auth when no userinfo is present", () => {
+    expect(parseFullOcppUrl("wss://csms.example.com/ocpp/")).toEqual({
+      wsURL: "wss://csms.example.com/ocpp/",
+      basicAuthEnabled: false,
+      basicAuthUsername: "",
+      basicAuthPassword: "",
+    });
+  });
+
+  it("accepts ws:// in addition to wss://", () => {
+    const parsed = parseFullOcppUrl("ws://localhost:8080/ocpp");
+    expect(parsed?.wsURL).toBe("ws://localhost:8080/ocpp");
+  });
+
+  it("rejects non-WebSocket schemes", () => {
+    expect(parseFullOcppUrl("https://csms.example.com/")).toBeNull();
+    expect(parseFullOcppUrl("http://csms.example.com/")).toBeNull();
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(parseFullOcppUrl("not-a-url")).toBeNull();
+    expect(parseFullOcppUrl("")).toBeNull();
+    expect(parseFullOcppUrl("   ")).toBeNull();
+  });
+
+  it("round-trips with buildFullOcppUrl", () => {
+    const original = "wss://CP001:secret@csms.example.com/ocpp/";
+    const parsed = parseFullOcppUrl(original);
+    expect(parsed).not.toBeNull();
+    const rebuilt = buildFullOcppUrl(parsed!.wsURL, {
+      enabled: parsed!.basicAuthEnabled,
+      username: parsed!.basicAuthUsername,
+      password: parsed!.basicAuthPassword,
+    });
+    expect(rebuilt).toBe(original);
+  });
+});

--- a/src/utils/ocppUrl.ts
+++ b/src/utils/ocppUrl.ts
@@ -1,0 +1,78 @@
+/**
+ * Bidirectional helpers between the "Full WebSocket URL" Settings field and
+ * the per-CP form fields (wsURL + basic auth username/password).
+ *
+ * Pasting a `wss://user:pass@host/path` URL splits the basic auth out of the
+ * URL and back into the dedicated form fields. Rendering the field goes the
+ * other way: when basic auth is enabled, the username/password are embedded
+ * back into the URL's userinfo so the displayed URL is a complete, ready-to-
+ * paste connection string.
+ */
+
+export interface OcppUrlBasicAuth {
+  enabled: boolean;
+  username: string;
+  password: string;
+}
+
+export interface ParsedOcppUrl {
+  wsURL: string;
+  basicAuthEnabled: boolean;
+  basicAuthUsername: string;
+  basicAuthPassword: string;
+}
+
+const VALID_PROTOCOLS = new Set(["ws:", "wss:"]);
+
+/** Compose the displayed full URL from the form fields. */
+export function buildFullOcppUrl(
+  wsURL: string,
+  basicAuth: OcppUrlBasicAuth,
+): string {
+  const base = wsURL.trim();
+  if (!base) return "";
+
+  try {
+    const url = new URL(base);
+    if (basicAuth.enabled && (basicAuth.username || basicAuth.password)) {
+      url.username = encodeURIComponent(basicAuth.username);
+      url.password = encodeURIComponent(basicAuth.password);
+    } else {
+      url.username = "";
+      url.password = "";
+    }
+    return url.toString();
+  } catch {
+    // Not a parseable URL yet — show the raw text so the user can keep typing.
+    return base;
+  }
+}
+
+/**
+ * Split a pasted/typed full URL back into the form fields. Returns `null`
+ * when the input isn't a syntactically valid ws://wss:// URL.
+ */
+export function parseFullOcppUrl(fullUrl: string): ParsedOcppUrl | null {
+  const trimmed = fullUrl.trim();
+  if (!trimmed) return null;
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (!VALID_PROTOCOLS.has(url.protocol)) return null;
+
+  const username = url.username ? decodeURIComponent(url.username) : "";
+  const password = url.password ? decodeURIComponent(url.password) : "";
+  url.username = "";
+  url.password = "";
+
+  return {
+    wsURL: url.toString(),
+    basicAuthEnabled: !!(username || password),
+    basicAuthUsername: username,
+    basicAuthPassword: password,
+  };
+}


### PR DESCRIPTION
## Summary

Three related UX improvements to the connector page, addressing user requests around fast transaction control, profile management, and authenticated WebSocket URLs (revisits the idea from #41).

### 1. Start/Stop transaction directly from each connector

Each connector card and the side panel's *Transaction* section now use a single toggle button — label/style flip based on the live `isCharging` status, no separate Start/Stop pair. The TagID is always a `<select>` sourced from the global profile list, so operators can switch profiles before pressing Start without opening the side panel or the CP modal.

### 2. RFID Tag IDs moved from per-CP modal to global Settings

Tag profiles are reused across every charge point, so they're now a single global list managed under **Settings → RFID Tag IDs**:

- Local mode: backed by `config.Experimental.TagIDs` (same on-disk shape, no migration needed).
- Remote mode: backed by a jotai `atomWithStorage` on `ocpp-cp.remote.tagIds`, which makes the list reactive across components in the same tab without needing a custom event bus.

The new `useGlobalTagIds()` hook abstracts the mode split. The per-CP *RFID Tag IDs (comma-separated)* input is removed from `ChargePointConfigModal`, and `tagIds` is dropped from `ChargePointConfig`.

The Settings input uses a local draft string so users can type literal commas/spaces — the old per-CP input round-tripped every keystroke through `split().filter().join()`, which ate trailing commas mid-typing and made the field unusable.

### 3. Full WebSocket URL field on CP config (auth parsing)

`ChargePointConfigModal` gets a *Full WebSocket URL* field above the existing WebSocket URL. Pasting `wss://user:pass@host/path` splits the basic auth out into the dedicated fields; the field is re-composed from those fields on display so it stays in sync. New utility module with `buildFullOcppUrl` / `parseFullOcppUrl` and round-trip unit tests.

## Test plan

- [ ] Add two RFID Tag IDs in Settings; verify they appear in every connector card's TagID dropdown.
- [ ] Type a tag ID with a literal comma in the Settings input; verify the comma survives between keystrokes.
- [ ] Start a transaction from a connector card with TagID A; switch to TagID B and start on another connector; verify each transaction uses the picked tag.
- [ ] Single button toggles Start → Stop on the same connector.
- [ ] Paste `wss://user:pass@host:8080/path/` into Full WebSocket URL in the CP modal; verify wsURL and Basic Auth fields autofill.
- [ ] `npm test` (28 tests pass, including 13 new for ocppUrl).
- [ ] `npm run lint` and `npx vite build` (no new errors).