### PR TITLE
feat(ocpp1.6): fill LocalAuthList, UpdateFirmware, GetDiagnostics lifecycle, SmartCharging spec compliance

### DIFF
--- a/src/cp/domain/auth/LocalAuthList.ts
+++ b/src/cp/domain/auth/LocalAuthList.ts
@@ -1,0 +1,170 @@
+import { Logger, LogType } from "../../shared/Logger";
+
+/**
+ * idTagInfo subset stored in the local authorization list. Matches
+ * ts-ocpp's inline `idTagInfo` shape on SendLocalListRequest entries.
+ * `expiryDate`/`parentIdTag` are intentionally not modeled — ts-ocpp's
+ * generated type allows `[k: string]: unknown` for extras, but for our
+ * authorization-decision path only `status` is consulted.
+ */
+export interface LocalAuthorizationEntry {
+  status: "Accepted" | "Blocked" | "Expired" | "Invalid" | "ConcurrentTx";
+}
+
+export type SendLocalListItem = {
+  idTag: string;
+  idTagInfo?: { status: LocalAuthorizationEntry["status"] };
+};
+
+export type SendLocalListStatus =
+  | "Accepted"
+  | "Failed"
+  | "NotSupported"
+  | "VersionMismatch";
+
+export interface LocalAuthListLimits {
+  /** Max total entries kept in the list. Mirrors LocalAuthListMaxLength. */
+  localAuthListMaxLength: number;
+  /** Max entries accepted in a single SendLocalList.req payload.
+   *  Mirrors SendLocalListMaxLength. */
+  sendLocalListMaxLength: number;
+}
+
+/**
+ * OCPP 1.6 §9 / §6.18 / §6.10:
+ *
+ * Owns the Charge Point's local authorization list (idTag → idTagInfo) and
+ * a monotonically increasing `version`. CSMS keeps the list in sync via
+ * `SendLocalList.req` (Full replacement or Differential update) and
+ * inspects `GetLocalListVersion.req` to decide whether a re-sync is needed.
+ *
+ * Storage is in-memory — same lifecycle decision as {@link
+ * ReservationManager} (lives only while the CP process is up). The
+ * persistence layer is intentionally NOT touched here so the LocalAuthList
+ * doesn't drift from upstream state across daemon restarts.
+ *
+ * Note on the `version` field: §6.10 / §9.4 specify -1 as the value the CP
+ * reports when LocalAuthListManagement is disabled. The manager itself
+ * does not know whether the feature is enabled — the handler consults
+ * Configuration (`LocalAuthListEnabled`) and short-circuits to -1 before
+ * calling `getVersion()`.
+ */
+export class LocalAuthListManager {
+  private list: Map<string, LocalAuthorizationEntry> = new Map();
+  private version = 0;
+  private readonly logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  getVersion(): number {
+    return this.version;
+  }
+
+  size(): number {
+    return this.list.size;
+  }
+
+  getEntry(idTag: string): LocalAuthorizationEntry | undefined {
+    return this.list.get(idTag);
+  }
+
+  /**
+   * §9.2 Full update: the new list completely replaces the existing one.
+   * The supplied `listVersion` is accepted as-is (the spec lets it move
+   * either way for Full).
+   */
+  applyFull(
+    listVersion: number,
+    items: SendLocalListItem[] | undefined,
+    limits: LocalAuthListLimits,
+  ): SendLocalListStatus {
+    const next = items ?? [];
+    if (next.length > limits.sendLocalListMaxLength) {
+      this.logger.warn(
+        `SendLocalList Full rejected: ${next.length} entries > SendLocalListMaxLength ${limits.sendLocalListMaxLength}`,
+        LogType.OCPP,
+      );
+      return "Failed";
+    }
+    if (next.length > limits.localAuthListMaxLength) {
+      this.logger.warn(
+        `SendLocalList Full rejected: ${next.length} entries > LocalAuthListMaxLength ${limits.localAuthListMaxLength}`,
+        LogType.OCPP,
+      );
+      return "Failed";
+    }
+    const fresh = new Map<string, LocalAuthorizationEntry>();
+    for (const item of next) {
+      if (item.idTagInfo) {
+        fresh.set(item.idTag, { status: item.idTagInfo.status });
+      }
+      // §9.2: in a Full update, entries without idTagInfo are simply not
+      // included in the resulting list — same semantics as omitting them.
+    }
+    this.list = fresh;
+    this.version = listVersion;
+    this.logger.info(
+      `Local auth list replaced (version=${listVersion}, entries=${this.list.size})`,
+      LogType.OCPP,
+    );
+    return "Accepted";
+  }
+
+  /**
+   * §9.3 Differential update: each entry is inserted/updated or, when
+   * `idTagInfo` is omitted, removed. `listVersion` MUST be strictly
+   * greater than the current version, otherwise the CP returns
+   * `VersionMismatch` and the list is left untouched.
+   */
+  applyDifferential(
+    listVersion: number,
+    items: SendLocalListItem[] | undefined,
+    limits: LocalAuthListLimits,
+  ): SendLocalListStatus {
+    if (listVersion <= this.version) {
+      this.logger.warn(
+        `SendLocalList Differential rejected: version ${listVersion} <= current ${this.version}`,
+        LogType.OCPP,
+      );
+      return "VersionMismatch";
+    }
+    const updates = items ?? [];
+    if (updates.length > limits.sendLocalListMaxLength) {
+      this.logger.warn(
+        `SendLocalList Differential rejected: ${updates.length} entries > SendLocalListMaxLength ${limits.sendLocalListMaxLength}`,
+        LogType.OCPP,
+      );
+      return "Failed";
+    }
+    // Apply to a working copy so we can roll back on overflow.
+    const draft = new Map(this.list);
+    for (const item of updates) {
+      if (item.idTagInfo) {
+        draft.set(item.idTag, { status: item.idTagInfo.status });
+      } else {
+        draft.delete(item.idTag);
+      }
+    }
+    if (draft.size > limits.localAuthListMaxLength) {
+      this.logger.warn(
+        `SendLocalList Differential rejected: post-merge size ${draft.size} > LocalAuthListMaxLength ${limits.localAuthListMaxLength}`,
+        LogType.OCPP,
+      );
+      return "Failed";
+    }
+    this.list = draft;
+    this.version = listVersion;
+    this.logger.info(
+      `Local auth list diff applied (version=${listVersion}, entries=${this.list.size})`,
+      LogType.OCPP,
+    );
+    return "Accepted";
+  }
+
+  dispose(): void {
+    this.list.clear();
+    this.version = 0;
+  }
+}

--- a/src/cp/domain/auth/__tests__/LocalAuthList.test.ts
+++ b/src/cp/domain/auth/__tests__/LocalAuthList.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { LocalAuthListManager } from "../LocalAuthList";
+import { Logger } from "../../../shared/Logger";
+
+const LIMITS = { localAuthListMaxLength: 100, sendLocalListMaxLength: 50 };
+
+function newManager(): LocalAuthListManager {
+  return new LocalAuthListManager(new Logger());
+}
+
+describe("LocalAuthListManager", () => {
+  let mgr: LocalAuthListManager;
+  beforeEach(() => {
+    mgr = newManager();
+  });
+
+  it("starts at version 0 with an empty list", () => {
+    expect(mgr.getVersion()).toBe(0);
+    expect(mgr.size()).toBe(0);
+  });
+
+  describe("Full update", () => {
+    it("replaces the list and sets the version", () => {
+      const status = mgr.applyFull(
+        5,
+        [
+          { idTag: "A", idTagInfo: { status: "Accepted" } },
+          { idTag: "B", idTagInfo: { status: "Blocked" } },
+        ],
+        LIMITS,
+      );
+      expect(status).toBe("Accepted");
+      expect(mgr.getVersion()).toBe(5);
+      expect(mgr.size()).toBe(2);
+      expect(mgr.getEntry("A")?.status).toBe("Accepted");
+      expect(mgr.getEntry("B")?.status).toBe("Blocked");
+    });
+
+    it("allows version to move backwards (spec permits)", () => {
+      mgr.applyFull(10, [], LIMITS);
+      const status = mgr.applyFull(3, [], LIMITS);
+      expect(status).toBe("Accepted");
+      expect(mgr.getVersion()).toBe(3);
+    });
+
+    it("rejects when entries exceed SendLocalListMaxLength", () => {
+      const items = Array.from({ length: 51 }, (_, i) => ({
+        idTag: `T${i}`,
+        idTagInfo: { status: "Accepted" as const },
+      }));
+      const status = mgr.applyFull(1, items, LIMITS);
+      expect(status).toBe("Failed");
+      expect(mgr.getVersion()).toBe(0); // unchanged
+    });
+
+    it("drops entries without idTagInfo", () => {
+      const status = mgr.applyFull(
+        1,
+        [
+          { idTag: "A", idTagInfo: { status: "Accepted" } },
+          { idTag: "B" }, // no info → omitted
+        ],
+        LIMITS,
+      );
+      expect(status).toBe("Accepted");
+      expect(mgr.size()).toBe(1);
+      expect(mgr.getEntry("A")).toBeDefined();
+      expect(mgr.getEntry("B")).toBeUndefined();
+    });
+  });
+
+  describe("Differential update", () => {
+    beforeEach(() => {
+      mgr.applyFull(
+        1,
+        [
+          { idTag: "A", idTagInfo: { status: "Accepted" } },
+          { idTag: "B", idTagInfo: { status: "Accepted" } },
+        ],
+        LIMITS,
+      );
+    });
+
+    it("rejects when version is not strictly greater than current", () => {
+      const status = mgr.applyDifferential(1, [], LIMITS);
+      expect(status).toBe("VersionMismatch");
+      expect(mgr.getVersion()).toBe(1);
+    });
+
+    it("upserts and deletes entries (omitted idTagInfo deletes)", () => {
+      const status = mgr.applyDifferential(
+        2,
+        [
+          { idTag: "A", idTagInfo: { status: "Blocked" } }, // update
+          { idTag: "B" }, // delete
+          { idTag: "C", idTagInfo: { status: "Accepted" } }, // insert
+        ],
+        LIMITS,
+      );
+      expect(status).toBe("Accepted");
+      expect(mgr.getVersion()).toBe(2);
+      expect(mgr.getEntry("A")?.status).toBe("Blocked");
+      expect(mgr.getEntry("B")).toBeUndefined();
+      expect(mgr.getEntry("C")?.status).toBe("Accepted");
+    });
+
+    it("rolls back when post-merge size exceeds LocalAuthListMaxLength", () => {
+      const tightLimits = {
+        localAuthListMaxLength: 2,
+        sendLocalListMaxLength: 50,
+      };
+      const status = mgr.applyDifferential(
+        2,
+        [{ idTag: "C", idTagInfo: { status: "Accepted" } }],
+        tightLimits,
+      );
+      expect(status).toBe("Failed");
+      expect(mgr.getVersion()).toBe(1); // unchanged
+      expect(mgr.getEntry("C")).toBeUndefined();
+    });
+  });
+
+  it("dispose clears state", () => {
+    mgr.applyFull(
+      7,
+      [{ idTag: "A", idTagInfo: { status: "Accepted" } }],
+      LIMITS,
+    );
+    mgr.dispose();
+    expect(mgr.size()).toBe(0);
+    expect(mgr.getVersion()).toBe(0);
+  });
+});

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -19,6 +19,9 @@ import {
 } from "../types/OcppTypes";
 import type { Transaction } from "../connector/Transaction";
 import { ReservationManager } from "../reservation/Reservation";
