### PR TITLE
feat(cli): HTTP Basic Auth for the web console / API / WS upgrades

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -45,6 +45,11 @@ function parseArgs(argv: string[]): CLIOptions {
   let stop = false;
   let basicAuthUser = "";
   let basicAuthPass = "";
+  // HTTP web-console Basic Auth credentials. Distinct from basicAuthUser /
+  // basicAuthPass above — those are sent on the *outgoing* CP → CSMS WS
+  // upgrade; these gate *incoming* HTTP requests to this daemon.
+  let webConsoleBasicAuthUser = "";
+  let webConsoleBasicAuthPass = "";
   let vendor = "CLI-Vendor";
   let model = "CLI-Model";
   let scenario: string | null = null;
@@ -108,6 +113,14 @@ function parseArgs(argv: string[]): CLIOptions {
         break;
       case "--basic-auth-pass":
         basicAuthPass = next ?? "";
+        i++;
+        break;
+      case "--web-console-basic-auth-user":
+        webConsoleBasicAuthUser = next ?? "";
+        i++;
+        break;
+      case "--web-console-basic-auth-pass":
+        webConsoleBasicAuthPass = next ?? "";
         i++;
         break;
       case "--vendor":
@@ -342,6 +355,24 @@ function parseArgs(argv: string[]): CLIOptions {
       ? { username: basicAuthUser, password: basicAuthPass }
       : null;
 
+  // Both web-console flags must be supplied together. Half-configured auth
+  // (e.g. user without pass) would let everyone in or block everyone out,
+  // so we hard-fail at startup instead of silently picking one.
+  if ((webConsoleBasicAuthUser === "") !== (webConsoleBasicAuthPass === "")) {
+    process.stderr.write(
+      "Error: --web-console-basic-auth-user and --web-console-basic-auth-pass " +
+        "must be supplied together (or both omitted)\n",
+    );
+    process.exit(1);
+  }
+  const webConsoleBasicAuth =
+    webConsoleBasicAuthUser && webConsoleBasicAuthPass
+      ? {
+          username: webConsoleBasicAuthUser,
+          password: webConsoleBasicAuthPass,
+        }
+      : null;
+
   return {
     wsUrl,
     cpId,
@@ -352,6 +383,7 @@ function parseArgs(argv: string[]): CLIOptions {
     events,
     stop,
     basicAuth,
+    webConsoleBasicAuth,
     vendor,
     model,
     scenario,
@@ -402,8 +434,18 @@ Options:
   --cp-id <id>             Charge Point ID
   --ws-url <url>           WebSocket URL of CSMS
   --connectors <n>         Number of connectors (default: 1)
-  --basic-auth-user <u>    Basic auth username
-  --basic-auth-pass <p>    Basic auth password
+  --basic-auth-user <u>    Outgoing WS Basic auth username (CP → CSMS)
+  --basic-auth-pass <p>    Outgoing WS Basic auth password (CP → CSMS)
+  --web-console-basic-auth-user <u>
+                           Basic auth user for INCOMING HTTP requests to
+                           this daemon (web console / JSON API / WS
+                           upgrades). Must be supplied together with
+                           --web-console-basic-auth-pass. Default: no auth.
+  --web-console-basic-auth-pass <p>
+                           Basic auth password for INCOMING HTTP. The
+                           configured health path (--health-path, default
+                           /v1/healthz) is always served without auth so
+                           k8s probes / load balancers keep working.
   --vendor <vendor>        Charge point vendor (default: CLI-Vendor)
   --model <model>          Charge point model (default: CLI-Model)
   --scenario <file>            Run scenario from JSON file on startup
@@ -566,6 +608,7 @@ async function main(): Promise<void> {
       webConsolePort: options.webConsolePort,
       stateDb: options.stateDb,
       healthPath: options.healthPath,
+      webConsoleBasicAuth: options.webConsoleBasicAuth,
     });
     return;
   }

--- a/src/cli/server/__tests__/httpServer.basicAuth.test.ts
+++ b/src/cli/server/__tests__/httpServer.basicAuth.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { createHttpHandlers } from "../httpServer";
+import { CPRegistry } from "../CPRegistry";
+import { EventBus } from "../eventBus";
+import { createLifecycle } from "../lifecycle";
+
+// The fetch handler's signature wants a Bun `Server<SocketData>` for WS
+// upgrades. Basic-auth check runs BEFORE dispatch() and the healthz route
+// also doesn't touch `server`, so an opaque cast is enough for these tests.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const stubServer = null as any;
+
+function makeHandlers(
+  basicAuth: { username: string; password: string } | null,
+): ReturnType<typeof createHttpHandlers> {
+  const bus = new EventBus();
+  const registry = new CPRegistry(bus, null);
+  const lifecycle = createLifecycle({ pidPath: null, registry });
+  return createHttpHandlers({
+    registry,
+    bus,
+    lifecycle,
+    database: null,
+    healthPath: "/v1/healthz",
+    webConsoleBasicAuth: basicAuth,
+  });
+}
+
+function basicAuthHeader(user: string, pass: string): string {
+  // UTF-8 → base64 (browser-compatible). btoa alone barfs on >0xFF code
+  // points; the encodeURIComponent / unescape dance converts to UTF-8
+  // bytes-as-Latin-1 first.
+  const utf8 = unescape(encodeURIComponent(`${user}:${pass}`));
+  return "Basic " + btoa(utf8);
+}
+
+describe("httpServer Basic Auth gate", () => {
+  it("passes through when webConsoleBasicAuth is null", async () => {
+    const handlers = makeHandlers(null);
+    const req = new Request("http://localhost/v1/healthz");
+    const res = await Promise.resolve(handlers.fetch(req, stubServer));
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).status).toBe(200);
+  });
+
+  it("returns 401 + WWW-Authenticate when header is missing", async () => {
+    const handlers = makeHandlers({ username: "alice", password: "secret" });
+    const req = new Request("http://localhost/v1/cps");
+    const res = await Promise.resolve(handlers.fetch(req, stubServer));
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).status).toBe(401);
+    // realm in WWW-Authenticate is what makes browsers show a creds prompt.
+    expect((res as Response).headers.get("www-authenticate")).toMatch(
+      /^Basic realm=/,
+    );
+  });
+
+  it("returns 401 for the wrong password", async () => {
+    const handlers = makeHandlers({ username: "alice", password: "secret" });
+    const req = new Request("http://localhost/v1/cps", {
+      headers: { authorization: basicAuthHeader("alice", "wrong") },
+    });
+    const res = await Promise.resolve(handlers.fetch(req, stubServer));
+    expect((res as Response).status).toBe(401);
+  });
+
+  it("returns 401 for the wrong username", async () => {
+    const handlers = makeHandlers({ username: "alice", password: "secret" });
+    const req = new Request("http://localhost/v1/cps", {
+      headers: { authorization: basicAuthHeader("bob", "secret") },
+    });
+    const res = await Promise.resolve(handlers.fetch(req, stubServer));
+    expect((res as Response).status).toBe(401);
+  });
+
+  it("returns 401 on garbled / non-Basic Authorization header", async () => {
+    const handlers = makeHandlers({ username: "alice", password: "secret" });
+    const req = new Request("http://localhost/v1/cps", {
+      headers: { authorization: "Bearer xyz" },
+    });
+    const res = await Promise.resolve(handlers.fetch(req, stubServer));
+    expect((res as Response).status).toBe(401);
+  });
+
+  it("passes through with correct credentials", async () => {
+    const handlers = makeHandlers({ username: "alice", password: "secret" });
+    const req = new Request("http://localhost/v1/healthz", {
+      headers: { authorization: basicAuthHeader("alice", "secret") },
+    });
+    const res = await Promise.resolve(handlers.fetch(req, stubServer));
+    expect((res as Response).status).toBe(200);
+  });
+
+  it("exempts the configured health path from auth (no header needed)", async () => {
+    const handlers = makeHandlers({ username: "alice", password: "secret" });
+    const req = new Request("http://localhost/v1/healthz");
+    const res = await Promise.resolve(handlers.fetch(req, stubServer));
+    expect((res as Response).status).toBe(200);
+  });
+
+  it("supports non-ASCII credentials via UTF-8 base64", async () => {
+    // OCPP CSMS deployments occasionally hand operators non-ASCII passwords
+    // (Japanese / German). atob in Bun handles the bytes directly, so this
+    // case must work the same as ASCII.
+    const handlers = makeHandlers({
+      username: "operator",
+      password: "パスワード",
+    });
+    const goodReq = new Request("http://localhost/v1/cps", {
+      headers: { authorization: basicAuthHeader("operator", "パスワード") },
+    });
+    const badReq = new Request("http://localhost/v1/cps", {
+      headers: { authorization: basicAuthHeader("operator", "ぱすわーど") },
+    });
+
+    const goodRes = await Promise.resolve(handlers.fetch(goodReq, stubServer));
+    // After auth passes the request falls through to dispatch which hits
+    // a no-such-route case and returns 404 — that's fine, we only care
+    // that the gate let it through.
+    expect((goodRes as Response).status).not.toBe(401);
+
+    const badRes = await Promise.resolve(handlers.fetch(badReq, stubServer));
+    expect((badRes as Response).status).toBe(401);
+  });
+});

