### PR TITLE
fix(connector): preserve transactionValue / socPercent on cleanup()

### DIFF
--- a/src/cp/domain/connector/Connector.ts
+++ b/src/cp/domain/connector/Connector.ts
@@ -697,8 +697,25 @@ export class Connector {
     }
     this.eventsEmitter.removeAllListeners();
     this.onMeterSend = null;
-    this.transactionValue = null;
-    this.socPercent = null;
+    // Intentionally do NOT clear `transactionValue` / `socPercent` here.
+    // `cleanup()` is called from `ChargePoint.teardownAfterClose` on any
+    // WebSocket close, including transient CSMS-side restarts (i.e. the
+    // simulator daemon stays up but its peer ocpp-cs / CSMS bounces).
+    // After such a reconnect the CSMS-side may have lost its in-memory
+    // ChargePointState entirely and rely on the simulator's next
+    // BootNotification + StatusNotifications to re-learn the live
+    // connector status. If we null `transactionValue` here, the post-
+    // boot fan-out in `BootNotificationResultHandler` takes the
+    // `autoResetToAvailable && transaction === null` branch and tells the
+    // CSMS "this connector is Available" — orphaning the in-flight
+    // transaction id at the CSMS side.
+    //
+    // The connector_runtime sqlite snapshot still has the active
+    // transaction at this point, so a full simulator daemon restart
+    // recovers via `CPRegistry.restoreFromDatabase` →
+    // `restoreConnectorRuntimeFromDatabase`. Keeping the in-memory
+    // values around lets the WS-only reconnect path benefit from the
+    // same correctness without going through sqlite.
   }
 
   private applyMeterValue(value: number): void {

--- a/src/cp/domain/connector/__tests__/Connector.cleanup.test.ts
+++ b/src/cp/domain/connector/__tests__/Connector.cleanup.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { Connector } from "../Connector";
+import { Logger, LogLevel } from "../../../shared/Logger";
+import { OCPPStatus } from "../../types/OcppTypes";
+import type { Transaction } from "../Transaction";
+
+function makeConnector(): Connector {
+  // ERROR-level logger so tests stay quiet without overriding stdout.
+  return new Connector(1, new Logger(LogLevel.ERROR));
+}
+
+function makeTransaction(id: number | null = 42): Transaction {
+  return {
+    id,
+    connectorId: 1,
+    tagId: "test-tag",
+    meterStart: 0,
+    meterStop: null,
+    startTime: new Date(),
+    stopTime: null,
+    meterSent: false,
+  };
+}
+
+describe("Connector.cleanup", () => {
+  it("does not clear transactionValue on cleanup", () => {
+    // Why: cleanup() is called from ChargePoint.teardownAfterClose on every
+    // WebSocket close, including transient CSMS-side restarts where the
+    // simulator daemon stays alive. If we null transactionValue here, the
+    // post-boot StatusNotification fan-out in BootNotificationResultHandler
+    // takes the autoReset-to-Available branch and orphans the in-flight
+    // transaction id at the CSMS side. The connector_runtime sqlite snapshot
+    // is the source of truth for daemon restarts; in-memory values must
+    // survive a WS-only reconnect to cover the CSMS-restart case.
+    const connector = makeConnector();
+    const tx = makeTransaction();
+    connector.beginTransaction(tx);
+    expect(connector.transaction).not.toBeNull();
+
+    connector.cleanup();
+
+    expect(connector.transaction).not.toBeNull();
+    expect(connector.transaction?.id).toBe(42);
+  });
+
+  it("does not clear socPercent on cleanup", () => {
+    // Same reasoning as transactionValue: the connector's SoC must survive
+    // a WS-only reconnect so the CSMS sees a consistent meter trail
+    // across the boot/StatusNotification fan-out.
+    const connector = makeConnector();
+    connector.beginTransaction(makeTransaction());
+    connector.soc = 72;
+    expect(connector.soc).toBe(72);
+
+    connector.cleanup();
+
+    expect(connector.soc).toBe(72);
+  });
+
+  it("status survives cleanup so BootNotificationResultHandler keeps it", () => {
+    // BootNotificationResultHandler reads connector.status to decide whether
+    // to fan out the resumed status (Preparing / Charging) or reset to
+    // Available. cleanup() must not move us off the live status.
+    const connector = makeConnector();
+    connector.restoreRuntimeSnapshot({
+      status: OCPPStatus.Charging,
+      availability: connector.availability,
+      scheduledAvailability: null,
+      transaction: makeTransaction(),
+      meterValueWh: 0,
+      socPercent: null,
+      lastAutoStartedScenarioKey: null,
+    });
+    expect(connector.status).toBe(OCPPStatus.Charging);
+
+    connector.cleanup();
+
+    expect(connector.status).toBe(OCPPStatus.Charging);
+  });
+});


### PR DESCRIPTION
## Summary

\`Connector.cleanup()\` is called from \`ChargePoint.teardownAfterClose\` on **every** WebSocket close, not just on simulator daemon shutdown. The typical production case where the CSMS bounces (e.g. a k8s rollout of the CSMS pod) keeps the simulator daemon alive, tears the connector down defensively, and reconnects on its own.

Previously \`cleanup()\` also nulled \`transactionValue\` and \`socPercent\`. The WS auto-reconnect then sent BootNotification, and [BootNotificationResultHandler](src/cp/infrastructure/transport/handlers/callresult/BootNotificationResultHandler.ts) took the

\`\`\`ts
if (connector.autoResetToAvailable && connector.transaction === null) {
  context.chargePoint.updateConnectorStatus(connector.id, OCPPStatus.Available);
  return;
}
\`\`\`

branch (\`connector.transaction\` was the just-nulled value) and announced the connector as \`Available\` — leaving the CSMS-side transaction id orphaned and the simulator unable to start a fresh transaction (\"already charging\" rejection at CSMS).

## Why this is the right fix

The simulator already has a working source of truth for the \"daemon goes away\" case: \`connector_runtime\` sqlite. \`CPRegistry.restoreFromDatabase\` calls \`restoreConnectorRuntimeFromDatabase\` for each CP it brings back, repopulating \`Connector.transactionValue\` and \`status\` from sqlite **before** the WS connects, so \`BootNotificationResultHandler\` sees a non-null transaction and keeps the resumed status.

The bug was that the WS-only reconnect path (daemon alive, CSMS bounced) wasn't covered by either mechanism: \`cleanup()\` wiped memory, and no sqlite-restore was called before the next \`boot()\`. Just stopping \`cleanup()\` from wiping in-memory state lines the two paths up: in-memory survives, sqlite stays the daemon-restart fallback.

Other resources \`cleanup()\` owns (meter scheduler, scenario manager, listener handles) still need to go and that's preserved.

## Repro context (real deployment)

ocpp-cs (CSMS) pod was restarted by k8s consolidation (~1×/hour). Each restart triggered:

1. WS close in simulator → \`cleanup()\` → \`transactionValue = null\`
2. WS auto-reconnect → BootNotification → all connectors announced as \`Available\`
3. CSMS-side transaction row stays \`finished_at IS NULL\`; user gets \"already charging\" when retrying

After this fix the post-reconnect StatusNotification fan-out preserves whatever the simulator was actually doing (\`Charging\`, \`Preparing\`, etc.) and the CSMS view stays consistent.

## Test plan

- [x] \`vitest run src/cp/domain/connector/__tests__/Connector.cleanup.test.ts\` — 3 new tests cover \`transactionValue\`, \`socPercent\`, and \`status\` survival
- [x] \`eslint src/cp/domain/connector/Connector.ts ...\` clean
- [x] \`vitest run\` for surrounding tests still pass
- [ ] (Manual) End-to-end on dev: simulate WS close + reopen and confirm StatusNotification carries resumed status