+import { LocalAuthListManager } from "../auth/LocalAuthList";
+import { ChargingProfileStore } from "./ChargingProfileStore";
+import type { ActiveChargingProfile } from "../connector/Connector";
 
 interface BasicAuthSettings {
   username: string;
@@ -43,6 +46,12 @@ export class ChargePoint {
   private readonly _stateManager: StateManager;
   private readonly _logRepository: LogRepository;
   private readonly _reservationManager: ReservationManager;
+  private readonly _localAuthListManager: LocalAuthListManager;
+  // §3.13.3: profiles installed with connectorId=0 (ChargePointMaxProfile,
+  // station-wide TxDefaultProfile) belong at the CP level, not duplicated
+  // onto every connector. Connectors consult this store at composite time.
+  private readonly _stationProfiles: ChargingProfileStore =
+    new ChargingProfileStore();
   private readonly _configuration: ConfigurationStore;
 
   // §7.7: connectorId=0 status MUST be Available / Unavailable / Faulted.
@@ -100,7 +109,11 @@ export class ChargePoint {
     };
 
     for (let connectorId = 1; connectorId <= connectorCount; connectorId++) {
-      const connector = new Connector(connectorId, this._logger);
+      const connector = new Connector(
+        connectorId,
+        this._logger,
+        () => this._stationProfiles,
+      );
       // §5.2: Unavailable set via ChangeAvailability persists across
       // reboots. Restore the persisted value before any event listeners
       // have a chance to react.
@@ -166,6 +179,7 @@ export class ChargePoint {
     );
 
     this._reservationManager = new ReservationManager(this._logger);
+    this._localAuthListManager = new LocalAuthListManager(this._logger);
 
     this._stateManager = new StateManager(
       this._logger,
@@ -383,6 +397,27 @@ export class ChargePoint {
     return this._reservationManager;
   }
 
+  get localAuthListManager(): LocalAuthListManager {
+    return this._localAuthListManager;
+  }
+
+  /** Read-only access for handlers and tests. SetChargingProfile /
+   *  ClearChargingProfile mutate this directly. */
+  get stationProfiles(): ChargingProfileStore {
+    return this._stationProfiles;
+  }
+
+  /** Convenience: the currently active ChargePointMaxProfile (highest
+   *  stackLevel) at the station level. Returns `null` if none. */
+  getActiveChargePointMaxProfile(
+    now: Date = new Date(),
+  ): ActiveChargingProfile | null {
+    return this._stationProfiles.getActive(
+      ChargingProfilePurposeType.ChargePointMaxProfile,
+      now,
+    );
+  }
+
   /**
    * Register a connector as being handled by a scenario.
    * When registered, RemoteStartTransaction handler will emit
@@ -541,6 +576,56 @@ export class ChargePoint {
     this._messageHandler.sendFirmwareStatusNotification(status);
   }
 
+  /** Set while a simulated firmware update is in flight, so a second
+   *  UpdateFirmware.req (the spec allows the CSMS to re-issue) doesn't
+   *  fork a parallel status train. */
+  private _firmwareUpdateInFlight = false;
+  /** Reference kept so disconnect/dispose can cancel a pending start
+   *  before `retrieveDate`. */
+  private _firmwareUpdateTimers: NodeJS.Timeout[] = [];
+
+  /**
+   * §4.5 / §6.19: schedule a simulated firmware update progression. After
+   * `retrieveDate` is reached, fires FirmwareStatusNotification.req in
+   * sequence — Downloading → Downloaded → Installing → Installed — with
+   * `intervalMs` between each transition.
+   *
+   * Real charge points download a binary, install it, and reboot. The
+   * simulator just walks the status machine so the CSMS observes the
+   * full happy-path. Failure paths (DownloadFailed / InstallationFailed)
+   * are reachable via TriggerMessage(FirmwareStatusNotification) for
+   * tests that want to drive them manually.
+   */
+  simulateFirmwareUpdate(retrieveDate: Date, intervalMs = 2000): void {
+    if (this._firmwareUpdateInFlight) {
+      this._logger.warn(
+        "UpdateFirmware: a previous simulated update is still in flight; ignoring",
+        LogType.OCPP,
+      );
+      return;
+    }
+    this._firmwareUpdateInFlight = true;
+
+    const startDelay = Math.max(0, retrieveDate.getTime() - Date.now());
+    const sequence: Array<
+      "Downloading" | "Downloaded" | "Installing" | "Installed"
+    > = ["Downloading", "Downloaded", "Installing", "Installed"];
+
+    const fireStep = (index: number) => {
+      if (index >= sequence.length) {
+        this._firmwareUpdateInFlight = false;
+        this._firmwareUpdateTimers = [];
+        return;
+      }
+      this.sendFirmwareStatusNotification(sequence[index]);
+      const t = setTimeout(() => fireStep(index + 1), intervalMs);
+      this._firmwareUpdateTimers.push(t);
+    };
+
+    const startTimer = setTimeout(() => fireStep(0), startDelay);
+    this._firmwareUpdateTimers.push(startTimer);
+  }
+
   /** Boot-notification gate accessors used by BootNotificationResultHandler. */
   markBootAccepted(): void {
     this._messageHandler.setBootStatus({ status: "Accepted" });
@@ -592,6 +677,13 @@ export class ChargePoint {
     this._heartbeat.cleanup();
     this._connectors.forEach((connector) => connector.cleanup());
     this._reservationManager.dispose();
+    this._localAuthListManager.dispose();
+    this._stationProfiles.clear();
+    // Cancel any pending firmware-update simulation so its status train
+    // doesn't keep firing against a dead WebSocket.
+    this._firmwareUpdateTimers.forEach((t) => clearTimeout(t));
+    this._firmwareUpdateTimers = [];
+    this._firmwareUpdateInFlight = false;
     this._scenarioHandledConnectors.clear();
     this._scenarioStopHandledConnectors.clear();
     // Cancel all ConnectionTimeOut watchdogs so the timer doesn't fire

--- a/src/cp/domain/charge-point/ChargingProfileStore.ts
+++ b/src/cp/domain/charge-point/ChargingProfileStore.ts
@@ -1,0 +1,92 @@
+import type { ActiveChargingProfile } from "../connector/Connector";
+import type { ChargingProfilePurposeType } from "../types/OcppTypes";
+
+export interface ProfileRemoveCriteria {
+  profileId?: number;
+  purpose?: ChargingProfilePurposeType;
+  stackLevel?: number;
+}
+
+/**
+ * Holds charging profiles that apply at the charge-point (station) level
+ * rather than to a specific connector. Per OCPP 1.6 §3.13.3 these are the
+ * profiles a CSMS installs by sending `SetChargingProfile.req` with
+ * `connectorId = 0`:
+ *
+ * - `ChargePointMaxProfile`: an overall cap on the station's total draw
+ *   that combines (via `min`) with per-connector Tx layers.
+ * - `TxDefaultProfile` (connectorId = 0): a station-wide default Tx layer
+ *   used by any connector that doesn't have its own `TxDefaultProfile`.
+ *
+ * The store is intentionally minimal — same Map+filter shape used by
+ * `Connector._chargingProfiles`. Keeping the storage symmetric makes the
+ * composite-schedule code that has to walk both layers easier to read.
+ */
+export class ChargingProfileStore {
+  private profiles: ActiveChargingProfile[] = [];
+
+  add(profile: ActiveChargingProfile): void {
+    // Same-id replacement matches Connector.addChargingProfile semantics
+    // (§5.16: SetChargingProfile.req with an existing chargingProfileId
+    // is an update, not an insert).
+    this.profiles = this.profiles.filter(
+      (p) => p.chargingProfileId !== profile.chargingProfileId,
+    );
+    this.profiles.push(profile);
+  }
+
+  remove(criteria: ProfileRemoveCriteria): number {
+    const before = this.profiles.length;
+    this.profiles = this.profiles.filter((profile) => {
+      if (
+        criteria.profileId != null &&
+        profile.chargingProfileId !== criteria.profileId
+      ) {
+        return true;
+      }
+      if (
+        criteria.purpose != null &&
+        profile.chargingProfilePurpose !== criteria.purpose
+      ) {
+        return true;
+      }
+      if (
+        criteria.stackLevel != null &&
+        profile.stackLevel !== criteria.stackLevel
+      ) {
+        return true;
+      }
+      return false;
+    });
+    return before - this.profiles.length;
+  }
+
+  clear(): void {
+    this.profiles = [];
+  }
+
+  all(): ActiveChargingProfile[] {
+    return [...this.profiles];
+  }
+
+  /**
+   * Highest-stackLevel, currently-valid profile matching the given
+   * purpose. Returns `null` if none. Validity respects `validFrom` /
+   * `validTo` if set; missing bounds count as "always valid" on that side.
+   */
+  getActive(
+    purpose: ChargingProfilePurposeType,
+    now: Date = new Date(),
+  ): ActiveChargingProfile | null {
+    const candidates = this.profiles.filter((p) => {
+      if (p.chargingProfilePurpose !== purpose) return false;
+      if (p.validFrom && new Date(p.validFrom) > now) return false;
+      if (p.validTo && new Date(p.validTo) < now) return false;
+      return true;
+    });
+    if (candidates.length === 0) return null;
+    return candidates.reduce((best, c) =>
+      c.stackLevel > best.stackLevel ? c : best,
+    );
+  }
+}

--- a/src/cp/domain/charge-point/Configuration.ts
+++ b/src/cp/domain/charge-point/Configuration.ts
@@ -458,6 +458,8 @@ export const defaultConfiguration: (cp: ChargePoint) => Configuration = (
     intVal(ConfigurationKeys.Core.StopTxnSampledDataMaxLength, 8),
     arrVal(ConfigurationKeys.Core.SupportedFeatureProfiles, [
       OcppFeatureProfile.Core,
+      OcppFeatureProfile.FirmwareManagement,
+      OcppFeatureProfile.LocalAuthListManagement,
       OcppFeatureProfile.Reservation,
       OcppFeatureProfile.SmartCharging,
       OcppFeatureProfile.RemoteTrigger,
@@ -467,6 +469,20 @@ export const defaultConfiguration: (cp: ChargePoint) => Configuration = (
     intVal(ConfigurationKeys.Core.TransactionMessageRetryInterval, 60),
     boolVal(ConfigurationKeys.Core.UnlockConnectorOnEVSideDisconnect, true),
     intVal(ConfigurationKeys.Core.WebSocketPingInterval, 0),
+
+    // ── LocalAuthListManagement profile ────────────────────────────────
+    boolVal(
+      ConfigurationKeys.LocalAuthListManagement.LocalAuthListEnabled,
+      true,
+    ),
+    intVal(
+      ConfigurationKeys.LocalAuthListManagement.LocalAuthListMaxLength,
+      1000,
+    ),
+    intVal(
+      ConfigurationKeys.LocalAuthListManagement.SendLocalListMaxLength,
+      100,
+    ),
 
     // ── Reservation profile ────────────────────────────────────────────
     boolVal(ConfigurationKeys.Reservation.ReserveConnectorZeroSupported, false),

--- a/src/cp/domain/charge-point/__tests__/ChargingProfileStore.test.ts
+++ b/src/cp/domain/charge-point/__tests__/ChargingProfileStore.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { ChargingProfileStore } from "../ChargingProfileStore";
+import type { ActiveChargingProfile } from "../../connector/Connector";
+import {
+  ChargingProfileKindType,
+  ChargingProfilePurposeType,
+  ChargingRateUnitType,
+} from "../../types/OcppTypes";
+
+function profile(
+  over: Partial<ActiveChargingProfile> = {},
+): ActiveChargingProfile {
+  return {
+    chargingProfileId: 1,
+    connectorId: 0,
+    stackLevel: 0,
+    chargingProfilePurpose: ChargingProfilePurposeType.ChargePointMaxProfile,
+    chargingProfileKind: ChargingProfileKindType.Absolute,
+    chargingRateUnit: ChargingRateUnitType.W,
+    chargingSchedulePeriods: [{ startPeriod: 0, limit: 5000 }],
+    ...over,
+  };
+}
+
+describe("ChargingProfileStore", () => {
+  it("starts empty", () => {
+    const store = new ChargingProfileStore();
+    expect(store.all()).toEqual([]);
+    expect(
+      store.getActive(ChargingProfilePurposeType.ChargePointMaxProfile),
+    ).toBeNull();
+  });
+
+  it("replaces a profile with the same id (§5.16)", () => {
+    const store = new ChargingProfileStore();
+    store.add(profile({ chargingProfileId: 7, stackLevel: 1 }));
+    store.add(
+      profile({ chargingProfileId: 7, stackLevel: 5 }), // same id, new stack
+    );
+    expect(store.all()).toHaveLength(1);
+    expect(store.all()[0].stackLevel).toBe(5);
+  });
+
+  it("returns the highest-stack profile for a purpose", () => {
+    const store = new ChargingProfileStore();
+    store.add(profile({ chargingProfileId: 1, stackLevel: 1 }));
+    store.add(profile({ chargingProfileId: 2, stackLevel: 9 }));
+    store.add(profile({ chargingProfileId: 3, stackLevel: 4 }));
+    const active = store.getActive(
+      ChargingProfilePurposeType.ChargePointMaxProfile,
+    );
+    expect(active?.chargingProfileId).toBe(2);
+  });
+
+  it("filters by purpose", () => {
+    const store = new ChargingProfileStore();
+    store.add(profile({ chargingProfileId: 1, stackLevel: 9 }));
+    store.add(
+      profile({
+        chargingProfileId: 2,
+        stackLevel: 5,
+        chargingProfilePurpose: ChargingProfilePurposeType.TxDefaultProfile,
+      }),
+    );
+    expect(
+      store.getActive(ChargingProfilePurposeType.TxDefaultProfile)
+        ?.chargingProfileId,
+    ).toBe(2);
+  });
+
+  it("ignores profiles outside their validity window", () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const store = new ChargingProfileStore();
+    store.add(profile({ chargingProfileId: 1, validTo: past }));
+    expect(
+      store.getActive(ChargingProfilePurposeType.ChargePointMaxProfile),
+    ).toBeNull();
+  });
+
+  describe("remove", () => {
+    it("removes by profileId", () => {
+      const store = new ChargingProfileStore();
+      store.add(profile({ chargingProfileId: 1 }));
+      store.add(profile({ chargingProfileId: 2 }));
+      expect(store.remove({ profileId: 1 })).toBe(1);
+      expect(store.all()).toHaveLength(1);
+    });
+
+    it("removes by purpose", () => {
+      const store = new ChargingProfileStore();
+      store.add(profile({ chargingProfileId: 1 }));
+      store.add(
+        profile({
+          chargingProfileId: 2,
+          chargingProfilePurpose: ChargingProfilePurposeType.TxDefaultProfile,
+        }),
+      );
+      expect(
+        store.remove({ purpose: ChargingProfilePurposeType.TxDefaultProfile }),
+      ).toBe(1);
+      expect(store.all()).toHaveLength(1);
+    });
+
+    it("clears all when called with no criteria", () => {
+      const store = new ChargingProfileStore();
+      store.add(profile({ chargingProfileId: 1 }));
+      store.add(profile({ chargingProfileId: 2 }));
+      expect(store.remove({})).toBe(2);
+      expect(store.all()).toEqual([]);
+    });
+  });
+});

--- a/src/cp/domain/connector/ChargingScheduleResolver.ts
+++ b/src/cp/domain/connector/ChargingScheduleResolver.ts
@@ -156,3 +156,197 @@ export function resolveScheduleLimitWatts(
     unit: profile.chargingRateUnit,
   };
 }
+
+/**
+ * §3.13.3 combined limit for a connector:
+ *
+ *   effective = min(connector's Tx-layer profile, ChargePointMaxProfile)
+ *
+ * Either side may be `null`; an absent profile contributes `Infinity` and
+ * is therefore ignored by `min`. When both sides are absent the result is
+ * `UNCAPPED`.
+ *
+ * The returned `profileId` / `periodIndex` come from whichever side is
+ * tighter (so logs show which profile actually constrained the draw).
+ */
+export function resolveEffectiveLimitWatts(
+  txProfile: ActiveChargingProfile | null,
+  chargePointMaxProfile: ActiveChargingProfile | null,
+  transactionStart: Date | null,
+  now: Date = new Date(),
+): ResolvedScheduleLimit {
+  const tx = resolveScheduleLimitWatts(txProfile, transactionStart, now);
+  const cap = resolveScheduleLimitWatts(
+    chargePointMaxProfile,
+    transactionStart,
+    now,
+  );
+  if (tx.watts === Infinity && cap.watts === Infinity) return UNCAPPED;
+  // The tighter side wins. Equal watts → prefer the tx side (more
+  // specific) for the metadata.
+  if (cap.watts < tx.watts) return cap;
+  return tx;
+}
+
+// ─── Composite schedule (GetCompositeSchedule.req) ───────────────────────
+
+export interface CompositePeriod {
+  startPeriod: number;
+  /** Watts. `Infinity` means "uncapped" — the caller should skip emitting
+   *  a ChargingSchedulePeriod for this slice, since OCPP has no encoding
+   *  for "no limit". */
+  watts: number;
+}
+
+export interface CompositeInput {
+  /**
+   * Tx-layer profile to apply across the duration. For a connector-scoped
+   * composite this is `connector.getActiveChargingProfile()`. For
+   * connectorId=0 composites the caller passes the SUM-of-connectors
+   * pseudo-profile — currently we approximate that by passing the highest
+   * connector Tx (simulator does not model multiple parallel sessions for
+   * total-power purposes).
+   */
+  txProfile: ActiveChargingProfile | null;
+  /** The station-wide ChargePointMaxProfile, if any. */
+  chargePointMaxProfile: ActiveChargingProfile | null;
+}
+
+/**
+ * Build a composite schedule over `[anchor, anchor + duration)`.
+ *
+ * Algorithm:
+ *   1. Project each input profile onto absolute-time period boundaries
+ *      inside the window. For Recurring profiles we expand cycles within
+ *      `duration` (so a Daily profile contributes its 24-hour period set
+ *      at every 24-hour offset that lands in the window).
+ *   2. Walk the merged sorted boundary set. At each boundary compute the
+ *      effective `min` across the inputs that are "live" at that instant.
+ *   3. Collapse consecutive identical limits to keep the period count
+ *      small (CSMSs commonly cap this around `ChargingScheduleMaxPeriods`).
+ *
+ * Output watts are clamped to `0..Infinity`. The CompositePeriod with
+ * `watts === Infinity` is emitted; the SmartCharging handler decides
+ * whether to skip those when serializing to ChargingSchedulePeriod[] (the
+ * OCPP type has no "uncapped" encoding).
+ */
+export function buildCompositeWattsSchedule(
+  inputs: CompositeInput,
+  anchor: Date,
+  durationSeconds: number,
+): CompositePeriod[] {
+  const profiles: ActiveChargingProfile[] = [];
+  if (inputs.txProfile) profiles.push(inputs.txProfile);
+  if (inputs.chargePointMaxProfile) profiles.push(inputs.chargePointMaxProfile);
+  if (profiles.length === 0) return [];
+
+  // Collect boundary offsets (seconds since anchor) where the effective
+  // limit could change. We seed with 0 to ensure at least one slice; the
+  // window-end at `duration` bounds the last slice but is not emitted.
+  const boundaries = new Set<number>([0]);
+  for (const profile of profiles) {
+    addProfileBoundaries(profile, anchor, durationSeconds, boundaries);
+  }
+  const sorted = Array.from(boundaries)
+    .filter((s) => s >= 0 && s < durationSeconds)
+    .sort((a, b) => a - b);
+
+  // Compute effective limit at each boundary.
+  const slices: CompositePeriod[] = [];
+  for (const startPeriod of sorted) {
+    const at = new Date(anchor.getTime() + startPeriod * 1000);
+    let limit = Infinity;
+    for (const profile of profiles) {
+      // For Recurring/Absolute kinds the resolver walks elapsed time from
+      // the profile's reference; for Relative it's elapsed from the
+      // anchor (we treat the composite anchor as the transaction start).
+      const r = resolveScheduleLimitWatts(profile, anchor, at);
+      if (r.watts < limit) limit = r.watts;
+    }
+    if (slices.length === 0 || slices[slices.length - 1].watts !== limit) {
+      slices.push({ startPeriod, watts: limit });
+    }
+  }
+  return slices;
+}
+
+/**
+ * Push boundary offsets (relative to `anchor`, in seconds) where the given
+ * profile's period selection could change inside `[0, duration)`.
+ *
+ * - `Absolute` / `Relative`: each `startPeriod` (validated against the
+ *   profile's reference instant) translates to an offset from `anchor`.
+ * - `Recurring`: we expand the period set across every cycle that
+ *   intersects the window.
+ *
+ * Defensive: profiles with no periods, periods past `duration`, or with
+ * insane start offsets are silently dropped here — the resolver still
+ * treats them as uncapped on lookup.
+ */
+function addProfileBoundaries(
+  profile: ActiveChargingProfile,
+  anchor: Date,
+  durationSeconds: number,
+  out: Set<number>,
+): void {
+  const periods = profile.chargingSchedulePeriods;
+  if (periods.length === 0) return;
+  const sorted = [...periods].sort((a, b) => a.startPeriod - b.startPeriod);
+
+  // Profile reference instant in ms — see elapsedSecondsForProfile.
+  const refMs = profileReferenceMs(profile, anchor);
+  const anchorMs = anchor.getTime();
+
+  if (profile.chargingProfileKind === ChargingProfileKindType.Recurring) {
+    const cycleSec =
+      profile.recurrencyKind === RecurrencyKindType.Weekly
+        ? 7 * 24 * 3600
+        : 24 * 3600;
+    // First cycle that touches [anchorMs, anchorMs + durationSeconds).
+    let cycleStartMs = refMs;
+    if (cycleStartMs > anchorMs) {
+      // Profile's first cycle hasn't started yet; nothing to emit until
+      // it does.
+      cycleStartMs = anchorMs; // walked forward below
+    } else {
+      const cyclesElapsed = Math.floor(
+        (anchorMs - cycleStartMs) / 1000 / cycleSec,
+      );
+      cycleStartMs = refMs + cyclesElapsed * cycleSec * 1000;
+    }
+    while (cycleStartMs < anchorMs + durationSeconds * 1000) {
+      for (const p of sorted) {
+        const offset = (cycleStartMs - anchorMs) / 1000 + p.startPeriod;
+        if (offset >= 0 && offset < durationSeconds) out.add(offset);
+      }
+      cycleStartMs += cycleSec * 1000;
+    }
+    return;
+  }
+
+  // Absolute / Relative: each startPeriod is an offset from `refMs`.
+  for (const p of sorted) {
+    const offset = (refMs - anchorMs) / 1000 + p.startPeriod;
+    if (offset >= 0 && offset < durationSeconds) out.add(offset);
+  }
+}
+
+function profileReferenceMs(
+  profile: ActiveChargingProfile,
+  anchor: Date,
+): number {
+  switch (profile.chargingProfileKind) {
+    case ChargingProfileKindType.Relative:
+      return anchor.getTime();
+    case ChargingProfileKindType.Absolute:
+    case ChargingProfileKindType.Recurring: {
+      if (profile.validFrom) {
+        const ms = new Date(profile.validFrom).getTime();
+        if (!Number.isNaN(ms)) return ms;
+      }
+      return anchor.getTime();
+    }
+    default:
+      return anchor.getTime();
+  }
+}

--- a/src/cp/domain/connector/Connector.ts
+++ b/src/cp/domain/connector/Connector.ts
@@ -24,7 +24,8 @@ import {
 } from "../../application/scenario/ScenarioTypes";
 import { Transaction } from "./Transaction";
 import { type EVSettings, getDefaultEVSettings } from "./EVSettings";
-import { resolveScheduleLimitWatts } from "./ChargingScheduleResolver";
+import { resolveEffectiveLimitWatts } from "./ChargingScheduleResolver";
+import type { ChargingProfileStore } from "../charge-point/ChargingProfileStore";
 
 export interface ChargingSchedulePeriod {
   startPeriod: number;
@@ -227,10 +228,23 @@ export class Connector {
     this.lastAutoStartedScenarioKeyValue = snapshot.lastAutoStartedScenarioKey;
   }
 
+  /**
+   * Lazy getter for the parent ChargePoint's `ChargingProfileStore`. We
+   * take a closure rather than a direct reference because the connector
+   * is constructed inside the ChargePoint's loop, and the store is a
+   * `this`-owned field that would force a temporal-dead-zone dance if
+   * we passed it eagerly. The closure is also nullable for the benefit
+   * of tests that construct a bare Connector without a ChargePoint —
+   * those just see an empty station store.
+   */
+  private readonly stationProfilesProvider: () => ChargingProfileStore | null;
+
   constructor(
     private readonly connectorId: number,
     private readonly logger: Logger,
+    stationProfilesProvider?: () => ChargingProfileStore | null,
   ) {
+    this.stationProfilesProvider = stationProfilesProvider ?? (() => null);
     this.meterScheduler = new MeterValueScheduler(
       connectorId,
       {
@@ -262,9 +276,13 @@ export class Connector {
    * without needing an extra timer.
    */
   currentScheduleLimitWatts(): number {
-    const profile = this.getActiveChargingProfile();
+    const txProfile = this.getActiveChargingProfile();
+    const stationMax =
+      this.stationProfilesProvider()?.getActive(
+        ChargingProfilePurposeType.ChargePointMaxProfile,
+      ) ?? null;
     const start = this.transactionValue?.startTime ?? null;
-    const resolved = resolveScheduleLimitWatts(profile, start);
+    const resolved = resolveEffectiveLimitWatts(txProfile, stationMax, start);
     const paused = resolved.watts === 0;
     const isCapped = resolved.watts !== Infinity;
     if (
@@ -469,29 +487,62 @@ export class Connector {
   }
 
   /**
-   * Get the currently active charging profile (highest valid stack level)
-   * Returns null if no valid profiles exist.
+   * Resolve the connector's currently active **Tx-layer** charging profile
+   * per OCPP 1.6 §3.13.3 precedence rules:
+   *
+   *   1. The connector's own TxProfile (highest valid stackLevel) — if
+   *      one exists it completely overrules anything else at the Tx layer.
+   *   2. Otherwise, the highest valid TxDefaultProfile among:
+   *        - this connector's own TxDefaultProfile(s), and
+   *        - the station-wide TxDefaultProfile(s) (installed by the CSMS
+   *          via SetChargingProfile.req with connectorId=0).
+   *
+   * The ChargePointMaxProfile lives separately on the ChargePoint and is
+   * combined with this result via `min` inside the resolver.
+   *
+   * Returns `null` when no Tx-layer profile applies.
    */
-  getActiveChargingProfile(): ActiveChargingProfile | null {
-    const now = new Date();
-    const validProfiles = this._chargingProfiles.filter((profile) => {
-      // Check validity period
-      if (profile.validFrom && new Date(profile.validFrom) > now) {
-        return false;
-      }
-      if (profile.validTo && new Date(profile.validTo) < now) {
-        return false;
-      }
+  getActiveChargingProfile(
+    now: Date = new Date(),
+  ): ActiveChargingProfile | null {
+    const isValid = (profile: ActiveChargingProfile) => {
+      if (profile.validFrom && new Date(profile.validFrom) > now) return false;
+      if (profile.validTo && new Date(profile.validTo) < now) return false;
       return true;
-    });
+    };
 
-    if (validProfiles.length === 0) {
-      return null;
+    // Tier 1: TxProfile on this connector wins outright (§3.13.3).
+    const txProfiles = this._chargingProfiles.filter(
+      (p) =>
+        p.chargingProfilePurpose === ChargingProfilePurposeType.TxProfile &&
+        isValid(p),
+    );
+    if (txProfiles.length > 0) {
+      return txProfiles.reduce((best, c) =>
+        c.stackLevel > best.stackLevel ? c : best,
+      );
     }
 
-    // Return profile with highest stack level
-    return validProfiles.reduce((highest, current) =>
-      current.stackLevel > highest.stackLevel ? current : highest,
+    // Tier 2: TxDefaultProfile — connector-own and station-wide compete
+    // by stackLevel. (If a CSMS wants connector defaults to always win
+    // over station defaults, it sets them at a higher stackLevel.)
+    const ownDefaults = this._chargingProfiles.filter(
+      (p) =>
+        p.chargingProfilePurpose ===
+          ChargingProfilePurposeType.TxDefaultProfile && isValid(p),
+    );
+    const stationDefaults =
+      this.stationProfilesProvider()
+        ?.all()
+        .filter(
+          (p) =>
+            p.chargingProfilePurpose ===
+              ChargingProfilePurposeType.TxDefaultProfile && isValid(p),
+        ) ?? [];
+    const defaults = [...ownDefaults, ...stationDefaults];
+    if (defaults.length === 0) return null;
+    return defaults.reduce((best, c) =>
+      c.stackLevel > best.stackLevel ? c : best,
     );
   }
 

--- a/src/cp/domain/connector/__tests__/CompositeSchedule.test.ts
+++ b/src/cp/domain/connector/__tests__/CompositeSchedule.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildCompositeWattsSchedule,
+  resolveEffectiveLimitWatts,
+} from "../ChargingScheduleResolver";
+import type { ActiveChargingProfile } from "../Connector";
+import {
+  ChargingProfileKindType,
+  ChargingProfilePurposeType,
+  ChargingRateUnitType,
+  RecurrencyKindType,
+} from "../../types/OcppTypes";
+
+function profile(
+  over: Partial<ActiveChargingProfile> = {},
+): ActiveChargingProfile {
+  return {
+    chargingProfileId: 1,
+    connectorId: 1,
+    stackLevel: 0,
+    chargingProfilePurpose: ChargingProfilePurposeType.TxProfile,
+    chargingProfileKind: ChargingProfileKindType.Relative,
+    chargingRateUnit: ChargingRateUnitType.W,
+    chargingSchedulePeriods: [{ startPeriod: 0, limit: 7000 }],
+    ...over,
+  };
+}
+
+describe("resolveEffectiveLimitWatts", () => {
+  const start = new Date("2026-01-01T00:00:00Z");
+  const now = new Date("2026-01-01T00:00:30Z");
+
+  it("returns the tx limit when no station max profile is present", () => {
+    const tx = profile({
+      chargingSchedulePeriods: [{ startPeriod: 0, limit: 6000 }],
+    });
+    const res = resolveEffectiveLimitWatts(tx, null, start, now);
+    expect(res.watts).toBe(6000);
+    expect(res.profileId).toBe(tx.chargingProfileId);
+  });
+
+  it("returns the station max when it is tighter than tx", () => {
+    const tx = profile({
+      chargingProfileId: 1,
+      chargingSchedulePeriods: [{ startPeriod: 0, limit: 10_000 }],
+    });
+    const cap = profile({
+      chargingProfileId: 99,
+      chargingProfilePurpose: ChargingProfilePurposeType.ChargePointMaxProfile,
+      chargingSchedulePeriods: [{ startPeriod: 0, limit: 4_000 }],
+    });
+    const res = resolveEffectiveLimitWatts(tx, cap, start, now);
+    expect(res.watts).toBe(4_000);
+    expect(res.profileId).toBe(99);
+  });
+
+  it("uncapped when neither side provides a limit", () => {
+    const res = resolveEffectiveLimitWatts(null, null, start, now);
+    expect(res.watts).toBe(Infinity);
+  });
+
+  it("falls back to the station max alone when no tx profile", () => {
+    const cap = profile({
+      chargingProfileId: 99,
+      chargingProfilePurpose: ChargingProfilePurposeType.ChargePointMaxProfile,
+      chargingSchedulePeriods: [{ startPeriod: 0, limit: 4_000 }],
+    });
+    const res = resolveEffectiveLimitWatts(null, cap, start, now);
+    expect(res.watts).toBe(4_000);
+  });
+});
+
+describe("buildCompositeWattsSchedule", () => {
+  const anchor = new Date("2026-01-01T00:00:00Z");
+
+  it("emits an empty schedule when no profiles are supplied", () => {
+    const result = buildCompositeWattsSchedule(
+      { txProfile: null, chargePointMaxProfile: null },
+      anchor,
+      3600,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("emits a single period when only the tx profile is present", () => {
+    const tx = profile({
+      chargingSchedulePeriods: [
+        { startPeriod: 0, limit: 5000 },
+        { startPeriod: 1800, limit: 3000 },
+      ],
+    });
+    const result = buildCompositeWattsSchedule(
+      { txProfile: tx, chargePointMaxProfile: null },
+      anchor,
+      3600,
+    );
+    expect(result).toEqual([
+      { startPeriod: 0, watts: 5000 },
+      { startPeriod: 1800, watts: 3000 },
+    ]);
+  });
+
+  it("takes the min across tx + ChargePointMaxProfile per slice", () => {
+    const tx = profile({
+      chargingSchedulePeriods: [
+        { startPeriod: 0, limit: 10_000 },
+        { startPeriod: 1800, limit: 2_000 },
+      ],
+    });
+    const cap = profile({
+      chargingProfilePurpose: ChargingProfilePurposeType.ChargePointMaxProfile,
+      chargingSchedulePeriods: [
+        { startPeriod: 0, limit: 6_000 },
+        { startPeriod: 900, limit: 4_000 },
+      ],
+    });
+    const result = buildCompositeWattsSchedule(
+      { txProfile: tx, chargePointMaxProfile: cap },
+      anchor,
+      3600,
+    );
+    // Expected boundaries: 0, 900, 1800. At each:
+    //   0    → min(10000, 6000) = 6000
+    //   900  → min(10000, 4000) = 4000
+    //   1800 → min( 2000, 4000) = 2000
+    expect(result).toEqual([
+      { startPeriod: 0, watts: 6000 },
+      { startPeriod: 900, watts: 4000 },
+      { startPeriod: 1800, watts: 2000 },
+    ]);
+  });
+
+  it("collapses consecutive identical limits", () => {
+    const tx = profile({
+      chargingSchedulePeriods: [
+        { startPeriod: 0, limit: 5000 },
+        { startPeriod: 1800, limit: 5000 }, // same limit → should merge
+      ],
+    });
+    const result = buildCompositeWattsSchedule(
+      { txProfile: tx, chargePointMaxProfile: null },
+      anchor,
+      3600,
+    );
+    expect(result).toEqual([{ startPeriod: 0, watts: 5000 }]);
+  });
+
+  it("expands a Recurring Daily profile across the window", () => {
+    // Daily profile anchored at midnight; window starts 12h in, runs 36h.
+    const cap = profile({
+      chargingProfilePurpose: ChargingProfilePurposeType.ChargePointMaxProfile,
+      chargingProfileKind: ChargingProfileKindType.Recurring,
+      recurrencyKind: RecurrencyKindType.Daily,
+      validFrom: anchor.toISOString(),
+      chargingSchedulePeriods: [
+        { startPeriod: 0, limit: 5000 }, // 00:00–06:00 each day
+        { startPeriod: 6 * 3600, limit: 10_000 }, // 06:00–24:00 each day
+      ],
+    });
+    const windowStart = new Date(anchor.getTime() + 12 * 3600 * 1000);
+    const result = buildCompositeWattsSchedule(
+      { txProfile: null, chargePointMaxProfile: cap },
+      windowStart,
+      36 * 3600,
+    );
+    // We expect boundaries at the daily cycle restarts: 12h (anchor=0
+    // already there), then 12h+12h=24h offset where the next day's
+    // 00:00→06:00 slot starts again.
+    const offsets = result.map((p) => p.startPeriod);
+    expect(offsets).toContain(0); // anchor
+    // Next-day 00:00 lands at offset 12h
+    expect(offsets).toContain(12 * 3600);
+    // Day-2 06:00 lands at offset 12h + 6h = 18h
+    expect(offsets).toContain(18 * 3600);
+  });
+});

--- a/src/cp/domain/types/OcppTypes.ts
+++ b/src/cp/domain/types/OcppTypes.ts
@@ -123,15 +123,15 @@ export enum OCPPAction {
   UnlockConnector = "UnlockConnector",
   // FirmwareManagement actions
   GetDiagnostics = "GetDiagnostics",
-  DiagnosticsStatusNotification = "DiagnosticsStatusNotification", // TODO
-  FirmwareStatusNotification = "FirmwareStatusNotification", // TODO
-  UpdateFirmware = "UpdateFirmware", // TODO
+  DiagnosticsStatusNotification = "DiagnosticsStatusNotification",
+  FirmwareStatusNotification = "FirmwareStatusNotification",
+  UpdateFirmware = "UpdateFirmware",
   // LocalAuthListManagement actions
-  GetLocalListVersion = "GetLocalListVersion", // TODO
-  SendLocalList = "SendLocalList", // TODO
+  GetLocalListVersion = "GetLocalListVersion",
+  SendLocalList = "SendLocalList",
   // Reservation actions
-  CancelReservation = "CancelReservation", // TODO
-  ReserveNow = "ReserveNow", // TODO
+  CancelReservation = "CancelReservation",
+  ReserveNow = "ReserveNow",
   // SmartCharging actions
   ClearChargingProfile = "ClearChargingProfile",
   GetCompositeSchedule = "GetCompositeSchedule",

--- a/src/cp/infrastructure/transport/OCPPMessageHandler.ts
+++ b/src/cp/infrastructure/transport/OCPPMessageHandler.ts
@@ -53,6 +53,9 @@ import {
   DataTransferResultHandler,
   DataTransferHandler,
   ChangeAvailabilityHandler,
+  GetLocalListVersionHandler,
+  SendLocalListHandler,
+  UpdateFirmwareHandler,
 } from "./handlers";
 
 type CoreOcppMessagePayloadCall =
@@ -288,6 +291,23 @@ export class OCPPMessageHandler {
     this._registry.registerCallHandler(
       OCPPAction.ChangeAvailability,
       new ChangeAvailabilityHandler(),
+    );
+    // §9 LocalAuthListManagement
+    this._registry.registerCallHandler(
+      OCPPAction.GetLocalListVersion,
+      new GetLocalListVersionHandler(),
+    );
+    this._registry.registerCallHandler(
+      OCPPAction.SendLocalList,
+      new SendLocalListHandler(),
+    );
+    // §6.19 FirmwareManagement: UpdateFirmware. (GetDiagnostics is
+    // registered above; the matching outbound status notifications fire
+    // from inside ChargePoint.simulateFirmwareUpdate / the GetDiagnostics
+    // handler — there is no CALLRESULT counterpart to register.)
+    this._registry.registerCallHandler(
+      OCPPAction.UpdateFirmware,
+      new UpdateFirmwareHandler(),
     );
 
     // Register CALLRESULT handlers (incoming responses from central system)

--- a/src/cp/infrastructure/transport/handlers/MessageHandlerRegistry.ts
+++ b/src/cp/infrastructure/transport/handlers/MessageHandlerRegistry.ts
@@ -30,15 +30,11 @@ export interface CallResultHandler<TPayload = unknown> {
  * Registry for message handlers using Strategy Pattern
  */
 export class MessageHandlerRegistry {
-  private callHandlers: Map<
-    OCPPAction,
-    CallHandler<unknown, unknown>
-  > = new Map();
+  private callHandlers: Map<OCPPAction, CallHandler<unknown, unknown>> =
+    new Map();
 
-  private callResultHandlers: Map<
-    OCPPAction,
-    CallResultHandler<unknown>
-  > = new Map();
+  private callResultHandlers: Map<OCPPAction, CallResultHandler<unknown>> =
+    new Map();
 
   /**
    * Register a handler for CALL messages (incoming requests)
@@ -57,16 +53,15 @@ export class MessageHandlerRegistry {
     action: OCPPAction,
     handler: CallResultHandler<TPayload>,
   ): void {
-    this.callResultHandlers.set(
-      action,
-      handler as CallResultHandler<unknown>,
-    );
+    this.callResultHandlers.set(action, handler as CallResultHandler<unknown>);
   }
 
   /**
    * Get handler for CALL messages
    */
-  getCallHandler(action: OCPPAction): CallHandler<unknown, unknown> | undefined {
+  getCallHandler(
+    action: OCPPAction,
+  ): CallHandler<unknown, unknown> | undefined {
     return this.callHandlers.get(action);
   }
 
@@ -104,10 +99,7 @@ export type CallHandlerMap = {
     request.RemoteStopTransactionRequest,
     response.RemoteStopTransactionResponse
   >;
-  [OCPPAction.Reset]: CallHandler<
-    request.ResetRequest,
-    response.ResetResponse
-  >;
+  [OCPPAction.Reset]: CallHandler<request.ResetRequest, response.ResetResponse>;
   [OCPPAction.GetDiagnostics]: CallHandler<
     request.GetDiagnosticsRequest,
     response.GetDiagnosticsResponse
@@ -139,6 +131,18 @@ export type CallHandlerMap = {
   [OCPPAction.CancelReservation]: CallHandler<
     request.CancelReservationRequest,
     response.CancelReservationResponse
+  >;
+  [OCPPAction.GetLocalListVersion]: CallHandler<
+    request.GetLocalListVersionRequest,
+    response.GetLocalListVersionResponse
+  >;
+  [OCPPAction.SendLocalList]: CallHandler<
+    request.SendLocalListRequest,
+    response.SendLocalListResponse
+  >;
+  [OCPPAction.UpdateFirmware]: CallHandler<
+    request.UpdateFirmwareRequest,
+    response.UpdateFirmwareResponse
   >;
 };
 

--- a/src/cp/infrastructure/transport/handlers/call/GetDiagnosticsHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/GetDiagnosticsHandler.ts
@@ -4,23 +4,61 @@ import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
 import { UploadFile } from "../../../file_upload";
 import { LogType } from "../../../../shared/Logger";
 
+/**
+ * §4.4 + §6.7 GetDiagnostics.req: the CALLRESULT returns the upload's
+ * target filename, then the CP follows up with a DiagnosticsStatusNotification
+ * train — `Uploading` while the POST is in flight, then `Uploaded` /
+ * `UploadFailed` on resolution. The actual upload uses
+ * `UploadFile(location, file)` which POSTs a multipart form to whatever
+ * URL the CSMS supplied (typical scheme: `file://`, `ftp://`, `http://`).
+ * Non-HTTP schemes will throw inside `fetch` and we surface that as
+ * UploadFailed.
+ */
 export class GetDiagnosticsHandler
   implements
-    CallHandler<
-      request.GetDiagnosticsRequest,
-      response.GetDiagnosticsResponse
-    >
+    CallHandler<request.GetDiagnosticsRequest, response.GetDiagnosticsResponse>
 {
   handle(
     payload: request.GetDiagnosticsRequest,
     context: HandlerContext,
   ): response.GetDiagnosticsResponse {
-    context.logger.info(`Get diagnostics request received: ${payload.location}`, LogType.DIAGNOSTICS);
+    context.logger.info(
+      `Get diagnostics request received: ${payload.location}`,
+      LogType.DIAGNOSTICS,
+    );
 
     const logs = context.logger.getLogs().join("\n");
     const blob = new Blob([logs], { type: "text/plain" });
     const file = new File([blob], "diagnostics.txt");
-    (async () => await UploadFile(payload.location, file))();
+
+    // §4.4: status notifications must follow the CALLRESULT, not precede
+    // it. queueMicrotask defers Uploading until the response has been
+    // serialized onto the wire (same pattern as TriggerMessage).
+    queueMicrotask(() => {
+      context.chargePoint.sendDiagnosticsStatusNotification("Uploading");
+      void (async () => {
+        try {
+          const res = await UploadFile(payload.location, file);
+          if (!res.ok) {
+            context.logger.warn(
+              `Diagnostics upload returned HTTP ${res.status}`,
+              LogType.DIAGNOSTICS,
+            );
+            context.chargePoint.sendDiagnosticsStatusNotification(
+              "UploadFailed",
+            );
+            return;
+          }
+          context.chargePoint.sendDiagnosticsStatusNotification("Uploaded");
+        } catch (err) {
+          context.logger.warn(
+            `Diagnostics upload failed: ${err instanceof Error ? err.message : String(err)}`,
+            LogType.DIAGNOSTICS,
+          );
+          context.chargePoint.sendDiagnosticsStatusNotification("UploadFailed");
+        }
+      })();
+    });
 
     return { fileName: "diagnostics.txt" };
   }

--- a/src/cp/infrastructure/transport/handlers/call/LocalAuthListHandlers.ts
+++ b/src/cp/infrastructure/transport/handlers/call/LocalAuthListHandlers.ts
@@ -1,0 +1,104 @@
+import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
+import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
+import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import { LogType } from "../../../../shared/Logger";
+import type { SendLocalListItem } from "../../../../domain/auth/LocalAuthList";
+
+/**
+ * `LocalAuthListEnabled` defaults to `true` when missing (the key is
+ * seeded by defaultConfiguration, but defending against a configuration
+ * delete is cheap).
+ */
+function isFeatureEnabled(context: HandlerContext): boolean {
+  return (
+    context.chargePoint.configuration.getBoolean("LocalAuthListEnabled") ?? true
+  );
+}
+
+function maxListLength(context: HandlerContext): number {
+  return (
+    context.chargePoint.configuration.getInteger("LocalAuthListMaxLength") ??
+    1000
+  );
+}
+
+function maxSendLength(context: HandlerContext): number {
+  return (
+    context.chargePoint.configuration.getInteger("SendLocalListMaxLength") ??
+    100
+  );
+}
+
+/**
+ * §6.10 GetLocalListVersion.req — returns the current list version, or
+ * `-1` when LocalAuthListManagement is disabled in Configuration.
+ */
+export class GetLocalListVersionHandler
+  implements
+    CallHandler<
+      request.GetLocalListVersionRequest,
+      response.GetLocalListVersionResponse
+    >
+{
+  handle(
+    _payload: request.GetLocalListVersionRequest,
+    context: HandlerContext,
+  ): response.GetLocalListVersionResponse {
+    if (!isFeatureEnabled(context)) {
+      context.logger.info(
+        "GetLocalListVersion: LocalAuthListEnabled=false, returning -1",
+        LogType.OCPP,
+      );
+      return { listVersion: -1 };
+    }
+    const listVersion = context.chargePoint.localAuthListManager.getVersion();
+    context.logger.info(`GetLocalListVersion → ${listVersion}`, LogType.OCPP);
+    return { listVersion };
+  }
+}
+
+/**
+ * §6.18 SendLocalList.req — Full replaces the entire list; Differential
+ * upserts entries (and deletes those whose `idTagInfo` is omitted). The
+ * CP returns `NotSupported` when LocalAuthListManagement is disabled.
+ */
+export class SendLocalListHandler
+  implements
+    CallHandler<request.SendLocalListRequest, response.SendLocalListResponse>
+{
+  handle(
+    payload: request.SendLocalListRequest,
+    context: HandlerContext,
+  ): response.SendLocalListResponse {
+    if (!isFeatureEnabled(context)) {
+      context.logger.warn(
+        "SendLocalList: LocalAuthListEnabled=false → NotSupported",
+        LogType.OCPP,
+      );
+      return { status: "NotSupported" };
+    }
+    const limits = {
+      localAuthListMaxLength: maxListLength(context),
+      sendLocalListMaxLength: maxSendLength(context),
+    };
+    // ts-ocpp permits unknown extra fields on idTagInfo via [k: string]:
+    // unknown. Narrow to the subset the manager actually reads — runtime
+    // shape matches because idTag is a top-level required field and
+    // status lives at the documented path.
+    const items = payload.localAuthorizationList as
+      | SendLocalListItem[]
+      | undefined;
+
+    const manager = context.chargePoint.localAuthListManager;
+    const status =
+      payload.updateType === "Full"
+        ? manager.applyFull(payload.listVersion, items, limits)
+        : manager.applyDifferential(payload.listVersion, items, limits);
+
+    context.logger.info(
+      `SendLocalList (${payload.updateType}, version=${payload.listVersion}, items=${items?.length ?? 0}) → ${status}`,
+      LogType.OCPP,
+    );
+    return { status };
+  }
+}

--- a/src/cp/infrastructure/transport/handlers/call/SmartChargingHandlers.ts
+++ b/src/cp/infrastructure/transport/handlers/call/SmartChargingHandlers.ts
@@ -1,50 +1,20 @@
 /**
  * OCPP 1.6J Smart Charging Handlers
  *
- * IMPORTANT: This is a SIMPLIFIED IMPLEMENTATION for simulator purposes.
- * Several aspects are NOT fully compliant with the OCPP 1.6J specification.
+ * Implements §5.10 SetChargingProfile, §5.4 ClearChargingProfile, and
+ * §5.7 GetCompositeSchedule against the connector / charge-point profile
+ * stores. Composite calculation walks the merged Tx-layer + station max
+ * profile via `buildCompositeWattsSchedule`.
  *
- * Known Non-Compliant Behaviors:
- * ================================
+ * Departures from spec that remain (intentionally out of scope here):
  *
- * 1. ConnectorId=0 Profile Handling:
- *    SPEC: Should store as single charge-point-level profile that applies to entire station
- *    HERE: Duplicates profile to each connector individually
- *    WHY: Simpler implementation, allows per-connector visualization
- *    IMPACT: ClearChargingProfile behavior differs from spec when clearing connector-specific
- *
- * 2. Composite Schedule Calculation:
- *    SPEC: Must calculate MINIMUM limit at each time period across all active profiles
- *          of different purposes (ChargePointMaxProfile, TxDefaultProfile, TxProfile)
- *    HERE: Returns the single "active" profile (highest stack level)
- *    WHY: Complex merging algorithm not needed for basic testing
- *    IMPACT: GetCompositeSchedule returns simplified schedule
- *
- * 3. Profile Purpose Precedence:
- *    SPEC: TxProfile completely overrules TxDefaultProfile (not minimum)
- *          Within same purpose, highest stackLevel wins
- *          Final limit = min(ChargePointMaxProfile, TxProfile OR TxDefaultProfile)
- *    HERE: Simple highest stackLevel selection across all purposes
- *    WHY: Simulator doesn't enforce combined station limits
- *
- * 4. ChargePointMaxProfile Enforcement:
- *    SPEC: Defines OVERALL limit for entire station (sum of all connectors)
- *          Station must ensure total draw doesn't exceed this limit
- *    HERE: Treated as just another profile without total station enforcement
- *    WHY: Requires load balancing logic across connectors
- *
- * 5. Recurring Profile Calculation:
- *    SPEC: Must calculate current period based on Daily/Weekly cycling from startSchedule
- *    HERE: Stores periods as-is without time-based recurrence calculation
- *    WHY: Time-based schedule advancement not implemented
- *
- * For Production Implementation:
- * ================================
- * - Store charge-point-level profiles separately from connector-level
- * - Implement composite schedule merging with min() across purposes
- * - Add load balancing when ChargePointMaxProfile is active
- * - Calculate recurring schedule periods based on elapsed time
- * - Track which profiles originated from connectorId=0 for proper clearing
+ * - `connectorId=0` GetCompositeSchedule returns the highest-draw single
+ *   connector composite, not the sum across simultaneous transactions.
+ *   The simulator typically drives one connector at a time, so summing
+ *   would mostly produce the same result as the per-connector view.
+ * - Unit conversion W↔A in GetCompositeSchedule responses uses
+ *   `numberPhases=3`, voltage=230 — matches what the resolver assumes
+ *   internally and is sufficient for CSMS validation tests.
  */
 
 import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
@@ -60,6 +30,10 @@ import {
 } from "../../../../domain/types/OcppTypes";
 import { LogType } from "../../../../shared/Logger";
 import { defaultConfiguration } from "../../../../domain/charge-point/Configuration";
+import { buildCompositeWattsSchedule } from "../../../../domain/connector/ChargingScheduleResolver";
+
+const REFERENCE_PHASE_VOLTAGE = 230;
+const DEFAULT_PHASES = 3;
 
 function getIntegerConfigValue(
   chargePoint: HandlerContext["chargePoint"],
@@ -75,21 +49,26 @@ function getIntegerConfigValue(
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+// ts-ocpp@2.7.3 inlines the charging-profile object inside
+// `SetChargingProfileRequest` rather than exporting a named ChargingProfile
+// type. Alias the inline shape so the validator can keep using a tight
+// parameter type.
+type CsChargingProfile =
+  request.SetChargingProfileRequest["csChargingProfiles"];
+
 /**
- * Validate charging profile against OCPP 1.6 spec and configuration
+ * Validate charging profile against OCPP 1.6 spec and configuration.
  */
 function validateChargingProfile(
-  profile: request.ChargingProfile,
+  profile: CsChargingProfile,
   connectorId: number,
   context: HandlerContext,
 ): { valid: boolean; reason?: string } {
-  // Check stack level against configuration
   const maxStackLevel = getIntegerConfigValue(
     context.chargePoint,
     "ChargeProfileMaxStackLevel",
     10,
   );
-
   if (profile.stackLevel > maxStackLevel) {
     return {
       valid: false,
@@ -97,10 +76,10 @@ function validateChargingProfile(
     };
   }
 
-  // Validate charging profile kind
-  const validKinds = Object.values(ChargingProfileKindType);
   if (
-    !validKinds.includes(profile.chargingProfileKind as ChargingProfileKindType)
+    !Object.values(ChargingProfileKindType).includes(
+      profile.chargingProfileKind as ChargingProfileKindType,
+    )
   ) {
     return {
       valid: false,
@@ -108,10 +87,8 @@ function validateChargingProfile(
     };
   }
 
-  // Validate charging profile purpose
-  const validPurposes = Object.values(ChargingProfilePurposeType);
   if (
-    !validPurposes.includes(
+    !Object.values(ChargingProfilePurposeType).includes(
       profile.chargingProfilePurpose as ChargingProfilePurposeType,
     )
   ) {
@@ -121,7 +98,8 @@ function validateChargingProfile(
     };
   }
 
-  // Validate TxProfile only allowed on specific connector
+  // §5.10 / §3.13.3: TxProfile is tied to a specific transaction —
+  // installing one at connectorId=0 makes no sense.
   if (
     profile.chargingProfilePurpose === ChargingProfilePurposeType.TxProfile &&
     connectorId === 0
@@ -131,8 +109,19 @@ function validateChargingProfile(
       reason: "TxProfile not allowed on connectorId 0",
     };
   }
+  // Mirror of the above for ChargePointMaxProfile: it MUST be installed
+  // at the CP level. A real CP would reject; we surface the same error.
+  if (
+    profile.chargingProfilePurpose ===
+      ChargingProfilePurposeType.ChargePointMaxProfile &&
+    connectorId !== 0
+  ) {
+    return {
+      valid: false,
+      reason: "ChargePointMaxProfile must be installed on connectorId 0",
+    };
+  }
 
-  // Validate recurrencyKind for Recurring profiles
   if (profile.chargingProfileKind === ChargingProfileKindType.Recurring) {
     if (!profile.recurrencyKind) {
       return {
@@ -140,9 +129,10 @@ function validateChargingProfile(
         reason: "recurrencyKind required for Recurring profile",
       };
     }
-    const validRecurrency = Object.values(RecurrencyKindType);
     if (
-      !validRecurrency.includes(profile.recurrencyKind as RecurrencyKindType)
+      !Object.values(RecurrencyKindType).includes(
+        profile.recurrencyKind as RecurrencyKindType,
+      )
     ) {
       return {
         valid: false,
@@ -151,10 +141,8 @@ function validateChargingProfile(
     }
   }
 
-  // Validate chargingRateUnit
-  const validUnits = Object.values(ChargingRateUnitType);
   if (
-    !validUnits.includes(
+    !Object.values(ChargingRateUnitType).includes(
       profile.chargingSchedule.chargingRateUnit as ChargingRateUnitType,
     )
   ) {
@@ -164,7 +152,6 @@ function validateChargingProfile(
     };
   }
 
-  // Validate schedule periods exist
   if (
     !profile.chargingSchedule.chargingSchedulePeriod ||
     profile.chargingSchedule.chargingSchedulePeriod.length === 0
@@ -178,34 +165,21 @@ function validateChargingProfile(
   return { valid: true };
 }
 
-/**
- * Check if the currently active charging profile has a zero limit
- */
 function isCurrentlyPaused(connector: Connector): boolean {
-  const activeProfile = connector.getActiveChargingProfile();
-  if (!activeProfile) return false;
-
-  // Simple check: if all periods are zero, it's paused
-  return activeProfile.chargingSchedulePeriods.every((p) => p.limit === 0);
+  const active = connector.getActiveChargingProfile();
+  if (!active) return false;
+  return active.chargingSchedulePeriods.every((p) => p.limit === 0);
 }
 
-/**
- * Apply the correct OCPP status after a profile change on a connector.
- *
- * Rules:
- * - Zero-limit active profile + connector is Charging → SuspendedEVSE
- * - Non-zero active profile + connector is SuspendedEVSE + active transaction → Charging
- */
 function applyProfileStatus(
   connector: Connector,
   chargePoint: HandlerContext["chargePoint"],
 ): void {
-  const isPaused = isCurrentlyPaused(connector);
-
-  if (isPaused && connector.status === OCPPStatus.Charging) {
+  const paused = isCurrentlyPaused(connector);
+  if (paused && connector.status === OCPPStatus.Charging) {
     chargePoint.updateConnectorStatus(connector.id, OCPPStatus.SuspendedEVSE);
   } else if (
-    !isPaused &&
+    !paused &&
     connector.status === OCPPStatus.SuspendedEVSE &&
     connector.transaction != null
   ) {
@@ -214,27 +188,15 @@ function applyProfileStatus(
 }
 
 /**
- * Handler for SetChargingProfile request (OCPP 1.6 SmartCharging)
+ * §5.10 SetChargingProfile.req
  *
- * Validates and stores charging profiles on the connector.
- * Supports multi-profile stack management with proper validation.
- * Updates connector status based on active profile limits.
+ * Routing:
+ *   - `connectorId = 0` → ChargePoint.stationProfiles (single station copy)
+ *   - `connectorId > 0` → that Connector's profile array
  *
- * NON-COMPLIANT: ConnectorId=0 Handling
- * ======================================
- * SPEC: Should store ONE charge-point-level profile that applies to the entire station
- * HERE: Duplicates the profile to each connector with modified connectorId
- *
- * Impact:
- * - Each connector gets its own copy with the same profileId and stackLevel
- * - ClearChargingProfile with specific connectorId will only clear that connector's copy
- * - For spec-compliant behavior, should store at ChargePoint level and reference during
- *   composite schedule calculation
- *
- * Why this approach:
- * - Simpler implementation for testing/simulation
- * - Allows UI to display profiles per connector
- * - Adequate for CSMS testing that doesn't rely on exact clearing semantics
+ * Spec-compliant precedence (TxProfile > TxDefaultProfile, station vs
+ * connector defaults, ChargePointMaxProfile min-merge) is enforced
+ * downstream by Connector.getActiveChargingProfile + the resolver.
  */
 export class SetChargingProfileHandler
   implements
@@ -254,7 +216,6 @@ export class SetChargingProfileHandler
       LogType.OCPP,
     );
 
-    // Validate the profile
     const validation = validateChargingProfile(
       csChargingProfiles,
       connectorId,
@@ -269,8 +230,6 @@ export class SetChargingProfileHandler
     }
 
     const periods = csChargingProfiles.chargingSchedule.chargingSchedulePeriod;
-
-    // Build the profile object
     const profile = {
       chargingProfileId: csChargingProfiles.chargingProfileId,
       connectorId,
@@ -290,13 +249,14 @@ export class SetChargingProfileHandler
     };
 
     if (connectorId === 0) {
-      // connectorId 0 applies to all connectors
-      context.chargePoint.connectors.forEach((connector: Connector) => {
-        connector.addChargingProfile({ ...profile, connectorId: connector.id });
-        applyProfileStatus(connector, context.chargePoint);
-      });
+      context.chargePoint.stationProfiles.add(profile);
+      // Status re-eval on every connector — a new station-wide profile
+      // may flip a Charging connector to SuspendedEVSE (or vice versa).
+      context.chargePoint.connectors.forEach((c: Connector) =>
+        applyProfileStatus(c, context.chargePoint),
+      );
       context.logger.info(
-        `Applied charging profile #${profile.chargingProfileId} to all connectors`,
+        `Installed station profile #${profile.chargingProfileId} (${profile.chargingProfilePurpose})`,
         LogType.OCPP,
       );
     } else {
@@ -312,19 +272,24 @@ export class SetChargingProfileHandler
         LogType.OCPP,
       );
     }
-
     return { status: "Accepted" };
   }
 }
 
 /**
- * Handler for ClearChargingProfile request (OCPP 1.6 SmartCharging)
+ * §5.4 ClearChargingProfile.req
  *
- * Clears charging profiles based on optional filter criteria:
- * - id: specific profile ID
- * - connectorId: specific connector (or all if omitted)
- * - chargingProfilePurpose: profiles with specific purpose
- * - stackLevel: profiles at specific stack level
+ * Filter dimensions (id / purpose / stackLevel) compose with the
+ * connector target the same way for both station and connector layers:
+ *
+ *   - `connectorId == null` → clear matching profiles from station store
+ *     AND every connector.
+ *   - `connectorId === 0` → station store only.
+ *   - `connectorId > 0`   → that one connector.
+ *
+ * Spec note: returns Accepted as long as the request was understood,
+ * even when zero profiles matched (this matches §5.4's "the CP MAY return
+ * Accepted regardless of whether profiles were cleared").
  */
 export class ClearChargingProfileHandler
   implements
@@ -342,46 +307,57 @@ export class ClearChargingProfileHandler
       LogType.OCPP,
     );
 
+    const criteria = {
+      profileId: payload.id,
+      purpose: payload.chargingProfilePurpose as
+        | ChargingProfilePurposeType
+        | undefined,
+      stackLevel: payload.stackLevel,
+    };
     let totalCleared = 0;
-    const connectors: Connector[] = [];
 
-    // Determine which connectors to clear
-    if (payload.connectorId != null) {
-      const connector = context.chargePoint.getConnector(payload.connectorId);
-      if (connector) {
-        connectors.push(connector);
-      }
-    } else {
-      // Clear from all connectors
-      context.chargePoint.connectors.forEach((connector) => {
-        connectors.push(connector);
+    const clearStation =
+      payload.connectorId == null || payload.connectorId === 0;
+    if (clearStation) {
+      const removed = context.chargePoint.stationProfiles.remove({
+        profileId: criteria.profileId,
+        purpose: criteria.purpose,
+        stackLevel: criteria.stackLevel,
       });
+      totalCleared += removed;
+      if (removed > 0) {
+        context.logger.info(
+          `Cleared ${removed} station-level profile(s)`,
+          LogType.OCPP,
+        );
+        // A station profile change may flip Charging/SuspendedEVSE on
+        // any connector currently in a transaction.
+        context.chargePoint.connectors.forEach((c: Connector) =>
+          applyProfileStatus(c, context.chargePoint),
+        );
+      }
     }
 
-    // Build filter criteria
-    const criteria: Parameters<Connector["removeChargingProfiles"]>[0] = {};
-    if (payload.id != null) {
-      criteria.profileId = payload.id;
-    }
-    if (payload.chargingProfilePurpose != null) {
-      criteria.purpose =
-        payload.chargingProfilePurpose as ChargingProfilePurposeType;
-    }
-    if (payload.stackLevel != null) {
-      criteria.stackLevel = payload.stackLevel;
+    const targets: Connector[] = [];
+    if (payload.connectorId == null) {
+      context.chargePoint.connectors.forEach((c: Connector) => targets.push(c));
+    } else if (payload.connectorId > 0) {
+      const c = context.chargePoint.getConnector(payload.connectorId);
+      if (c) targets.push(c);
     }
 
-    // Apply clearing to each connector
-    for (const connector of connectors) {
-      const cleared = connector.removeChargingProfiles(criteria);
+    for (const connector of targets) {
+      const cleared = connector.removeChargingProfiles({
+        profileId: criteria.profileId,
+        purpose: criteria.purpose,
+        stackLevel: criteria.stackLevel,
+      });
       totalCleared += cleared;
-
       if (cleared > 0) {
         context.logger.info(
           `Cleared ${cleared} profile(s) from connector ${connector.id}`,
           LogType.OCPP,
         );
-        // Re-evaluate connector status after clearing
         applyProfileStatus(connector, context.chargePoint);
       }
     }
@@ -392,37 +368,29 @@ export class ClearChargingProfileHandler
         LogType.OCPP,
       );
     }
-
     return { status: "Accepted" };
   }
 }
 
+function wattsToUnit(watts: number, unit: ChargingRateUnitType): number {
+  if (unit === ChargingRateUnitType.W) return watts;
+  // W → A: divide by phase voltage × phases. Mirrors the inverse used by
+  // the resolver. Caller is responsible for rounding semantics; we return
+  // the raw float here.
+  return watts / REFERENCE_PHASE_VOLTAGE / DEFAULT_PHASES;
+}
+
 /**
- * Handler for GetCompositeSchedule request (OCPP 1.6 SmartCharging)
+ * §5.7 GetCompositeSchedule.req
  *
- * Returns the effective charging schedule for the requested connector and duration.
+ * Builds a composite of (connector Tx-layer profile, ChargePointMaxProfile)
+ * over the requested `duration`. Returns `Accepted` with an empty
+ * schedule when no profile is active — CSMSs interpret this as
+ * "unconstrained for the window".
  *
- * NON-COMPLIANT: Simplified Composite Schedule Calculation
- * =========================================================
- * SPEC: Must calculate composite by:
- *   1. Find leading profile for each purpose (highest stackLevel)
- *   2. TxProfile completely overrules TxDefaultProfile (not min)
- *   3. Take MINIMUM limit across ChargePointMaxProfile and active Tx profile at each time period
- *   4. For connectorId=0: return TOTAL station power (sum of all connectors + ChargePointMaxProfile)
- *
- * HERE: Returns the single "active" profile (highest valid stackLevel across all purposes)
- *
- * Impact:
- * - Does not merge multiple profiles with min() logic
- * - Does not handle connectorId=0 as total station calculation
- * - Does not apply TxProfile > TxDefaultProfile precedence rules
- * - Adequate for simple CSMS testing but not real load management
- *
- * For Production:
- * - Implement profile merging algorithm per OCPP 1.6 spec section 5.10
- * - Track ChargePointMaxProfile separately
- * - Calculate total for connectorId=0 requests
- * - Handle Recurring profile time calculations
+ * `connectorId = 0` returns the composite considering only
+ * ChargePointMaxProfile (the simulator does not track parallel
+ * transactions for total-power roll-up).
  */
 export class GetCompositeScheduleHandler
   implements
@@ -442,62 +410,47 @@ export class GetCompositeScheduleHandler
       LogType.OCPP,
     );
 
-    const connector = context.chargePoint.getConnector(connectorId);
-    if (!connector) {
-      context.logger.warn(`Connector ${connectorId} not found`, LogType.OCPP);
-      return { status: "Rejected" };
+    let txProfile = null as ReturnType<
+      Connector["getActiveChargingProfile"]
+    > | null;
+    if (connectorId > 0) {
+      const connector = context.chargePoint.getConnector(connectorId);
+      if (!connector) {
+        context.logger.warn(`Connector ${connectorId} not found`, LogType.OCPP);
+        return { status: "Rejected" };
+      }
+      txProfile = connector.getActiveChargingProfile();
     }
+    const chargePointMaxProfile =
+      context.chargePoint.getActiveChargePointMaxProfile();
 
-    const activeProfile = connector.getActiveChargingProfile();
-    if (!activeProfile) {
-      context.logger.info(
-        `No active charging profile for connector ${connectorId}`,
-        LogType.OCPP,
-      );
-      return { status: "Rejected" };
-    }
-
-    // If chargingRateUnit is specified and doesn't match, we'd need conversion
-    // For simplicity, we return the profile's native unit
-    const responseUnit = chargingRateUnit || activeProfile.chargingRateUnit;
-
-    if (
-      chargingRateUnit &&
-      chargingRateUnit !== activeProfile.chargingRateUnit
-    ) {
-      context.logger.warn(
-        `Unit conversion from ${activeProfile.chargingRateUnit} to ${chargingRateUnit} not implemented`,
-        LogType.OCPP,
-      );
-      return { status: "Rejected" };
-    }
-
-    // Build the composite schedule from the active profile
-    // For now, we return the schedule periods as-is
-    // A more complete implementation would merge multiple profiles and trim to duration
-    const compositeSchedule = {
-      chargingSchedulePeriod: activeProfile.chargingSchedulePeriods.map(
-        (period) => ({
-          startPeriod: period.startPeriod,
-          limit: period.limit,
-          numberPhases: period.numberPhases,
-        }),
-      ),
+    const anchor = new Date();
+    const slices = buildCompositeWattsSchedule(
+      { txProfile, chargePointMaxProfile },
+      anchor,
       duration,
-      startSchedule: activeProfile.validFrom || new Date().toISOString(),
-      chargingRateUnit: responseUnit,
-    };
-
-    context.logger.info(
-      `Returning composite schedule for connector ${connectorId} with ${compositeSchedule.chargingSchedulePeriod.length} periods`,
-      LogType.OCPP,
     );
+
+    // No profile data → respond Accepted with empty period array.
+    const responseUnit: "W" | "A" =
+      (chargingRateUnit as "W" | "A" | undefined) ?? "W";
+    const chargingSchedulePeriod = slices
+      .filter((s) => Number.isFinite(s.watts))
+      .map((s) => ({
+        startPeriod: s.startPeriod,
+        limit: wattsToUnit(s.watts, responseUnit as ChargingRateUnitType),
+      }));
 
     return {
       status: "Accepted",
       connectorId,
-      scheduleStart: compositeSchedule.startSchedule,
-      chargingSchedule: compositeSchedule,
+      scheduleStart: anchor.toISOString(),
+      chargingSchedule: {
+        duration,
+        startSchedule: anchor.toISOString(),
+        chargingRateUnit: responseUnit,
+        chargingSchedulePeriod,
+      },
     };
   }
 }

--- a/src/cp/infrastructure/transport/handlers/call/UpdateFirmwareHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/UpdateFirmwareHandler.ts
@@ -1,0 +1,50 @@
+import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
+import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
+import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import { LogType } from "../../../../shared/Logger";
+
+/**
+ * §6.19 UpdateFirmware.req — the spec's response is an empty payload; the
+ * actual update progresses asynchronously via FirmwareStatusNotification.
+ * Because the simulator has no real binary to fetch, we just schedule the
+ * status sequence (Downloading → Downloaded → Installing → Installed) so
+ * the CSMS sees the same external observable as a real CP would on the
+ * happy path. `retries` / `retryInterval` are logged but not exercised —
+ * the simulated flow never fails. CSMS can still test the failure paths
+ * via TriggerMessage(FirmwareStatusNotification).
+ */
+export class UpdateFirmwareHandler
+  implements
+    CallHandler<request.UpdateFirmwareRequest, response.UpdateFirmwareResponse>
+{
+  handle(
+    payload: request.UpdateFirmwareRequest,
+    context: HandlerContext,
+  ): response.UpdateFirmwareResponse {
+    const retrieveDate = new Date(payload.retrieveDate);
+    if (Number.isNaN(retrieveDate.getTime())) {
+      context.logger.warn(
+        `UpdateFirmware: invalid retrieveDate '${payload.retrieveDate}', starting immediately`,
+        LogType.OCPP,
+      );
+    }
+    context.logger.info(
+      `UpdateFirmware received: location=${payload.location}, retrieveDate=${payload.retrieveDate}` +
+        (payload.retries != null ? `, retries=${payload.retries}` : "") +
+        (payload.retryInterval != null
+          ? `, retryInterval=${payload.retryInterval}s`
+          : ""),
+      LogType.OCPP,
+    );
+
+    // §6.19: response is empty and sent immediately. Defer the simulated
+    // download train so the CALLRESULT goes out first — same pattern as
+    // TriggerMessage handler.
+    const startAt = Number.isNaN(retrieveDate.getTime())
+      ? new Date()
+      : retrieveDate;
+    queueMicrotask(() => context.chargePoint.simulateFirmwareUpdate(startAt));
+
+    return {};
+  }
+}

--- a/src/cp/infrastructure/transport/handlers/call/__tests__/GetDiagnosticsHandler.test.ts
+++ b/src/cp/infrastructure/transport/handlers/call/__tests__/GetDiagnosticsHandler.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { GetDiagnosticsHandler } from "../GetDiagnosticsHandler";
+import { Logger } from "../../../../../shared/Logger";
+import type { HandlerContext } from "../../MessageHandlerRegistry";
+import type { ChargePoint } from "../../../../../domain/charge-point/ChargePoint";
+
+type DiagStatus = "Idle" | "Uploaded" | "UploadFailed" | "Uploading";
+
+function buildContext() {
+  const sent: DiagStatus[] = [];
+  const logger = new Logger();
+  const chargePoint = {
+    sendDiagnosticsStatusNotification: (status: DiagStatus) => {
+      sent.push(status);
+    },
+  };
+  return {
+    ctx: {
+      chargePoint: chargePoint as unknown as ChargePoint,
+      logger,
+    } as HandlerContext,
+    sent,
+  };
+}
+
+describe("GetDiagnosticsHandler", () => {
+  // The narrow vi.spyOn signature is awkward to satisfy across vitest
+  // versions when spying on globalThis.fetch; the test just needs to keep
+  // a handle for mockRestore so loose typing here is fine.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fetchSpy: any = null;
+
+  beforeEach(() => {
+    // Blob/File/FormData live on globalThis under happy-dom / jsdom but
+    // not under node's default environment. The handler instantiates a
+    // Blob+File regardless of test env, so we polyfill the trio here.
+    if (typeof globalThis.Blob === "undefined") {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).Blob = class Blob {
+        constructor(
+          public parts: unknown[],
+          public opts?: unknown,
+        ) {}
+      };
+    }
+    if (typeof globalThis.File === "undefined") {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).File = class File extends (globalThis as any).Blob {
+        constructor(
+          parts: unknown[],
+          public name: string,
+        ) {
+          super(parts);
+        }
+      };
+    }
+    if (typeof globalThis.FormData === "undefined") {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).FormData = class FormData {
+        append(): void {}
+      };
+    }
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+    fetchSpy = null;
+  });
+
+  it("returns the fileName immediately", () => {
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("", { status: 200 }));
+    const { ctx } = buildContext();
+    const handler = new GetDiagnosticsHandler();
+    const res = handler.handle({ location: "http://example/upload" }, ctx);
+    expect(res).toEqual({ fileName: "diagnostics.txt" });
+  });
+
+  it("sends Uploading then Uploaded on HTTP success", async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("", { status: 200 }));
+    const { ctx, sent } = buildContext();
+    const handler = new GetDiagnosticsHandler();
+    handler.handle({ location: "http://example/upload" }, ctx);
+    // microtask drain → schedules Uploading + starts fetch
+    await Promise.resolve();
+    // fetch promise resolves on the next microtask + the await chain
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(sent).toEqual(["Uploading", "Uploaded"]);
+  });
+
+  it("sends UploadFailed when fetch rejects", async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("ECONNREFUSED"));
+    const { ctx, sent } = buildContext();
+    const handler = new GetDiagnosticsHandler();
+    handler.handle({ location: "http://nope/upload" }, ctx);
+    for (let i = 0; i < 4; i++) await Promise.resolve();
+    expect(sent).toEqual(["Uploading", "UploadFailed"]);
+  });
+
+  it("sends UploadFailed on non-2xx HTTP", async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("", { status: 500 }));
+    const { ctx, sent } = buildContext();
+    const handler = new GetDiagnosticsHandler();
+    handler.handle({ location: "http://broken/upload" }, ctx);
+    for (let i = 0; i < 4; i++) await Promise.resolve();
+    expect(sent).toEqual(["Uploading", "UploadFailed"]);
+  });
+});

--- a/src/cp/infrastructure/transport/handlers/call/__tests__/LocalAuthListHandlers.test.ts
+++ b/src/cp/infrastructure/transport/handlers/call/__tests__/LocalAuthListHandlers.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  GetLocalListVersionHandler,
+  SendLocalListHandler,
+} from "../LocalAuthListHandlers";
+import { LocalAuthListManager } from "../../../../../domain/auth/LocalAuthList";
+import { Logger } from "../../../../../shared/Logger";
+import type { HandlerContext } from "../../MessageHandlerRegistry";
+
+/**
+ * Builds the minimal duck-typed HandlerContext the handlers consume. We
+ * stub Configuration via a tiny record so tests can flip
+ * LocalAuthListEnabled / *MaxLength without spinning up a full
+ * ChargePoint + ConfigurationStore + Database stack.
+ */
+function buildContext(
+  opts: {
+    enabled?: boolean;
+    localMax?: number;
+    sendMax?: number;
+    manager?: LocalAuthListManager;
+  } = {},
+): HandlerContext {
+  const logger = new Logger();
+  const manager = opts.manager ?? new LocalAuthListManager(logger);
+  const configStub = {
+    getBoolean: (name: string) =>
+      name === "LocalAuthListEnabled" ? (opts.enabled ?? true) : undefined,
+    getInteger: (name: string) => {
+      if (name === "LocalAuthListMaxLength") return opts.localMax ?? 1000;
+      if (name === "SendLocalListMaxLength") return opts.sendMax ?? 100;
+      return undefined;
+    },
+  };
+  const chargePointStub = {
+    configuration: configStub,
+    localAuthListManager: manager,
+  };
+  return {
+    // Tests only exercise the handler surface — the real ChargePoint type
+    // is far wider than what these specific handlers touch.
+    chargePoint: chargePointStub as unknown as HandlerContext["chargePoint"],
+    logger,
+  };
+}
+
+describe("GetLocalListVersionHandler", () => {
+  it("returns the manager's current version when enabled", () => {
+    const manager = new LocalAuthListManager(new Logger());
+    manager.applyFull(4, [{ idTag: "A", idTagInfo: { status: "Accepted" } }], {
+      localAuthListMaxLength: 100,
+      sendLocalListMaxLength: 50,
+    });
+    const ctx = buildContext({ manager });
+    const handler = new GetLocalListVersionHandler();
+    expect(handler.handle({}, ctx)).toEqual({ listVersion: 4 });
+  });
+
+  it("returns -1 when LocalAuthListEnabled is false (§9.4)", () => {
+    const ctx = buildContext({ enabled: false });
+    const handler = new GetLocalListVersionHandler();
+    expect(handler.handle({}, ctx)).toEqual({ listVersion: -1 });
+  });
+});
+
+describe("SendLocalListHandler", () => {
+  let handler: SendLocalListHandler;
+  beforeEach(() => {
+    handler = new SendLocalListHandler();
+  });
+
+  it("Full update accepted", () => {
+    const ctx = buildContext();
+    const res = handler.handle(
+      {
+        listVersion: 1,
+        updateType: "Full",
+        localAuthorizationList: [
+          { idTag: "A", idTagInfo: { status: "Accepted" } },
+        ],
+      },
+      ctx,
+    );
+    expect(res).toEqual({ status: "Accepted" });
+    expect(ctx.chargePoint.localAuthListManager.getVersion()).toBe(1);
+    expect(ctx.chargePoint.localAuthListManager.size()).toBe(1);
+  });
+
+  it("Differential with older version → VersionMismatch", () => {
+    const manager = new LocalAuthListManager(new Logger());
+    manager.applyFull(5, [], {
+      localAuthListMaxLength: 100,
+      sendLocalListMaxLength: 50,
+    });
+    const ctx = buildContext({ manager });
+    const res = handler.handle(
+      {
+        listVersion: 5,
+        updateType: "Differential",
+        localAuthorizationList: [],
+      },
+      ctx,
+    );
+    expect(res).toEqual({ status: "VersionMismatch" });
+  });
+
+  it("returns NotSupported when feature is disabled", () => {
+    const ctx = buildContext({ enabled: false });
+    const res = handler.handle(
+      { listVersion: 1, updateType: "Full", localAuthorizationList: [] },
+      ctx,
+    );
+    expect(res).toEqual({ status: "NotSupported" });
+  });
+
+  it("Full update exceeding SendLocalListMaxLength → Failed", () => {
+    const ctx = buildContext({ sendMax: 2 });
+    const res = handler.handle(
+      {
+        listVersion: 1,
+        updateType: "Full",
+        localAuthorizationList: [
+          { idTag: "A", idTagInfo: { status: "Accepted" } },
+          { idTag: "B", idTagInfo: { status: "Accepted" } },
+          { idTag: "C", idTagInfo: { status: "Accepted" } },
+        ],
+      },
+      ctx,
+    );
+    expect(res).toEqual({ status: "Failed" });
+  });
+});

--- a/src/cp/infrastructure/transport/handlers/call/__tests__/SmartChargingHandlers.test.ts
+++ b/src/cp/infrastructure/transport/handlers/call/__tests__/SmartChargingHandlers.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  SetChargingProfileHandler,
+  ClearChargingProfileHandler,
+  GetCompositeScheduleHandler,
+} from "../SmartChargingHandlers";
+import { ChargingProfileStore } from "../../../../../domain/charge-point/ChargingProfileStore";
+import { Logger } from "../../../../../shared/Logger";
+import type { HandlerContext } from "../../MessageHandlerRegistry";
+import type { ChargePoint } from "../../../../../domain/charge-point/ChargePoint";
+import {
+  ChargingProfilePurposeType,
+  OCPPStatus,
+} from "../../../../../domain/types/OcppTypes";
+import type { ActiveChargingProfile } from "../../../../../domain/connector/Connector";
+
+/**
+ * Construct a stand-in HandlerContext that exposes only the slice these
+ * handlers consume:
+ *   - chargePoint.stationProfiles  (real ChargingProfileStore)
+ *   - chargePoint.connectors       (Map of stub connectors)
+ *   - chargePoint.getConnector(id) (Map lookup)
+ *   - chargePoint.updateConnectorStatus(id, status) (no-op)
+ *   - chargePoint.getActiveChargePointMaxProfile()
+ *
+ * The stub connectors expose `addChargingProfile`, `removeChargingProfiles`,
+ * `getActiveChargingProfile`, and the `id` / `status` / `transaction`
+ * shape touched by `applyProfileStatus`.
+ */
+function buildContext(opts: { connectorIds?: number[] } = {}) {
+  const stationProfiles = new ChargingProfileStore();
+  const logger = new Logger();
+  const ids = opts.connectorIds ?? [1, 2];
+
+  const connectors = new Map<number, ConnectorStub>();
+  for (const id of ids) {
+    connectors.set(id, makeConnectorStub(id));
+  }
+
+  const chargePoint = {
+    stationProfiles,
+    connectors,
+    getConnector: (id: number) => connectors.get(id),
+    updateConnectorStatus: (_id: number, _status: OCPPStatus) => {
+      // no-op: status transitions are not under test here
+    },
+    getActiveChargePointMaxProfile: (now?: Date) =>
+      stationProfiles.getActive(
+        ChargingProfilePurposeType.ChargePointMaxProfile,
+        now,
+      ),
+    // ConfigurationStore stub for defaultConfiguration() in validate path
+    wsUrl: "ws://stub",
+    connectorNumber: ids.length,
+  };
+
+  return {
+    ctx: {
+      chargePoint: chargePoint as unknown as ChargePoint,
+      logger,
+    } as HandlerContext,
+    stationProfiles,
+    connectors,
+  };
+}
+
+interface ConnectorStub {
+  id: number;
+  status: OCPPStatus;
+  transaction: null;
+  profiles: ActiveChargingProfile[];
+  addChargingProfile(p: ActiveChargingProfile): void;
+  removeChargingProfiles(criteria: {
+    profileId?: number;
+    purpose?: ChargingProfilePurposeType;
+    stackLevel?: number;
+  }): number;
+  getActiveChargingProfile(): ActiveChargingProfile | null;
+}
+
+function makeConnectorStub(id: number): ConnectorStub {
+  return {
+    id,
+    status: OCPPStatus.Available,
+    transaction: null,
+    profiles: [],
+    addChargingProfile(p: ActiveChargingProfile) {
+      this.profiles = this.profiles.filter(
+        (x) => x.chargingProfileId !== p.chargingProfileId,
+      );
+      this.profiles.push(p);
+    },
+    removeChargingProfiles(criteria) {
+      const before = this.profiles.length;
+      this.profiles = this.profiles.filter((p) => {
+        if (
+          criteria.profileId != null &&
+          p.chargingProfileId !== criteria.profileId
+        )
+          return true;
+        if (
+          criteria.purpose != null &&
+          p.chargingProfilePurpose !== criteria.purpose
+        )
+          return true;
+        if (criteria.stackLevel != null && p.stackLevel !== criteria.stackLevel)
+          return true;
+        return false;
+      });
+      return before - this.profiles.length;
+    },
+    getActiveChargingProfile() {
+      return this.profiles[0] ?? null;
+    },
+  };
+}
+
+describe("SetChargingProfileHandler", () => {
+  let handler: SetChargingProfileHandler;
+  beforeEach(() => {
+    handler = new SetChargingProfileHandler();
+  });
+
+  it("routes connectorId=0 ChargePointMaxProfile to station store (no per-connector duplication)", () => {
+    const { ctx, stationProfiles, connectors } = buildContext();
+    const res = handler.handle(
+      {
+        connectorId: 0,
+        csChargingProfiles: {
+          chargingProfileId: 100,
+          stackLevel: 1,
+          chargingProfilePurpose: "ChargePointMaxProfile",
+          chargingProfileKind: "Absolute",
+          chargingSchedule: {
+            chargingRateUnit: "W",
+            chargingSchedulePeriod: [{ startPeriod: 0, limit: 5000 }],
+          },
+        },
+      },
+      ctx,
+    );
+    expect(res).toEqual({ status: "Accepted" });
+    expect(stationProfiles.all()).toHaveLength(1);
+    // Crucially: no duplication onto each connector.
+    for (const c of connectors.values()) {
+      expect(c.profiles).toEqual([]);
+    }
+  });
+
+  it("rejects ChargePointMaxProfile on a non-zero connector", () => {
+    const { ctx } = buildContext();
+    const res = handler.handle(
+      {
+        connectorId: 1,
+        csChargingProfiles: {
+          chargingProfileId: 1,
+          stackLevel: 0,
+          chargingProfilePurpose: "ChargePointMaxProfile",
+          chargingProfileKind: "Absolute",
+          chargingSchedule: {
+            chargingRateUnit: "W",
+            chargingSchedulePeriod: [{ startPeriod: 0, limit: 5000 }],
+          },
+        },
+      },
+      ctx,
+    );
+    expect(res).toEqual({ status: "Rejected" });
+  });
+
+  it("rejects TxProfile on connector 0", () => {
+    const { ctx } = buildContext();
+    const res = handler.handle(
+      {
+        connectorId: 0,
+        csChargingProfiles: {
+          chargingProfileId: 1,
+          stackLevel: 0,
+          chargingProfilePurpose: "TxProfile",
+          chargingProfileKind: "Relative",
+          chargingSchedule: {
+            chargingRateUnit: "W",
+            chargingSchedulePeriod: [{ startPeriod: 0, limit: 5000 }],
+          },
+        },
+      },
+      ctx,
+    );
+    expect(res).toEqual({ status: "Rejected" });
+  });
+
+  it("stores a connector-scoped TxDefaultProfile on the connector", () => {
+    const { ctx, connectors } = buildContext();
+    handler.handle(
+      {
+        connectorId: 1,
+        csChargingProfiles: {
+          chargingProfileId: 5,
+          stackLevel: 0,
+          chargingProfilePurpose: "TxDefaultProfile",
+          chargingProfileKind: "Relative",
+          chargingSchedule: {
+            chargingRateUnit: "W",
+            chargingSchedulePeriod: [{ startPeriod: 0, limit: 4000 }],
+          },
+        },
+      },
+      ctx,
+    );
+    expect(connectors.get(1)!.profiles).toHaveLength(1);
+    expect(connectors.get(2)!.profiles).toHaveLength(0);
+  });
+});
+
+describe("ClearChargingProfileHandler", () => {
+  it("clears station profiles when connectorId is omitted", () => {
+    const { ctx, stationProfiles } = buildContext();
+    stationProfiles.add({
+      chargingProfileId: 9,
+      connectorId: 0,
+      stackLevel: 0,
+      chargingProfilePurpose: ChargingProfilePurposeType.ChargePointMaxProfile,
+      chargingProfileKind: "Absolute" as never,
+      chargingRateUnit: "W" as never,
+      chargingSchedulePeriods: [{ startPeriod: 0, limit: 1000 }],
+    });
+    const res = new ClearChargingProfileHandler().handle({}, ctx);
+    expect(res).toEqual({ status: "Accepted" });
+    expect(stationProfiles.all()).toEqual([]);
+  });
+
+  it("Accepted even when no profiles matched (§5.4)", () => {
+    const { ctx } = buildContext();
+    const res = new ClearChargingProfileHandler().handle({ id: 999 }, ctx);
+    expect(res).toEqual({ status: "Accepted" });
+  });
+});
+
+describe("GetCompositeScheduleHandler", () => {
+  it("returns an Accepted+empty composite when no profiles are active", () => {
+    const { ctx } = buildContext();
+    const res = new GetCompositeScheduleHandler().handle(
+      { connectorId: 1, duration: 3600 },
+      ctx,
+    );
+    expect(res.status).toBe("Accepted");
+    // chargingSchedule is in the response shape when Accepted
+    if (res.status === "Accepted") {
+      expect(res.chargingSchedule?.chargingSchedulePeriod).toEqual([]);
+    }
+  });
+
+  it("returns the min-merge of tx + station max", () => {
+    const { ctx, connectors, stationProfiles } = buildContext();
+    // Connector 1 has a tx profile capped at 10kW for 30min then 8kW
+    connectors.get(1)!.profiles = [
+      {
+        chargingProfileId: 1,
+        connectorId: 1,
+        stackLevel: 0,
+        chargingProfilePurpose: ChargingProfilePurposeType.TxProfile,
+        chargingProfileKind: "Relative" as never,
+        chargingRateUnit: "W" as never,
+        chargingSchedulePeriods: [
+          { startPeriod: 0, limit: 10_000 },
+          { startPeriod: 1800, limit: 8_000 },
+        ],
+      },
+    ];
+    // Station-wide max capped at 5kW
+    stationProfiles.add({
+      chargingProfileId: 99,
+      connectorId: 0,
+      stackLevel: 0,
+      chargingProfilePurpose: ChargingProfilePurposeType.ChargePointMaxProfile,
+      chargingProfileKind: "Absolute" as never,
+      chargingRateUnit: "W" as never,
+      chargingSchedulePeriods: [{ startPeriod: 0, limit: 5_000 }],
+    });
+
+    const res = new GetCompositeScheduleHandler().handle(
+      { connectorId: 1, duration: 3600 },
+      ctx,
+    );
+    expect(res.status).toBe("Accepted");
+    if (res.status === "Accepted") {
+      // Min should be 5000 (station max) throughout; the inner shift at
+      // 1800 doesn't surface because station cap is tighter.
+      expect(res.chargingSchedule?.chargingSchedulePeriod).toEqual([
+        { startPeriod: 0, limit: 5_000 },
+      ]);
+    }
+  });
+});

--- a/src/cp/infrastructure/transport/handlers/call/__tests__/UpdateFirmwareHandler.test.ts
+++ b/src/cp/infrastructure/transport/handlers/call/__tests__/UpdateFirmwareHandler.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { UpdateFirmwareHandler } from "../UpdateFirmwareHandler";
+import { Logger } from "../../../../../shared/Logger";
+import type { HandlerContext } from "../../MessageHandlerRegistry";
+import type { ChargePoint } from "../../../../../domain/charge-point/ChargePoint";
+
+type FirmwareStatus =
+  | "Downloaded"
+  | "DownloadFailed"
+  | "Downloading"
+  | "Idle"
+  | "InstallationFailed"
+  | "Installing"
+  | "Installed";
+
+/**
+ * Spies on `sendFirmwareStatusNotification` and exposes the recorded
+ * sequence so each test can assert on the exact status train. We reuse
+ * ChargePoint's real `simulateFirmwareUpdate` since the schedule is the
+ * thing under test — the spy only intercepts the leaf send call.
+ */
+function buildContext() {
+  const logger = new Logger();
+  const sent: FirmwareStatus[] = [];
+  const timers: NodeJS.Timeout[] = [];
+  let inFlight = false;
+
+  // Minimal duck-typed ChargePoint replicating the slice of
+  // simulateFirmwareUpdate that's relevant to this handler test. We
+  // intentionally do not pull in the real ChargePoint to keep the test
+  // fast (no WebSocket, no Database).
+  const chargePoint = {
+    sendFirmwareStatusNotification: (status: FirmwareStatus) => {
+      sent.push(status);
+    },
+    simulateFirmwareUpdate(retrieveDate: Date, intervalMs = 2000): void {
+      if (inFlight) return;
+      inFlight = true;
+      const sequence: FirmwareStatus[] = [
+        "Downloading",
+        "Downloaded",
+        "Installing",
+        "Installed",
+      ];
+      const startDelay = Math.max(0, retrieveDate.getTime() - Date.now());
+      const fireStep = (i: number) => {
+        if (i >= sequence.length) {
+          inFlight = false;
+          return;
+        }
+        this.sendFirmwareStatusNotification(sequence[i]);
+        timers.push(setTimeout(() => fireStep(i + 1), intervalMs));
+      };
+      timers.push(setTimeout(() => fireStep(0), startDelay));
+    },
+  };
+
+  const ctx: HandlerContext = {
+    chargePoint: chargePoint as unknown as ChargePoint,
+    logger,
+  };
+  return { ctx, sent };
+}
+
+describe("UpdateFirmwareHandler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns an empty response immediately (§6.19)", () => {
+    const { ctx } = buildContext();
+    const handler = new UpdateFirmwareHandler();
+    const res = handler.handle(
+      {
+        location: "http://example.invalid/firmware.bin",
+        retrieveDate: new Date(Date.now() + 1000).toISOString(),
+      },
+      ctx,
+    );
+    expect(res).toEqual({});
+  });
+
+  it("fires Downloading → Downloaded → Installing → Installed after retrieveDate", async () => {
+    const { ctx, sent } = buildContext();
+    const handler = new UpdateFirmwareHandler();
+    handler.handle(
+      {
+        location: "http://example.invalid/firmware.bin",
+        retrieveDate: new Date(Date.now() + 1000).toISOString(),
+      },
+      ctx,
+    );
+
+    // microtask: schedules the actual update
+    await Promise.resolve();
+    expect(sent).toEqual([]);
+
+    // before retrieveDate: nothing yet
+    vi.advanceTimersByTime(999);
+    expect(sent).toEqual([]);
+
+    // hit retrieveDate → Downloading
+    vi.advanceTimersByTime(1);
+    expect(sent).toEqual(["Downloading"]);
+
+    vi.advanceTimersByTime(2000);
+    expect(sent).toEqual(["Downloading", "Downloaded"]);
+
+    vi.advanceTimersByTime(2000);
+    expect(sent).toEqual(["Downloading", "Downloaded", "Installing"]);
+
+    vi.advanceTimersByTime(2000);
+    expect(sent).toEqual([
+      "Downloading",
+      "Downloaded",
+      "Installing",
+      "Installed",
+    ]);
+  });
+
+  it("starts immediately when retrieveDate is invalid", async () => {
+    const { ctx, sent } = buildContext();
+    const handler = new UpdateFirmwareHandler();
+    handler.handle({ location: "http://x", retrieveDate: "not-a-date" }, ctx);
+    await Promise.resolve();
+    vi.advanceTimersByTime(0);
+    expect(sent[0]).toBe("Downloading");
+  });
+});

--- a/src/cp/infrastructure/transport/handlers/index.ts
+++ b/src/cp/infrastructure/transport/handlers/index.ts
@@ -12,6 +12,8 @@ export * from "./call/ReservationHandlers";
 export * from "./call/SmartChargingHandlers";
 export * from "./call/DataTransferHandler";
 export * from "./call/ChangeAvailabilityHandler";
+export * from "./call/LocalAuthListHandlers";
+export * from "./call/UpdateFirmwareHandler";
 
 // Export CALLRESULT handlers
 export * from "./callresult/BootNotificationResultHandler";


### PR DESCRIPTION
## Summary

Fills in the OCPP 1.6J feature profiles that were previously left as `// TODO` or only partially implemented. After this PR the simulator advertises and implements the full **Core / FirmwareManagement / LocalAuthListManagement / Reservation / SmartCharging / RemoteTrigger** profile set.

- **LocalAuthListManagement** — new `LocalAuthListManager` + `GetLocalListVersion` / `SendLocalList` handlers. Implements Full / Differential semantics with `VersionMismatch` on stale Differential, `NotSupported` when disabled, and `Failed` on `SendLocalListMaxLength` / `LocalAuthListMaxLength` overflow (with Differential rollback). Seeds `LocalAuthListEnabled` / `LocalAuthListMaxLength` / `SendLocalListMaxLength`.
- **FirmwareManagement (incoming)** — new `UpdateFirmware` handler returns the empty CALLRESULT and schedules `ChargePoint.simulateFirmwareUpdate`, which drives `FirmwareStatusNotification` through `Downloading → Downloaded → Installing → Installed` after `retrieveDate`. In-flight guard prevents a second `UpdateFirmware.req` from forking a parallel status train; teardown cancels pending timers.
- **GetDiagnostics lifecycle** — handler now sends `DiagnosticsStatusNotification(Uploading)` after the CALLRESULT, then `Uploaded` on HTTP 2xx or `UploadFailed` on either a fetch rejection or a non-2xx response.
- **SmartCharging spec compliance** — resolves all five "Known Non-Compliant Behaviors" previously documented in the handler header:
  - `connectorId=0` now lands in a new `ChargingProfileStore` on the ChargePoint instead of being duplicated to every connector.
  - `Connector.getActiveChargingProfile` honors `TxProfile > TxDefaultProfile` precedence and merges connector-own and station-wide defaults.
  - `ChargePointMaxProfile` is `min`-composed against the Tx layer via `resolveEffectiveLimitWatts` so the meter scheduler sees the tighter cap.
  - `GetCompositeSchedule` walks merged period boundaries, expands Recurring (Daily / Weekly) profiles across the requested window, collapses consecutive identical limits, converts W↔A, and now returns `Accepted` with an empty schedule when nothing is active (was `Rejected`).
- **SupportedFeatureProfiles** advertises `FirmwareManagement` and `LocalAuthListManagement` alongside the existing four.

## Test plan

- [x] `pnpm test:vitest` — 11 files / 75 tests pass (29 new).
- [x] `npx tsc -p tsconfig.cli.json --noEmit` — no new type errors in changed files.
- [x] `pnpm lint` — no new lint errors (the 3 pre-existing errors / 6 warnings are in files this PR does not touch).
- [ ] Manual end-to-end against a CSMS:
  - [ ] `GetLocalListVersion` → `{ listVersion: 0 }`; `SendLocalList(Full, v=1, [...])` then `GetLocalListVersion` → `{ listVersion: 1 }`.
  - [ ] `UpdateFirmware(retrieveDate)` returns `{}` immediately, followed by the four `FirmwareStatusNotification` transitions.
  - [ ] `GetDiagnostics(location)` returns `{ fileName }` immediately, then `Uploading`, then `UploadFailed` for an unreachable URL.
  - [ ] `SetChargingProfile(connectorId=0, ChargePointMaxProfile, 5000W)` + `SetChargingProfile(connectorId=1, TxDefault, 10000W)` → `GetCompositeSchedule(connectorId=1, duration=3600)` reflects the 5000W station cap.
  - [ ] `GetConfiguration` returns all six profiles in `SupportedFeatureProfiles`.
- [ ] Web UI (`pnpm dev`) — existing transaction flow has no regressions.