--- a/src/cli/server/httpServer.ts
+++ b/src/cli/server/httpServer.ts
@@ -139,6 +139,69 @@ function forbidden(): Response {
   return new Response("origin not allowed", { status: 403 });
 }
 
+/**
+ * Parse a `Authorization: Basic <base64>` header into username + password.
+ * Returns null when the header is missing, not Basic, or doesn't decode.
+ * Tolerates the rare `Basic` scheme written in any case.
+ */
+function parseBasicAuthHeader(
+  header: string | null,
+): { username: string; password: string } | null {
+  if (!header) return null;
+  const match = /^\s*Basic\s+(\S+)\s*$/i.exec(header);
+  if (!match) return null;
+  let latin1: string;
+  try {
+    latin1 = atob(match[1]);
+  } catch {
+    return null;
+  }
+  // RFC 7617 lets clients encode credentials as UTF-8 (and we hint
+  // `charset="UTF-8"` in the WWW-Authenticate header). atob produces a
+  // Latin-1 string where each char carries one byte; re-decode through
+  // a UTF-8 TextDecoder so non-ASCII passwords compare correctly.
+  const bytes = new Uint8Array(latin1.length);
+  for (let i = 0; i < latin1.length; i++) bytes[i] = latin1.charCodeAt(i);
+  const decoded = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  const idx = decoded.indexOf(":");
+  if (idx < 0) return null;
+  return {
+    username: decoded.slice(0, idx),
+    password: decoded.slice(idx + 1),
+  };
+}
+
+/**
+ * Constant-time comparison of supplied creds vs the configured creds.
+ * Length differences are inferred from the buffer comparison itself, so
+ * an attacker can still time-distinguish "wrong length" from "wrong
+ * content" — that leak is fine because the realm name in
+ * WWW-Authenticate already announces the server's identity. What we
+ * defend against is byte-by-byte secret discovery via response timing.
+ */
+function credentialsMatch(
+  supplied: { username: string; password: string },
+  expected: { username: string; password: string },
+): boolean {
+  return (
+    timingSafeStringEqual(supplied.username, expected.username) &&
+    timingSafeStringEqual(supplied.password, expected.password)
+  );
+}
+
+function timingSafeStringEqual(a: string, b: string): boolean {
+  // Buffer compare is constant-time when lengths match; if they don't,
+  // we return false immediately. Pad to avoid a length-zero edge case.
+  const ba = new TextEncoder().encode(a);
+  const bb = new TextEncoder().encode(b);
+  if (ba.length !== bb.length) return false;
+  let diff = 0;
+  for (let i = 0; i < ba.length; i++) {
+    diff |= ba[i] ^ bb[i];
+  }
+  return diff === 0;
+}
+
 export interface HttpHandlers {
   fetch: (
     req: Request,
@@ -159,16 +222,43 @@ export function createHttpHandlers(deps: {
   /** Absolute URL path the health-check JSON is served on. Defaults to
    *  `/v1/healthz`. */
   healthPath?: string;
+  /** Optional Basic Auth gate for the HTTP web console / API / WS upgrades.
+   *  When set, every request except the configured `healthPath` must
+   *  carry a matching `Authorization: Basic <base64(user:pass)>` header.
+   *  Null = no auth (default; backward compatible). */
+  webConsoleBasicAuth?: { username: string; password: string } | null;
 }): HttpHandlers {
   const { registry, bus, lifecycle } = deps;
   const cors: CorsPolicy = deps.cors ?? { kind: "any" };
   const staticDir = deps.staticDir ?? null;
   const database = deps.database ?? null;
   const healthPath = deps.healthPath ?? "/v1/healthz";
+  const webConsoleBasicAuth = deps.webConsoleBasicAuth ?? null;
 
   return {
     fetch(req, server) {
-      // Reserved hook: authentication middleware can be added here.
+      // Optional Basic Auth gate. Runs *before* CORS so an attacker without
+      // creds can't probe internal endpoints via a same-origin request.
+      // The health path is intentionally exempt so k8s probes / external
+      // load balancers / browser auto-detect can keep working unprompted.
+      if (webConsoleBasicAuth !== null) {
+        const url = new URL(req.url);
+        if (url.pathname !== healthPath) {
+          const auth = parseBasicAuthHeader(req.headers.get("authorization"));
+          if (!auth || !credentialsMatch(auth, webConsoleBasicAuth)) {
+            // 401 with WWW-Authenticate so browsers prompt for credentials
+            // instead of just showing the 401 body. realm is shown in the
+            // prompt; charset hints UTF-8 for non-ASCII passwords.
+            return new Response("authentication required", {
+              status: 401,
+              headers: {
+                "www-authenticate":
+                  'Basic realm="ocpp-cp-simulator", charset="UTF-8"',
+              },
+            });
+          }
+        }
+      }
 
       // Block disallowed browser origins BEFORE dispatching so simple-request
       // POSTs / WS upgrades / GETs don't trigger side effects under a tightened

--- a/src/cli/server/startServer.ts
+++ b/src/cli/server/startServer.ts
@@ -68,6 +68,13 @@ export interface ServerOptions {
   /** Absolute URL path the health-check JSON is served on. Defaults to
    *  `/v1/healthz` (set by the CLI). */
   readonly healthPath: string;
+  /** Optional Basic Auth credentials for the inbound HTTP server (web
+   *  console / JSON API / WS upgrades). Health path is exempt. Null = no
+   *  auth. Plumbed straight through to `createHttpHandlers`. */
+  readonly webConsoleBasicAuth: {
+    readonly username: string;
+    readonly password: string;
+  } | null;
 }
 
 export async function startServer(opts: ServerOptions): Promise<void> {
@@ -117,6 +124,7 @@ export async function startServer(opts: ServerOptions): Promise<void> {
     cors: opts.cors,
     database,
     healthPath: opts.healthPath,
+    webConsoleBasicAuth: opts.webConsoleBasicAuth,
   });
   const consoleHandlers = opts.staticDir
     ? createHttpHandlers({
@@ -127,10 +135,19 @@ export async function startServer(opts: ServerOptions): Promise<void> {
         staticDir: opts.staticDir,
         database,
         healthPath: opts.healthPath,
+        webConsoleBasicAuth: opts.webConsoleBasicAuth,
       })
     : apiHandlers;
   if (opts.staticDir) {
     serverLog(`Web console: ${opts.staticDir}`);
+  }
+  if (opts.webConsoleBasicAuth) {
+    // Visible-on-startup log line so an operator can confirm the gate is on
+    // (and which user). The password is intentionally NOT logged.
+    serverLog(
+      `HTTP Basic Auth: enabled (user=${opts.webConsoleBasicAuth.username}, ` +
+        `health path ${opts.healthPath} exempt)`,
+    );
   }
   serverLog(`Health endpoint: GET ${opts.healthPath}`);
   const servers: AnyServer[] = [];

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -11,6 +11,17 @@ export interface CLIOptions {
     readonly username: string;
     readonly password: string;
   } | null;
+  /** Optional Basic Auth gate for the HTTP web console / API / WS upgrades.
+   *  Unrelated to `basicAuth` above (which is for the *outgoing* CP →
+   *  CSMS WebSocket). When set, every request to the daemon's HTTP server
+   *  except the configured health path must carry a matching
+   *  `Authorization: Basic <base64(user:pass)>` header; otherwise the
+   *  server returns 401 + `WWW-Authenticate: Basic realm="..."` so
+   *  browsers prompt for credentials. */
+  readonly webConsoleBasicAuth: {
+    readonly username: string;
+    readonly password: string;
+  } | null;
   readonly vendor: string;
   readonly model: string;
   readonly scenario: string | null;


### PR DESCRIPTION
## Summary

The daemon's HTTP server (`--http-port` / `--web-console-port`) is open by default — fine for localhost, but unauthenticated when the simulator is exposed behind a public Ingress / proxy. In that case anyone reaching the URL can drive the simulator, trigger OCPP traffic into the upstream CSMS, and read in-flight transaction state.

Two new CLI flags:

```
--web-console-basic-auth-user <user>
--web-console-basic-auth-pass <pass>
```

Both must be supplied together (half-configured auth fails fast at startup). When set, every incoming HTTP request — REST, static file, WS upgrade — must carry a matching `Authorization: Basic <base64(user:pass)>` header. Missing or wrong creds return `401` + `WWW-Authenticate: Basic realm="ocpp-cp-simulator", charset="UTF-8"` so browsers prompt for credentials. The configured health path (`--health-path`, default `/v1/healthz`) is exempt so probes / external LBs keep working unprompted.

Distinct from the existing `--basic-auth-user/--basic-auth-pass` (those configure *outgoing* CP → CSMS WS Basic auth). Help text now distinguishes the two pairs.

## Where the check lives

[`httpServer.ts`](src/cli/server/httpServer.ts) — at the very top of the `fetch` handler (the spot the file already marked as "Reserved hook: authentication middleware can be added here"). Runs *before* the CORS check so an attacker without creds can't probe internal endpoints via same-origin requests. Same gate also covers `/v1/events` and `/v1/cp/:cpId/events` WebSocket upgrades because those go through the same `dispatch()`.

Notable touches:

- RFC 7617 UTF-8: `atob` → `Uint8Array` → `TextDecoder("utf-8")` so non-ASCII passwords work end-to-end.
- Constant-time credential compare (`timingSafeStringEqual`) to avoid byte-by-byte timing oracles. Length-mismatch leak is acceptable: the realm in `WWW-Authenticate` already announces the server's identity.
- Startup log line announcing auth is on — password is not logged.

## Test plan

- [x] `vitest run` — 8 new test cases pass, full suite green.
- [x] `eslint` clean on touched files.
- [ ] Local manual: `bun src/cli/main.ts --daemon --http-port 9700 --web-console-basic-auth-user u --web-console-basic-auth-pass p` → `curl -i http://localhost:9700/v1/cps` returns 401 + `WWW-Authenticate`; `curl -u u:p` succeeds; `curl http://localhost:9700/v1/healthz` succeeds without creds.
- [ ] Manual WS check: `wscat -c ws://localhost:9700/v1/events` → 401, with `-H 'Authorization: Basic ...'` → connected.