### PR TITLE
feat(cli): --header and --ws-subprotocol for WS upgrade routing

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -66,6 +66,8 @@ function parseArgs(argv: string[]): CLIOptions {
   let logFormat: "plain" | "json" = "plain";
   let healthPath = "/v1/healthz";
   const corsOrigins: string[] = [];
+  const extraWsHeaders: Record<string, string> = {};
+  const extraWsSubprotocols: string[] = [];
 
   for (let i = 2; i < argv.length; i++) {
     const arg = argv[i];
@@ -190,6 +192,38 @@ function parseArgs(argv: string[]): CLIOptions {
           process.exit(1);
         }
         healthPath = next;
+        i++;
+        break;
+      case "--header": {
+        if (!next || next.startsWith("--")) {
+          process.stderr.write(
+            "Error: --header requires KEY:VALUE (use multiple --header flags for several headers)\n",
+          );
+          process.exit(1);
+        }
+        const idx = next.indexOf(":");
+        if (idx <= 0) {
+          process.stderr.write(
+            `Error: --header value must be KEY:VALUE, got '${next}'\n`,
+          );
+          process.exit(1);
+        }
+        const k = next.slice(0, idx).trim();
+        const v = next.slice(idx + 1).trim();
+        if (!k) {
+          process.stderr.write("Error: --header KEY part is empty\n");
+          process.exit(1);
+        }
+        extraWsHeaders[k] = v;
+        i++;
+        break;
+      }
+      case "--ws-subprotocol":
+        if (!next || next.startsWith("--")) {
+          process.stderr.write("Error: --ws-subprotocol requires a value\n");
+          process.exit(1);
+        }
+        extraWsSubprotocols.push(next);
         i++;
         break;
       case "--web-console":
@@ -335,6 +369,8 @@ function parseArgs(argv: string[]): CLIOptions {
     stateDb,
     logFormat,
     healthPath,
+    extraWsHeaders,
+    extraWsSubprotocols,
   };
 }
 
@@ -468,6 +504,8 @@ function buildBootstrap(options: CLIOptions): ChargePointInitOptions | null {
     vendor: options.vendor,
     model: options.model,
     basicAuth: options.basicAuth,
+    extraWsHeaders: options.extraWsHeaders,
+    extraWsSubprotocols: options.extraWsSubprotocols,
   };
 }
 

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -237,6 +237,8 @@ export class CLIChargePointService {
       init.basicAuth,
       autoMeterValue,
       this.database,
+      init.extraWsHeaders ?? {},
+      init.extraWsSubprotocols ?? [],
     );
 
     this.attachEventForwarders();

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -80,15 +80,12 @@ export interface ChargePointInitOptions {
   };
   /** Extra HTTP headers attached to every WS upgrade request (CLI runtime
    *  only — the browser WebSocket constructor can't set arbitrary headers).
-   *  Typical use: `X-Preview-Slug: feature-foo` to route to a preview env
-   *  CSMS sitting behind a header-routing proxy. */
+   *  Useful for driving a header-routing proxy in front of the CSMS. */
   readonly extraWsHeaders?: Record<string, string>;
   /** Extra Sec-WebSocket-Protocol tokens appended after the OCPP version
    *  subprotocol. OCPP servers pick the first recognised version token
    *  (ocpp1.6 / ocpp2.0.1) and ignore the rest, so any extras are visible
-   *  to upstream routers but harmless for OCPP negotiation.
-   *  Typical use: `preview-feature-foo` for WSS preview routing on
-   *  charger clients that can't set custom HTTP headers. */
+   *  to upstream routers but harmless for OCPP negotiation. */
   readonly extraWsSubprotocols?: ReadonlyArray<string>;
 }
 

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -51,6 +51,12 @@ export interface CLIOptions {
    *  set as `VITE_HEALTH_PATH` at UI build time so the browser auto-detect
    *  probe targets the same endpoint. */
   readonly healthPath: string;
+  /** Repeatable `--header KEY:VALUE` — extra HTTP headers attached to
+   *  the WS upgrade. CLI runtime only. See ChargePointInitOptions. */
+  readonly extraWsHeaders: Record<string, string>;
+  /** Repeatable `--ws-subprotocol TOKEN` — extra subprotocols appended
+   *  to the OCPP version subprotocol in the WS upgrade. */
+  readonly extraWsSubprotocols: ReadonlyArray<string>;
 }
 
 export interface ChargePointInitOptions {
@@ -72,6 +78,18 @@ export interface ChargePointInitOptions {
     readonly iccid?: string;
     readonly imsi?: string;
   };
+  /** Extra HTTP headers attached to every WS upgrade request (CLI runtime
+   *  only — the browser WebSocket constructor can't set arbitrary headers).
+   *  Typical use: `X-Preview-Slug: feature-foo` to route to a preview env
+   *  CSMS sitting behind a header-routing proxy. */
+  readonly extraWsHeaders?: Record<string, string>;
+  /** Extra Sec-WebSocket-Protocol tokens appended after the OCPP version
+   *  subprotocol. OCPP servers pick the first recognised version token
+   *  (ocpp1.6 / ocpp2.0.1) and ignore the rest, so any extras are visible
+   *  to upstream routers but harmless for OCPP negotiation.
+   *  Typical use: `preview-feature-foo` for WSS preview routing on
+   *  charger clients that can't set custom HTTP headers. */
+  readonly extraWsSubprotocols?: ReadonlyArray<string>;
 }
 
 export interface JsonCommand {

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -77,8 +77,7 @@ export class ChargePoint {
     private readonly _database: Database | null = null,
     /** Extra HTTP headers and Sec-WebSocket-Protocol tokens emitted on
      *  every WS upgrade. Wired through to OCPPWebSocket so reconnects
-     *  pick the same values up. CLI-only (DOM WebSocket ignores headers).
-     *  Used to drive header-based CSMS routing for preview envs. */
+     *  pick the same values up. CLI-only (DOM WebSocket ignores headers). */
     extraWsHeaders: Record<string, string> = {},
     extraWsSubprotocols: ReadonlyArray<string> = [],
   ) {

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -75,6 +75,12 @@ export class ChargePoint {
      *  and per-connector availability. `null` keeps everything in-memory —
      *  used by the daemon's `:memory:` mode and by tests. */
     private readonly _database: Database | null = null,
+    /** Extra HTTP headers and Sec-WebSocket-Protocol tokens emitted on
+     *  every WS upgrade. Wired through to OCPPWebSocket so reconnects
+     *  pick the same values up. CLI-only (DOM WebSocket ignores headers).
+     *  Used to drive header-based CSMS routing for preview envs. */
+    extraWsHeaders: Record<string, string> = {},
+    extraWsSubprotocols: ReadonlyArray<string> = [],
   ) {
     this._autoMeterValueSetting = autoMeterValueSetting;
     this._logger.setCpId(this._id);
@@ -146,6 +152,8 @@ export class ChargePoint {
       this._id,
       this._logger,
       basicAuthSettings,
+      extraWsHeaders,
+      extraWsSubprotocols,
     );
     this._messageHandler = new OCPPMessageHandler(
       this,

--- a/src/cp/infrastructure/transport/OCPPWebSocket.ts
+++ b/src/cp/infrastructure/transport/OCPPWebSocket.ts
@@ -61,12 +61,22 @@ export class OCPPWebSocket {
   private _onOpenCallback: (() => void) | null = null;
   private _onCloseCallback: ((ev: CloseEvent) => void) | null = null;
   private _isManualDisconnect: boolean = false;
+  // Extra HTTP headers + Sec-WebSocket-Protocol tokens attached on each
+  // upgrade. Used to drive header-based routing in front of the CSMS
+  // (e.g. preview envs matching on X-Preview-Slug or `preview-<slug>`
+  // in the subprotocol negotiation). Both are CLI-only — DOM WebSocket
+  // ignores extraHeaders, but the runtime fallback in openOcppWebSocket
+  // handles that.
+  private _extraHeaders: Record<string, string>;
+  private _extraSubprotocols: ReadonlyArray<string>;
 
   constructor(
     url: string,
     chargePointId: string,
     logger: Logger,
     basicAuthSettings: { username: string; password: string } | null = null,
+    extraHeaders: Record<string, string> = {},
+    extraSubprotocols: ReadonlyArray<string> = [],
   ) {
     this._url = url;
     this._chargePointId = chargePointId;
@@ -77,6 +87,8 @@ export class OCPPWebSocket {
         password: basicAuthSettings.password,
       };
     }
+    this._extraHeaders = extraHeaders;
+    this._extraSubprotocols = extraSubprotocols;
   }
 
   get url(): string {
@@ -97,6 +109,8 @@ export class OCPPWebSocket {
       baseUrl: this._url,
       chargePointId: this._chargePointId,
       basicAuth: this._basicAuth,
+      extraHeaders: this._extraHeaders,
+      extraSubprotocols: this._extraSubprotocols,
     });
     this._ws.onopen = () => {
       this.handleOpen();

--- a/src/cp/infrastructure/transport/OCPPWebSocket.ts
+++ b/src/cp/infrastructure/transport/OCPPWebSocket.ts
@@ -62,11 +62,8 @@ export class OCPPWebSocket {
   private _onCloseCallback: ((ev: CloseEvent) => void) | null = null;
   private _isManualDisconnect: boolean = false;
   // Extra HTTP headers + Sec-WebSocket-Protocol tokens attached on each
-  // upgrade. Used to drive header-based routing in front of the CSMS
-  // (e.g. preview envs matching on X-Preview-Slug or `preview-<slug>`
-  // in the subprotocol negotiation). Both are CLI-only — DOM WebSocket
-  // ignores extraHeaders, but the runtime fallback in openOcppWebSocket
-  // handles that.
+  // upgrade. Both are CLI-only — DOM WebSocket ignores extraHeaders, but
+  // the runtime fallback in openOcppWebSocket handles that.
   private _extraHeaders: Record<string, string>;
   private _extraSubprotocols: ReadonlyArray<string>;
 

--- a/src/cp/infrastructure/transport/wsUrlWithBasic.ts
+++ b/src/cp/infrastructure/transport/wsUrlWithBasic.ts
@@ -58,9 +58,8 @@ export function openOcppWebSocket(params: {
   basicAuth: BasicAuthSettings | null;
   /** Extra raw HTTP headers attached to the WebSocket upgrade request.
    *  Only emitted when running in the Bun/Node CLI runtime — the DOM
-   *  WebSocket constructor doesn't accept headers. Useful for CSMS in
-   *  front of a header-routing proxy (e.g. preview environments matching
-   *  on `X-Preview-Slug`). */
+   *  WebSocket constructor doesn't accept headers. Useful for driving a
+   *  header-routing proxy in front of the CSMS. */
   extraHeaders?: Record<string, string>;
   /** Extra Sec-WebSocket-Protocol tokens appended to the OCPP version
    *  subprotocol. OCPP servers pick the first recognised version token

--- a/src/cp/infrastructure/transport/wsUrlWithBasic.ts
+++ b/src/cp/infrastructure/transport/wsUrlWithBasic.ts
@@ -56,15 +56,34 @@ export function openOcppWebSocket(params: {
   baseUrl: string;
   chargePointId: string;
   basicAuth: BasicAuthSettings | null;
+  /** Extra raw HTTP headers attached to the WebSocket upgrade request.
+   *  Only emitted when running in the Bun/Node CLI runtime — the DOM
+   *  WebSocket constructor doesn't accept headers. Useful for CSMS in
+   *  front of a header-routing proxy (e.g. preview environments matching
+   *  on `X-Preview-Slug`). */
+  extraHeaders?: Record<string, string>;
+  /** Extra Sec-WebSocket-Protocol tokens appended to the OCPP version
+   *  subprotocol. OCPP servers pick the first recognised version token
+   *  and ignore the rest, so extras are safe to add and become visible
+   *  to upstream routers that match on subprotocol. */
+  extraSubprotocols?: ReadonlyArray<string>;
 }): WebSocket {
   const url = buildOcppWebSocketUrl(params);
-  if (!isBrowserRuntime() && params.basicAuth?.password) {
+  const protocols = [
+    OCPP_WEBSOCKET_PROTOCOL,
+    ...(params.extraSubprotocols ?? []),
+  ];
+  const extraHeaders = params.extraHeaders ?? {};
+  const hasExtraHeaders = Object.keys(extraHeaders).length > 0;
+  if (!isBrowserRuntime() && (params.basicAuth?.password || hasExtraHeaders)) {
+    const headers: Record<string, string> = { ...extraHeaders };
+    if (params.basicAuth?.password) {
+      headers.Authorization = buildOcppBasicAuthorization(params.basicAuth);
+    }
     return new (WebSocket as unknown as WebSocketWithHeaders)(url, {
-      protocols: [OCPP_WEBSOCKET_PROTOCOL],
-      headers: {
-        Authorization: buildOcppBasicAuthorization(params.basicAuth),
-      },
+      protocols,
+      headers,
     });
   }
-  return new WebSocket(url, [OCPP_WEBSOCKET_PROTOCOL]);
+  return new WebSocket(url, protocols);
 }


### PR DESCRIPTION
## Summary

Adds two repeatable CLI flags so the simulator can drive the WebSocket upgrade through a header/subprotocol-routing proxy in front of the CSMS:

- `--header KEY:VALUE` — attaches arbitrary HTTP headers to the WS upgrade request (CLI runtime only — the browser `WebSocket` constructor doesn't accept headers, so the React UI is unaffected).
- `--ws-subprotocol TOKEN` — appends extra tokens to `Sec-WebSocket-Protocol` after `ocpp1.6`. OCPP servers pick the first recognised version subprotocol and ignore the rest, so the extra tokens are harmless for protocol negotiation but visible to upstream routers that match on subprotocol.

```
ocpp-cp-sim --cp-id cp1 --ws-url wss://csms.example.com/chargepoint/ \
            --header 'X-Some-Header: some-value' \
            --ws-subprotocol some-token
```

## Plumbing

- `CLIOptions` gains `extraWsHeaders` / `extraWsSubprotocols`.
- `ChargePointInitOptions` gains optional same.
- `ChargePoint` constructor takes two new positional args with empty defaults — existing browser-side `LocalChargePointService` caller still compiles unchanged.
- `OCPPWebSocket` constructor stashes the values on the instance so reconnects reuse them.
- `openOcppWebSocket()` merges them into the headers/protocols passed to the underlying `new WebSocket(url, {…})`. The headers-aware constructor path activates only when basicAuth OR at least one extra header is present, so the existing no-auth no-headers code path is unchanged.

## Test plan

- [ ] `bun test` green locally.
- [ ] Manual smoke against a header-routing CSMS:
  ```
  bun src/cli/main.ts --cp-id cp1 --ws-url wss://csms.example.com/chargepoint/ \
      --header 'X-Some-Header: some-value' \
      --ws-subprotocol some-token --json
  ```
  Verify the upgrade request shows the header + extra subprotocol in the CSMS access log.
- [ ] Browser UI build still loads and connects (the new fields are no-ops there).