### PR TITLE
feat(persistence+ui): scenario position across restarts + simpler MeterValue editor

### DIFF
--- a/src/cli/__tests__/service.scenarioResume.bun.test.ts
+++ b/src/cli/__tests__/service.scenarioResume.bun.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "bun:test";
+import { Database as BunSqliteDatabase } from "bun:sqlite";
+import { CLIChargePointService } from "../service";
+import { BunSqliteDatabase as BunDb } from "../../cp/domain/persistence/BunSqliteDatabase";
+import { runMigrations } from "../../cp/domain/persistence/schema";
+import {
+  ScenarioDefinition,
+  ScenarioNodeType,
+} from "../../cp/application/scenario/ScenarioTypes";
+
+/**
+ * Reproduces the daemon-restart resume failure mode the E2E run exposed:
+ *
+ *   - On boot 1 the scenario template is instantiated with a runtime id
+ *     containing `Date.now()` + a random suffix (see scenarioTemplates.ts).
+ *     The persisted ScenarioPositionSnapshot stamps that id as
+ *     `scenarioKey`.
+ *   - On boot 2 the same template is instantiated again — but it gets a
+ *     fresh timestamp + suffix, so the new instance id !== the saved key.
+ *
+ * The original `pending.scenarioKey === scenarioId` check therefore
+ * always failed across restarts, and the executor replayed from the
+ * START node (re-firing Plug In / Start Transaction etc.). The fix
+ * matches by node-id structure instead: if the saved
+ * lastCompletedNodeId + executedNodes still resolve in the new
+ * scenario's node graph, resume is honored.
+ */
+function buildScenarioInstance(
+  templateId: string,
+  cpId: string,
+  connectorId: number,
+  instanceSuffix: string,
+): ScenarioDefinition {
+  return {
+    id: `${templateId}-${cpId}-c${connectorId}-${Date.now()}-${instanceSuffix}`,
+    name: "Linear",
+    targetType: "connector",
+    targetId: connectorId,
+    nodes: [
+      {
+        id: "start-1",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "S" },
+      },
+      {
+        id: "node-a",
+        type: ScenarioNodeType.METER_VALUE,
+        position: { x: 0, y: 1 },
+        data: { label: "A", value: 11, sendMessage: false },
+      },
+      {
+        id: "node-b",
+        type: ScenarioNodeType.METER_VALUE,
+        position: { x: 0, y: 2 },
+        data: { label: "B", value: 22, sendMessage: false },
+      },
+      {
+        id: "end-1",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 3 },
+        data: { label: "E" },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "start-1", target: "node-a" },
+      { id: "e2", source: "node-a", target: "node-b" },
+      { id: "e3", source: "node-b", target: "end-1" },
+    ],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    defaultExecutionMode: "oneshot",
+    enabled: true,
+    trigger: { type: "manual" },
+  };
+}
+
+describe("runScenario resume across daemon restart", () => {
+  it("honors a persisted position even when the new scenario instance id differs from the saved key", async () => {
+    const raw = new BunSqliteDatabase(":memory:");
+    const db = new BunDb(raw);
+    runMigrations(db);
+
+    const svc = new CLIChargePointService(
+      {
+        cpId: "test-cp",
+        wsUrl: "ws://127.0.0.1:65534/never",
+        connectors: 1,
+        vendor: "v",
+        model: "m",
+      },
+      db,
+    );
+
+    const boot1Def = buildScenarioInstance("t", "test-cp", 1, "boot1");
+    const boot1Id = svc.loadScenario(1, boot1Def);
+
+    // Pretend boot 1 ran through node-a and then the daemon was killed:
+    // write the connector_runtime row directly to set up the resume state.
+    const repo = (
+      svc as unknown as {
+        _runtimeRepo: {
+          save: (cpId: string, connectorId: number, snap: unknown) => void;
+        };
+      }
+    )._runtimeRepo;
+    repo.save("test-cp", 1, {
+      status: "Charging",
+      availability: "Operative",
+      meterValueWh: 100,
+      scenarioPosition: {
+        // The bug: this id encodes Date.now(), so on the next boot the
+        // freshly-instantiated scenario gets a different one.
+        scenarioKey: boot1Id,
+        lastCompletedNodeId: "node-a",
+        executedNodes: ["start-1", "node-a"],
+      },
+    });
+
+    svc.restoreConnectorRuntimeFromDatabase();
+
+    // Boot 2 ⇒ same template, different runtime id.
+    const boot2Def = buildScenarioInstance("t", "test-cp", 1, "boot2");
+    const boot2Id = svc.loadScenario(1, boot2Def);
+    expect(boot2Id).not.toBe(boot1Id);
+
+    const meterVals: number[] = [];
+    const cp = (
+      svc as unknown as { _chargePoint: { connectors: Map<number, unknown> } }
+    )._chargePoint;
+    const connector = cp.connectors.get(1) as {
+      events: {
+        on: (e: string, cb: (data: { meterValue: number }) => void) => void;
+      };
+    };
+    connector.events.on("meterValueChange", ({ meterValue }) => {
+      meterVals.push(meterValue);
+    });
+
+    svc.runScenario(1, boot2Id);
+    await new Promise((r) => setTimeout(r, 600));
+
+    // node-a's set (value=11) MUST be skipped; only node-b's (value=22)
+    // fires. Pre-fix: both fire because the resume opts were dropped.
+    expect(meterVals).toContain(22);
+    expect(meterVals).not.toContain(11);
+  });
+
+  it("falls back to a fresh run when the persisted node ids don't exist in the new scenario", async () => {
+    const raw = new BunSqliteDatabase(":memory:");
+    const db = new BunDb(raw);
+    runMigrations(db);
+
+    const svc = new CLIChargePointService(
+      {
+        cpId: "test-cp",
+        wsUrl: "ws://127.0.0.1:65534/never",
+        connectors: 1,
+        vendor: "v",
+        model: "m",
+      },
+      db,
+    );
+    const def = buildScenarioInstance("t", "test-cp", 1, "current");
+    const id = svc.loadScenario(1, def);
+
+    const repo = (
+      svc as unknown as {
+        _runtimeRepo: {
+          save: (cpId: string, connectorId: number, snap: unknown) => void;
+        };
+      }
+    )._runtimeRepo;
+    repo.save("test-cp", 1, {
+      status: "Charging",
+      availability: "Operative",
+      meterValueWh: 0,
+      scenarioPosition: {
+        scenarioKey: "any",
+        // ← node id that was removed from the scenario graph between
+        // persistence and the next boot.
+        lastCompletedNodeId: "node-removed",
+        executedNodes: ["start-1", "node-removed"],
+      },
+    });
+    svc.restoreConnectorRuntimeFromDatabase();
+
+    const meterVals: number[] = [];
+    const cp = (
+      svc as unknown as { _chargePoint: { connectors: Map<number, unknown> } }
+    )._chargePoint;
+    const connector = cp.connectors.get(1) as {
+      events: {
+        on: (e: string, cb: (data: { meterValue: number }) => void) => void;
+      };
+    };
+    connector.events.on("meterValueChange", ({ meterValue }) => {
+      meterVals.push(meterValue);
+    });
+
+    svc.runScenario(1, id);
+    await new Promise((r) => setTimeout(r, 600));
+
+    // Structural match fails → full replay: both A and B run.
+    expect(meterVals).toContain(11);
+    expect(meterVals).toContain(22);
+  });
+});

--- a/src/cli/__tests__/service.scenarioResume.bun.test.ts
+++ b/src/cli/__tests__/service.scenarioResume.bun.test.ts
@@ -124,26 +124,24 @@ describe("runScenario resume across daemon restart", () => {
     const boot2Id = svc.loadScenario(1, boot2Def);
     expect(boot2Id).not.toBe(boot1Id);
 
-    const meterVals: number[] = [];
-    const cp = (
-      svc as unknown as { _chargePoint: { connectors: Map<number, unknown> } }
-    )._chargePoint;
-    const connector = cp.connectors.get(1) as {
-      events: {
-        on: (e: string, cb: (data: { meterValue: number }) => void) => void;
-      };
-    };
-    connector.events.on("meterValueChange", ({ meterValue }) => {
-      meterVals.push(meterValue);
+    const executedNodes: string[] = [];
+    svc.onEvent((ev) => {
+      if (
+        ev.event === "scenario_node_execute" &&
+        typeof ev.data.nodeId === "string"
+      ) {
+        executedNodes.push(ev.data.nodeId);
+      }
     });
 
     svc.runScenario(1, boot2Id);
     await new Promise((r) => setTimeout(r, 600));
 
-    // node-a's set (value=11) MUST be skipped; only node-b's (value=22)
-    // fires. Pre-fix: both fire because the resume opts were dropped.
-    expect(meterVals).toContain(22);
-    expect(meterVals).not.toContain(11);
+    // node-a MUST be skipped on resume; only node-b runs. Pre-fix the
+    // resume opts were dropped and both fired (false negative for the
+    // bug we're guarding against).
+    expect(executedNodes).toContain("node-b");
+    expect(executedNodes).not.toContain("node-a");
   });
 
   it("falls back to a fresh run when the persisted node ids don't exist in the new scenario", async () => {
@@ -185,24 +183,21 @@ describe("runScenario resume across daemon restart", () => {
     });
     svc.restoreConnectorRuntimeFromDatabase();
 
-    const meterVals: number[] = [];
-    const cp = (
-      svc as unknown as { _chargePoint: { connectors: Map<number, unknown> } }
-    )._chargePoint;
-    const connector = cp.connectors.get(1) as {
-      events: {
-        on: (e: string, cb: (data: { meterValue: number }) => void) => void;
-      };
-    };
-    connector.events.on("meterValueChange", ({ meterValue }) => {
-      meterVals.push(meterValue);
+    const executedNodes: string[] = [];
+    svc.onEvent((ev) => {
+      if (
+        ev.event === "scenario_node_execute" &&
+        typeof ev.data.nodeId === "string"
+      ) {
+        executedNodes.push(ev.data.nodeId);
+      }
     });
 
     svc.runScenario(1, id);
     await new Promise((r) => setTimeout(r, 600));
 
     // Structural match fails → full replay: both A and B run.
-    expect(meterVals).toContain(11);
-    expect(meterVals).toContain(22);
+    expect(executedNodes).toContain("node-a");
+    expect(executedNodes).toContain("node-b");
   });
 });

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -727,21 +727,37 @@ export class CLIChargePointService {
     );
 
     // Resume hint: if restoreConnectorRuntimeFromDatabase loaded a
-    // position for this connector AND the scenarioKey matches the
-    // scenario we're about to run, hand it to the executor's start()
-    // so it walks the graph from after lastCompletedNodeId. Mismatched
-    // key (different scenario) → fresh start, leave the pending entry
-    // in place for a later matching runScenario call.
+    // position for this connector AND the saved node ids still exist in
+    // the scenario we're about to run, hand it to the executor's start()
+    // so it walks the graph from after lastCompletedNodeId. We can't
+    // compare scenarioKey directly: scenario template instances get a
+    // fresh `${templateId}-${cpId}-c${connectorId}-${Date.now()}-${suffix}`
+    // id on every daemon boot, so the saved key never matches the new
+    // run's id. Structural match (lastCompletedNodeId is a node in the
+    // current scenario, every executedNode resolves too) is the
+    // load-bearing check.
     const pending = this._pendingScenarioResumes.get(connectorId);
-    const resumeOpts =
-      pending && pending.scenarioKey === scenarioId
-        ? {
-            resumeFromNodeId: pending.lastCompletedNodeId ?? undefined,
-            executedNodes: pending.executedNodes,
-          }
-        : undefined;
+    const nodeIds = new Set(entry.definition.nodes.map((n) => n.id));
+    const positionMatches =
+      pending &&
+      pending.lastCompletedNodeId != null &&
+      nodeIds.has(pending.lastCompletedNodeId) &&
+      pending.executedNodes.every((id) => nodeIds.has(id));
+    const resumeOpts = positionMatches
+      ? {
+          resumeFromNodeId: pending!.lastCompletedNodeId ?? undefined,
+          executedNodes: pending!.executedNodes,
+        }
+      : undefined;
     if (resumeOpts) {
       this._pendingScenarioResumes.delete(connectorId);
+      // Rebase the position map to this run's scenarioId so subsequent
+      // node.complete writes accumulate against the right key on the
+      // next persistConnectorRuntime call.
+      this._scenarioPositionByConnector.set(connectorId, {
+        ...pending!,
+        scenarioKey: scenarioId,
+      });
     }
 
     const executor = new ScenarioExecutor(

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -10,7 +10,9 @@ import type {
   ConnectorStatus,
 } from "./types";
 import { ScenarioExecutor } from "../cp/application/scenario/ScenarioExecutor";
+import type { ScenarioEvents } from "../cp/application/scenario/ScenarioTypes";
 import { createScenarioExecutorCallbacks } from "../cp/application/scenario/ScenarioRuntime";
+import { EventEmitter } from "../cp/shared/EventEmitter";
 import type {
   ScenarioDefinition,
   ScenarioExecutionContext,
@@ -23,6 +25,7 @@ import { SqliteConnectorRuntimeRepository } from "../cp/domain/persistence/Sqlit
 import {
   NoopConnectorRuntimeRepository,
   type ConnectorRuntimeRepository,
+  type ScenarioPositionSnapshot,
 } from "../cp/domain/persistence/ConnectorRuntimeRepository";
 import type { EVSettings } from "../cp/domain/connector/EVSettings";
 import type { AutoMeterValueConfig } from "../cp/domain/connector/MeterValueCurve";
@@ -195,6 +198,36 @@ export class CLIChargePointService {
   private readonly _executors: Map<string, ScenarioExecutor> = new Map();
   private readonly _scenarioRepo: SqliteScenarioRepository;
   private readonly _runtimeRepo: ConnectorRuntimeRepository;
+  /**
+   * Per-connector scenario execution position that was loaded from the
+   * persistence layer during {@link restoreConnectorRuntimeFromDatabase}
+   * but hasn't yet been handed to a fresh {@link ScenarioExecutor}.
+   * Consumed by {@link runScenario} on the first matching call so the
+   * resumed executor picks up at the saved node instead of replaying
+   * from `start`. Keyed by connectorId because at restore time we don't
+   * yet know which scenarioId the auto-start path will pick.
+   */
+  private readonly _pendingScenarioResumes: Map<
+    number,
+    ScenarioPositionSnapshot
+  > = new Map();
+  /**
+   * Tracks which connector each running executor belongs to, so the
+   * `node.complete` listener can persist the scenarioPosition for the
+   * right connector + clear it when the scenario exits.
+   */
+  private readonly _executorConnectorIds: Map<string, number> = new Map();
+  /**
+   * The currently-tracked scenario position for each connector. Updated
+   * by the `node.complete` listener attached in {@link runScenario}, read
+   * by {@link persistConnectorRuntime} so connector-field-change writes
+   * include the latest scenario position in the same row. Cleared by the
+   * executor exit listener.
+   */
+  private readonly _scenarioPositionByConnector: Map<
+    number,
+    ScenarioPositionSnapshot
+  > = new Map();
   // Keep the original init so the web console can prefill the "Edit CP"
   // modal without us having to round-trip the persisted SQL row back into
   // ChargePointInitOptions shape. Exposed via getInit() and the
@@ -666,13 +699,70 @@ export class CLIChargePointService {
       },
     });
 
-    const executor = new ScenarioExecutor(entry.definition, callbacks);
+    // Build a per-executor event emitter so we can subscribe to
+    // `node.complete` and persist the scenario position after every
+    // step. Without this, a daemon restart mid-flow can resume the
+    // connector_runtime row (Charging, in-flight transaction) but the
+    // scenario would replay from `start` and double-fire side-effecting
+    // nodes (Plug In, Start Transaction) before reaching `meterValue`.
+    const eventEmitter = new EventEmitter<ScenarioEvents>();
+    eventEmitter.on(
+      "node.complete",
+      (data: ScenarioEvents["node.complete"]) => {
+        // Push the latest position into the connector-keyed map so any
+        // imminent connector-field-change write (status/transaction/…)
+        // picks it up. Then trigger a write directly so a daemon kill
+        // *right now* still captures the just-finished node.
+        const existing = this._scenarioPositionByConnector.get(connectorId);
+        const executedNodes = existing
+          ? [...existing.executedNodes, data.nodeId]
+          : [data.nodeId];
+        this._scenarioPositionByConnector.set(connectorId, {
+          scenarioKey: scenarioId,
+          lastCompletedNodeId: data.nodeId,
+          executedNodes,
+        });
+        this.persistConnectorRuntime(connector, connectorId);
+      },
+    );
+
+    // Resume hint: if restoreConnectorRuntimeFromDatabase loaded a
+    // position for this connector AND the scenarioKey matches the
+    // scenario we're about to run, hand it to the executor's start()
+    // so it walks the graph from after lastCompletedNodeId. Mismatched
+    // key (different scenario) → fresh start, leave the pending entry
+    // in place for a later matching runScenario call.
+    const pending = this._pendingScenarioResumes.get(connectorId);
+    const resumeOpts =
+      pending && pending.scenarioKey === scenarioId
+        ? {
+            resumeFromNodeId: pending.lastCompletedNodeId ?? undefined,
+            executedNodes: pending.executedNodes,
+          }
+        : undefined;
+    if (resumeOpts) {
+      this._pendingScenarioResumes.delete(connectorId);
+    }
+
+    const executor = new ScenarioExecutor(
+      entry.definition,
+      callbacks,
+      eventEmitter,
+    );
     this._executors.set(scenarioId, executor);
+    this._executorConnectorIds.set(scenarioId, connectorId);
 
     this.emit({ event: "scenario_started", data: { connectorId, scenarioId } });
 
-    executor.start().finally(() => {
+    executor.start(resumeOpts).finally(() => {
       this._executors.delete(scenarioId);
+      this._executorConnectorIds.delete(scenarioId);
+      // Scenario exited cleanly — clear the persisted position so a
+      // subsequent restart treats the connector as idle (the
+      // connector_runtime row's transaction_json itself is already
+      // null by the time the Stop Transaction node ran).
+      this._scenarioPositionByConnector.delete(connectorId);
+      this.persistConnectorRuntime(connector, connectorId);
     });
   }
 
@@ -951,11 +1041,15 @@ export class CLIChargePointService {
   ): void {
     if (!connector) return;
     try {
-      this._runtimeRepo.save(
-        this._init.cpId,
-        connectorId,
-        connector.snapshotRuntime(),
-      );
+      this._runtimeRepo.save(this._init.cpId, connectorId, {
+        ...connector.snapshotRuntime(),
+        // Persist whichever scenario position we last captured for this
+        // connector, so the row stays a self-consistent snapshot even
+        // when the trigger is a connector field change (status/meter/…)
+        // rather than a scenario node completion.
+        scenarioPosition:
+          this._scenarioPositionByConnector.get(connectorId) ?? null,
+      });
     } catch (err) {
       console.warn(
         `[service] failed to persist connector_runtime for ` +
@@ -984,6 +1078,24 @@ export class CLIChargePointService {
       const snapshot = this._runtimeRepo.load(this._init.cpId, connectorId);
       if (!snapshot) return;
       connector.restoreRuntimeSnapshot(snapshot);
+      // Capture the scenario position so the auto-start path can resume
+      // the scenario at the saved node instead of replaying from `start`.
+      // Stored on both _pendingScenarioResumes (for runScenario to
+      // consume once) and _scenarioPositionByConnector (so the row stays
+      // self-consistent on later connector-field-change writes that
+      // happen before the executor is re-armed). The same snapshot is
+      // intentionally placed in both maps; runScenario removes the
+      // pending entry as soon as it hands the position to the executor.
+      if (snapshot.scenarioPosition) {
+        this._pendingScenarioResumes.set(
+          connectorId,
+          snapshot.scenarioPosition,
+        );
+        this._scenarioPositionByConnector.set(
+          connectorId,
+          snapshot.scenarioPosition,
+        );
+      }
       restored += 1;
     });
     return restored;

--- a/src/components/scenario/NodeConfigPanel.tsx
+++ b/src/components/scenario/NodeConfigPanel.tsx
@@ -816,27 +816,36 @@ const MeterValueEditor: React.FC<{
         </p>
       </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="maxChargeKwh">Max charge (kWh, 0 = unlimited)</Label>
-        <Input
-          id="maxChargeKwh"
-          type="number"
-          step="0.1"
-          min="0"
-          value={maxChargeKwh ?? 0}
-          onChange={(e) => {
-            const next = parseFloat(e.target.value);
-            const kwh = Number.isFinite(next) && next >= 0 ? next : 0;
-            setFormData((prev) => ({
-              ...prev,
-              maxChargeKwh: kwh,
-              // Keep `maxValue` (Wh) in sync so older daemon builds that
-              // only read `maxValue` stop at the same point.
-              maxValue: Math.round(kwh * 1000),
-            }));
-          }}
-        />
-      </div>
+      {formData.stopMode !== "evSettings" && (
+        <div className="space-y-2">
+          <Label htmlFor="maxChargeKwh">Max charge (kWh, 0 = unlimited)</Label>
+          <Input
+            id="maxChargeKwh"
+            type="number"
+            step="0.1"
+            min="0"
+            value={maxChargeKwh ?? 0}
+            onChange={(e) => {
+              const next = parseFloat(e.target.value);
+              const kwh = Number.isFinite(next) && next >= 0 ? next : 0;
+              setFormData((prev) => ({
+                ...prev,
+                maxChargeKwh: kwh,
+                // Keep `maxValue` (Wh) in sync so older daemon builds
+                // that only read `maxValue` stop at the same point.
+                maxValue: Math.round(kwh * 1000),
+              }));
+            }}
+          />
+        </div>
+      )}
+      {formData.stopMode === "evSettings" && (
+        <div className="rounded border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/30 px-3 py-2 text-xs text-blue-700 dark:text-blue-300">
+          Auto-meter stops at the connector's target SoC (set in EV Settings).
+          Switch the stop condition in the advanced panel below to use a fixed
+          kWh cap instead.
+        </div>
+      )}
 
       {/* --- Advanced (collapsible) --- */}
       <div className="border-t pt-3">
@@ -892,6 +901,39 @@ const MeterValueEditor: React.FC<{
               >
                 Auto increment (start AutoMeterValue manager)
               </Label>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="stopMode">Stop condition</Label>
+              <Select
+                value={(formData.stopMode as string) || "manual"}
+                onValueChange={(value) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    stopMode: value as "manual" | "evSettings",
+                  }))
+                }
+              >
+                <SelectTrigger id="stopMode">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="manual">
+                    Manual (use Max value / Max time below)
+                  </SelectItem>
+                  <SelectItem value="evSettings">
+                    EV Settings (stop at target SoC)
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                In <em>EV Settings</em> mode the auto-meter stops when delivered
+                Wh reaches{" "}
+                <code>
+                  capacity_kWh × (targetSoc − initialSoc) ÷ 100 × 1000
+                </code>
+                . Configure the connector's EV settings (battery capacity,
+                target SoC) from the connector side panel.
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="incrementInterval">

--- a/src/components/scenario/NodeConfigPanel.tsx
+++ b/src/components/scenario/NodeConfigPanel.tsx
@@ -190,137 +190,7 @@ const NodeConfigPanel: React.FC<NodeConfigPanelProps> = ({
 
       case ScenarioNodeType.METER_VALUE:
         return (
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="meter-label">Label</Label>
-              <Input
-                id="meter-label"
-                type="text"
-                value={formData.label || ""}
-                onChange={(e) =>
-                  setFormData({ ...formData, label: e.target.value })
-                }
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="meter-value">Initial Value (Wh)</Label>
-              <Input
-                id="meter-value"
-                type="number"
-                value={formData.value || 0}
-                onChange={(e) =>
-                  setFormData({
-                    ...formData,
-                    value: parseInt(e.target.value) || 0,
-                  })
-                }
-              />
-            </div>
-            <div className="flex items-center gap-2">
-              <Checkbox
-                id="sendMessage"
-                checked={formData.sendMessage || false}
-                onCheckedChange={(checked) =>
-                  setFormData({ ...formData, sendMessage: checked })
-                }
-              />
-              <Label
-                htmlFor="sendMessage"
-                className="font-normal cursor-pointer"
-              >
-                Send MeterValue Message
-              </Label>
-            </div>
-            <div className="flex items-center gap-2">
-              <Checkbox
-                id="autoIncrement"
-                checked={formData.autoIncrement || false}
-                onCheckedChange={(checked) =>
-                  setFormData({ ...formData, autoIncrement: checked })
-                }
-              />
-              <Label
-                htmlFor="autoIncrement"
-                className="font-normal cursor-pointer"
-              >
-                Auto Increment (Start AutoMeterValue Manager)
-              </Label>
-            </div>
-            {formData.autoIncrement && (
-              <>
-                <div className="space-y-2">
-                  <Label htmlFor="incrementInterval">
-                    Increment Interval (seconds)
-                  </Label>
-                  <Input
-                    id="incrementInterval"
-                    type="number"
-                    value={formData.incrementInterval || 10}
-                    onChange={(e) =>
-                      setFormData({
-                        ...formData,
-                        incrementInterval: parseInt(e.target.value) || 10,
-                      })
-                    }
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="incrementAmount">Increment Amount (Wh)</Label>
-                  <Input
-                    id="incrementAmount"
-                    type="number"
-                    value={formData.incrementAmount || 1000}
-                    onChange={(e) =>
-                      setFormData({
-                        ...formData,
-                        incrementAmount: parseInt(e.target.value) || 1000,
-                      })
-                    }
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="maxTime">
-                    Max Time (seconds, 0 = unlimited)
-                  </Label>
-                  <Input
-                    id="maxTime"
-                    type="number"
-                    value={formData.maxTime || 0}
-                    onChange={(e) =>
-                      setFormData({
-                        ...formData,
-                        maxTime: parseInt(e.target.value) || 0,
-                      })
-                    }
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    AutoMeterValue will stop after this many seconds (0 =
-                    unlimited)
-                  </p>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="maxValue">
-                    Max Value (Wh, 0 = unlimited)
-                  </Label>
-                  <Input
-                    id="maxValue"
-                    type="number"
-                    value={formData.maxValue || 0}
-                    onChange={(e) =>
-                      setFormData({
-                        ...formData,
-                        maxValue: parseInt(e.target.value) || 0,
-                      })
-                    }
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    AutoMeterValue will stop when meter reaches this value (0 =
-                    unlimited)
-                  </p>
-                </div>
-              </>
-            )}
-          </div>
+          <MeterValueEditor formData={formData} setFormData={setFormData} />
         );
 
       case ScenarioNodeType.DELAY:
@@ -833,6 +703,285 @@ const NodeConfigPanel: React.FC<NodeConfigPanelProps> = ({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+};
+
+/**
+ * MeterValue node editor split into two surfaces:
+ *
+ *   - **Simple** (always visible): `Output (kW)` and `Max charge (kWh)`.
+ *     These are the two knobs an operator typically wants when
+ *     simulating an EV plugged into a charger — "how fast and how
+ *     much?". The editor derives the existing `incrementAmount` (Wh per
+ *     tick) and `maxValue` (Wh) on save, keeping the scheduler
+ *     contract unchanged so older scenarios and the runtime
+ *     `MeterValueScheduler` keep working.
+ *
+ *   - **Advanced** (collapsed by default unless the scenario has raw
+ *     fields and no `outputKw`): the existing Initial value /
+ *     interval / increment amount / max time / max value fields. Power
+ *     users can still tune raw Wh-per-tick or non-default intervals;
+ *     when those diverge from what `outputKw` would compute, advanced
+ *     wins (the scheduler reads the raw fields).
+ *
+ * Default interval is 5 s (matches what scenarios already produce). A
+ * different interval can be set in the advanced panel.
+ */
+function deriveIncrementAmountWh(
+  outputKw: number,
+  intervalSec: number,
+): number {
+  // Wh delivered in `intervalSec` at `outputKw` of constant output.
+  //   kW × (intervalSec / 3600) × 1000  =  Wh
+  // Rounded to 2 decimals so the chart doesn't drift on long runs from
+  // a quietly truncating integer cast downstream.
+  return Math.round(outputKw * intervalSec * (1000 / 3600) * 100) / 100;
+}
+
+const MeterValueEditor: React.FC<{
+  formData: Record<string, unknown>;
+  setFormData: React.Dispatch<React.SetStateAction<Record<string, unknown>>>;
+}> = ({ formData, setFormData }) => {
+  const outputKw =
+    typeof formData.outputKw === "number" ? formData.outputKw : undefined;
+  const maxChargeKwh =
+    typeof formData.maxChargeKwh === "number"
+      ? formData.maxChargeKwh
+      : undefined;
+  const intervalSec =
+    typeof formData.incrementInterval === "number"
+      ? formData.incrementInterval
+      : 5;
+  // Open the Advanced panel by default for legacy scenarios that have raw
+  // increment fields but no outputKw (otherwise the operator opens the
+  // editor and sees what looks like a fresh node with the raw values
+  // hidden behind the toggle).
+  const initialAdvancedOpen =
+    outputKw === undefined &&
+    typeof formData.incrementAmount === "number" &&
+    formData.incrementAmount > 0;
+  const [advancedOpen, setAdvancedOpen] =
+    useState<boolean>(initialAdvancedOpen);
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="meter-label">Label</Label>
+        <Input
+          id="meter-label"
+          type="text"
+          value={(formData.label as string) || ""}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, label: e.target.value }))
+          }
+        />
+      </div>
+
+      {/* --- Simple inputs --- */}
+      <div className="space-y-2">
+        <Label htmlFor="outputKw">Output (kW)</Label>
+        <Input
+          id="outputKw"
+          type="number"
+          step="0.1"
+          min="0"
+          value={outputKw ?? 5}
+          onChange={(e) => {
+            const next = parseFloat(e.target.value);
+            const kw = Number.isFinite(next) && next >= 0 ? next : 0;
+            setFormData((prev) => ({
+              ...prev,
+              outputKw: kw,
+              // Enable auto-increment + send-message implicitly when the
+              // simple inputs are touched; the operator can override
+              // these checkboxes in the advanced panel below.
+              autoIncrement: true,
+              sendMessage: true,
+              incrementInterval:
+                typeof prev.incrementInterval === "number"
+                  ? prev.incrementInterval
+                  : 5,
+              incrementAmount: deriveIncrementAmountWh(
+                kw,
+                typeof prev.incrementInterval === "number"
+                  ? prev.incrementInterval
+                  : 5,
+              ),
+            }));
+          }}
+        />
+        <p className="text-xs text-muted-foreground">
+          1 tick = {deriveIncrementAmountWh(outputKw ?? 5, intervalSec)} Wh at{" "}
+          {intervalSec} s interval
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="maxChargeKwh">Max charge (kWh, 0 = unlimited)</Label>
+        <Input
+          id="maxChargeKwh"
+          type="number"
+          step="0.1"
+          min="0"
+          value={maxChargeKwh ?? 0}
+          onChange={(e) => {
+            const next = parseFloat(e.target.value);
+            const kwh = Number.isFinite(next) && next >= 0 ? next : 0;
+            setFormData((prev) => ({
+              ...prev,
+              maxChargeKwh: kwh,
+              // Keep `maxValue` (Wh) in sync so older daemon builds that
+              // only read `maxValue` stop at the same point.
+              maxValue: Math.round(kwh * 1000),
+            }));
+          }}
+        />
+      </div>
+
+      {/* --- Advanced (collapsible) --- */}
+      <div className="border-t pt-3">
+        <button
+          type="button"
+          onClick={() => setAdvancedOpen((v) => !v)}
+          className="text-xs font-medium text-muted-foreground hover:text-foreground"
+        >
+          {advancedOpen ? "▼" : "▶"} Advanced settings
+        </button>
+        {advancedOpen && (
+          <div className="mt-3 space-y-3">
+            <div className="space-y-2">
+              <Label htmlFor="meter-value">Initial value (Wh)</Label>
+              <Input
+                id="meter-value"
+                type="number"
+                value={(formData.value as number) || 0}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    value: parseInt(e.target.value) || 0,
+                  }))
+                }
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="sendMessage"
+                checked={(formData.sendMessage as boolean) || false}
+                onCheckedChange={(checked) =>
+                  setFormData((prev) => ({ ...prev, sendMessage: checked }))
+                }
+              />
+              <Label
+                htmlFor="sendMessage"
+                className="font-normal cursor-pointer"
+              >
+                Send MeterValue message
+              </Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="autoIncrement"
+                checked={(formData.autoIncrement as boolean) || false}
+                onCheckedChange={(checked) =>
+                  setFormData((prev) => ({ ...prev, autoIncrement: checked }))
+                }
+              />
+              <Label
+                htmlFor="autoIncrement"
+                className="font-normal cursor-pointer"
+              >
+                Auto increment (start AutoMeterValue manager)
+              </Label>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="incrementInterval">
+                Increment interval (seconds)
+              </Label>
+              <Input
+                id="incrementInterval"
+                type="number"
+                value={(formData.incrementInterval as number) ?? 5}
+                onChange={(e) => {
+                  const nextInterval = parseInt(e.target.value) || 5;
+                  setFormData((prev) => ({
+                    ...prev,
+                    incrementInterval: nextInterval,
+                    // Recompute Wh-per-tick when interval changes so the
+                    // effective kW output the operator set in the simple
+                    // panel stays constant.
+                    ...(typeof prev.outputKw === "number"
+                      ? {
+                          incrementAmount: deriveIncrementAmountWh(
+                            prev.outputKw,
+                            nextInterval,
+                          ),
+                        }
+                      : {}),
+                  }));
+                }}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="incrementAmount">Increment amount (Wh)</Label>
+              <Input
+                id="incrementAmount"
+                type="number"
+                step="0.01"
+                value={(formData.incrementAmount as number) ?? 0}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    incrementAmount: parseFloat(e.target.value) || 0,
+                    // Detach from `outputKw` once the operator edits the
+                    // raw Wh-per-tick directly — otherwise the next save
+                    // would overwrite their value with the derived one.
+                    outputKw: undefined,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="maxTime">Max time (seconds, 0 = unlimited)</Label>
+              <Input
+                id="maxTime"
+                type="number"
+                value={(formData.maxTime as number) || 0}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    maxTime: parseInt(e.target.value) || 0,
+                  }))
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                AutoMeterValue stops after this many seconds (0 = unlimited).
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="maxValue">Max value (Wh, 0 = unlimited)</Label>
+              <Input
+                id="maxValue"
+                type="number"
+                value={(formData.maxValue as number) || 0}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    maxValue: parseInt(e.target.value) || 0,
+                    // Detach from `maxChargeKwh` so the next round-trip
+                    // doesn't silently overwrite the raw Wh threshold.
+                    maxChargeKwh: undefined,
+                  }))
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                AutoMeterValue stops when the meter reaches this value (0 =
+                unlimited).
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
   );
 };
 

--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -640,7 +640,22 @@ export class ScenarioExecutor {
     data: MeterValueNodeData,
   ): Promise<void> {
     if (this.callbacks.onSetMeterValue) {
-      this.callbacks.onSetMeterValue(data.value);
+      // Daemon-restart resume case: the persisted connector_runtime row
+      // restored a non-zero meter accumulator (e.g. 624 Wh from a charge
+      // that was interrupted), and now the scenario walks back into the
+      // meterValue node whose `data.value` is the node's *initial seed*
+      // (commonly 0). Writing that seed would erase the accumulator and
+      // restart the maxValue cap from scratch. Skip the seed write when
+      // the connector already holds more.
+      const current = this.callbacks.onGetMeterValue?.();
+      if (current == null || current <= data.value) {
+        this.callbacks.onSetMeterValue(data.value);
+      } else {
+        this.callbacks.log?.(
+          `[${this.scenario.name}] Preserving meter accumulator ${current}Wh (> node seed ${data.value}Wh) on resume`,
+          "info",
+        );
+      }
     }
 
     // Handle auto-increment mode - start AutoMeterValue manager

--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -32,6 +32,27 @@ import {
 import { interpret } from "robot3";
 import type { EventEmitter } from "../../shared/EventEmitter";
 
+/**
+ * Optional resume hint passed to {@link ScenarioExecutor.start}. When set
+ * the executor skips the normal walk from the `start` node and instead
+ * resumes from the outgoing edge of `resumeFromNodeId`. Intended for the
+ * daemon-restart path that loads a {@link ScenarioPositionSnapshot} from
+ * the connector_runtime persistence and reattaches an executor to it.
+ *
+ * If `resumeFromNodeId` doesn't exist in the scenario graph (because the
+ * scenario was edited between runs) the executor logs a warning and
+ * falls back to a fresh start from `start` — the safe default; the next
+ * RemoteStartTransaction will re-arm the connector cleanly.
+ */
+export interface ScenarioStartOptions {
+  resumeFromNodeId?: string;
+  /** Seed for `context.executedNodes`. Lets branching-history checks
+   *  (the ones that look at "have we executed node X already?") behave
+   *  consistently after resume. Optional; defaults to a list containing
+   *  just `resumeFromNodeId`. */
+  executedNodes?: string[];
+}
+
 export class ScenarioExecutor {
   private scenario: ScenarioDefinition;
   private callbacks: ScenarioExecutorCallbacks;
@@ -101,7 +122,7 @@ export class ScenarioExecutor {
    * Start scenario execution. Execution mode is always one-shot — the
    * step / loop variants were removed from the product surface.
    */
-  public async start(): Promise<void> {
+  public async start(opts?: ScenarioStartOptions): Promise<void> {
     const mode: ScenarioExecutionMode = "oneshot";
     // Dispatch START event to transition to running state
     this.service.send({ type: "START", mode });
@@ -138,7 +159,7 @@ export class ScenarioExecutor {
     }
 
     try {
-      await this.executeFlow();
+      await this.executeFlow(opts);
 
       // Check if we were stopped during execution
       const stateName = getScenarioStateName(this.service.machine);
@@ -188,32 +209,76 @@ export class ScenarioExecutor {
    * Execute the flow from start to end
    * Supports scenarios with internal loops - use Stop button to exit infinite loops
    * Supports parallel branches from Start node
+   *
+   * If `opts.resumeFromNodeId` is supplied AND the node exists, the executor
+   * resumes from the outgoing edge of that node — the START node and every
+   * node up to `resumeFromNodeId` are treated as already executed and are
+   * NOT re-fired. Used by the daemon restart path so side-effecting nodes
+   * (Plug In, Start Transaction, …) don't double-emit OCPP traffic.
    */
-  private async executeFlow(): Promise<void> {
-    // Find start node
-    const startNode = this.scenario.nodes.find(
-      (n) => n.type === ScenarioNodeType.START || n.data.label === "Start",
-    );
+  private async executeFlow(opts?: ScenarioStartOptions): Promise<void> {
+    const resumeFromNodeId = opts?.resumeFromNodeId;
+    let originNode: ScenarioNode | undefined;
+    let resumed = false;
 
-    if (!startNode) {
-      throw new Error("No start node found in scenario");
+    if (resumeFromNodeId) {
+      originNode = this.scenario.nodes.find((n) => n.id === resumeFromNodeId);
+      if (originNode) {
+        // Seed executedNodes from the resume snapshot so any node-history
+        // check inside an executor down the flow has the right shape.
+        // Fall back to `[resumeFromNodeId]` when the caller didn't provide
+        // the full list (it's only used for diagnostics in most nodes).
+        const seededNodes =
+          opts?.executedNodes && opts.executedNodes.length > 0
+            ? [...opts.executedNodes]
+            : [resumeFromNodeId];
+        const context = getScenarioContext(this.service.machine);
+        context.executedNodes = seededNodes;
+        context.currentNodeId = originNode.id;
+        this.service.machine.context.executedNodes = seededNodes;
+        this.service.machine.context.currentNodeId = originNode.id;
+        resumed = true;
+        this.callbacks.log?.(
+          `[${this.scenario.name}] Resuming scenario from node "${
+            originNode.data?.label || originNode.id
+          }"`,
+          "info",
+        );
+      } else {
+        // Scenario tree changed between persistence and resume; fall
+        // through to a fresh run. Logged at warn so an operator sees it.
+        this.callbacks.log?.(
+          `[${this.scenario.name}] Cannot resume: node "${resumeFromNodeId}" no ` +
+            "longer exists in scenario; falling back to fresh start",
+          "warn",
+        );
+      }
     }
 
-    // Execute start node
-    await this.executeSingleNode(startNode);
+    if (!originNode) {
+      // Normal path: find and execute the Start node.
+      originNode = this.scenario.nodes.find(
+        (n) => n.type === ScenarioNodeType.START || n.data.label === "Start",
+      );
+      if (!originNode) {
+        throw new Error("No start node found in scenario");
+      }
+      await this.executeSingleNode(originNode);
+    }
 
-    // Check for parallel branches from Start node
+    // Walk outgoing edges from the origin node (whether Start or resume).
     const outgoingEdges = this.scenario.edges.filter(
-      (e) => e.source === startNode.id,
+      (e) => e.source === originNode!.id,
     );
     const nextNodes = outgoingEdges
       .map((edge) => this.scenario.nodes.find((n) => n.id === edge.target))
-      .filter((node) => node !== undefined);
+      .filter((node): node is ScenarioNode => node !== undefined);
 
     if (nextNodes.length === 0) {
+      const tag = resumed ? "Resume point" : "Start";
       this.callbacks.log?.(
-        `[${this.scenario.name}] No nodes after Start, scenario ends`,
-        "warn",
+        `[${this.scenario.name}] No nodes after ${tag}, scenario ends`,
+        resumed ? "info" : "warn",
       );
       return;
     }

--- a/src/cp/application/scenario/ScenarioRuntime.ts
+++ b/src/cp/application/scenario/ScenarioRuntime.ts
@@ -322,6 +322,7 @@ export const createScenarioExecutorCallbacks = (
     onSetMeterValue: (value) => {
       chargePoint.setMeterValue(connector.id, value);
     },
+    onGetMeterValue: () => connector.meterValue,
     onSendMeterValue: async () => {
       chargePoint.sendMeterValue(connector.id);
     },

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -409,6 +409,10 @@ export interface ScenarioExecutorCallbacks {
     targetValue: number,
     timeout?: number,
   ) => Promise<void>; // Waits for meter value to reach target
+  /** Read the connector's current meter accumulator (Wh). Used by the
+   *  meterValue node to avoid clobbering a persisted value with the
+   *  node's own `data.value` after a daemon restart resume. */
+  onGetMeterValue?: () => number;
   onReserveNow?: (
     expiryMinutes: number,
     idTag: string,

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -87,6 +87,18 @@ export interface MeterValueNodeData extends BaseNodeData {
   value: number;
   sendMessage: boolean; // If true, send MeterValue message
   autoIncrement?: boolean; // If true, automatically increment meter value
+  /** Simplified "how fast is the EV charging?" input expressed in kW.
+   *  The editor derives `incrementAmount` from this on save (using the
+   *  current `incrementInterval`) so the runtime scheduler keeps using
+   *  its raw Wh-per-tick contract. Optional: when null/undefined the
+   *  scenario was authored against the advanced inputs directly and the
+   *  editor opens with the details panel expanded by default. */
+  outputKw?: number;
+  /** Simplified stop condition mirroring `maxValue` but expressed in kWh
+   *  (the total energy delivered before auto-increment stops). The editor
+   *  writes both this field AND `maxValue` (Wh) on save so older daemon
+   *  builds that only read `maxValue` keep working. 0 = unlimited. */
+  maxChargeKwh?: number;
   incrementInterval?: number; // Interval in seconds between auto-increments
   incrementAmount?: number; // Amount to increment each time (Wh)
   /**

--- a/src/cp/application/scenario/__tests__/ScenarioExecutor.resume.test.ts
+++ b/src/cp/application/scenario/__tests__/ScenarioExecutor.resume.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import { ScenarioExecutor } from "../ScenarioExecutor";
+import { ScenarioDefinition, ScenarioNodeType } from "../ScenarioTypes";
+
+/**
+ * Builds a small four-node scenario: Start → A → B → End. Both A and B
+ * are MeterValue nodes so we can spy on which ones the executor actually
+ * fires via `onSetMeterValue`. Used to assert what `resumeFromNodeId`
+ * does and does not re-execute.
+ */
+function buildLinearScenario(): ScenarioDefinition {
+  return {
+    id: "scenario-resume-test",
+    name: "Resume test",
+    targetType: "connector",
+    targetId: 1,
+    nodes: [
+      {
+        id: "start",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "node-a",
+        type: ScenarioNodeType.METER_VALUE,
+        position: { x: 0, y: 100 },
+        data: { label: "A", value: 100, sendMessage: false },
+      },
+      {
+        id: "node-b",
+        type: ScenarioNodeType.METER_VALUE,
+        position: { x: 0, y: 200 },
+        data: { label: "B", value: 200, sendMessage: false },
+      },
+      {
+        id: "end",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 300 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e-start", source: "start", target: "node-a" },
+      { id: "e-a", source: "node-a", target: "node-b" },
+      { id: "e-b", source: "node-b", target: "end" },
+    ],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    defaultExecutionMode: "oneshot",
+    enabled: true,
+    trigger: { type: "manual" },
+  };
+}
+
+describe("ScenarioExecutor.start(resumeFromNodeId)", () => {
+  it("resumes from the edge after lastCompletedNodeId", async () => {
+    // After a restart that captured "we just finished node-a", the
+    // executor should pick up at node-b without re-executing node-a.
+    // (Re-running the meterValue node would double-bump the meter and
+    // — in the real world — replay side effects like Plug In / Start
+    // Transaction.)
+    const onSetMeterValue = vi.fn();
+    const executor = new ScenarioExecutor(buildLinearScenario(), {
+      onSetMeterValue,
+    });
+
+    await executor.start({
+      resumeFromNodeId: "node-a",
+      executedNodes: ["start", "node-a"],
+    });
+
+    expect(onSetMeterValue).toHaveBeenCalledTimes(1);
+    expect(onSetMeterValue).toHaveBeenCalledWith(200); // B, not A
+  });
+
+  it("falls back to a fresh run when the resume node is unknown", async () => {
+    // Scenario edited between persistence and resume — the stored node
+    // id no longer exists in the graph. Executor must warn and replay
+    // from the start node instead of throwing or hanging.
+    const onSetMeterValue = vi.fn();
+    const log = vi.fn();
+    const executor = new ScenarioExecutor(buildLinearScenario(), {
+      onSetMeterValue,
+      log,
+    });
+
+    await executor.start({
+      resumeFromNodeId: "node-removed",
+      executedNodes: ["start", "node-removed"],
+    });
+
+    expect(onSetMeterValue).toHaveBeenCalledTimes(2);
+    expect(onSetMeterValue).toHaveBeenNthCalledWith(1, 100);
+    expect(onSetMeterValue).toHaveBeenNthCalledWith(2, 200);
+    // Warning was emitted.
+    const warnedCalls = log.mock.calls.filter(([, level]) => level === "warn");
+    expect(warnedCalls.length).toBeGreaterThan(0);
+    expect(warnedCalls[0][0]).toMatch(/Cannot resume/);
+  });
+
+  it("runs the full flow when no resume hint is given (backward compat)", async () => {
+    const onSetMeterValue = vi.fn();
+    const executor = new ScenarioExecutor(buildLinearScenario(), {
+      onSetMeterValue,
+    });
+    await executor.start();
+    expect(onSetMeterValue).toHaveBeenCalledTimes(2);
+    expect(onSetMeterValue).toHaveBeenNthCalledWith(1, 100);
+    expect(onSetMeterValue).toHaveBeenNthCalledWith(2, 200);
+  });
+});

--- a/src/cp/application/scenario/__tests__/ScenarioExecutor.resume.test.ts
+++ b/src/cp/application/scenario/__tests__/ScenarioExecutor.resume.test.ts
@@ -109,4 +109,35 @@ describe("ScenarioExecutor.start(resumeFromNodeId)", () => {
     expect(onSetMeterValue).toHaveBeenNthCalledWith(1, 100);
     expect(onSetMeterValue).toHaveBeenNthCalledWith(2, 200);
   });
+
+  it("preserves the connector meter accumulator on resume when current > node seed", async () => {
+    // Real-world resume case: daemon was killed mid-charge, the
+    // connector_runtime row restored meter=624Wh, the scenario now
+    // walks into a meterValue node whose `data.value` is 0 (the
+    // common "start from zero" seed). The node MUST NOT clobber the
+    // accumulator back to 0 — that would erase a real charge.
+    const def = buildLinearScenario();
+    def.nodes.find((n) => n.id === "node-a")!.data.value = 0;
+    def.nodes.find((n) => n.id === "node-b")!.data.value = 0;
+    const onSetMeterValue = vi.fn();
+    const onGetMeterValue = vi.fn(() => 624);
+    const log = vi.fn();
+    const executor = new ScenarioExecutor(def, {
+      onSetMeterValue,
+      onGetMeterValue,
+      log,
+    });
+
+    await executor.start({
+      resumeFromNodeId: "node-a",
+      executedNodes: ["start", "node-a"],
+    });
+
+    // node-b's seed (0) must NOT have been written — current (624) > seed (0).
+    expect(onSetMeterValue).not.toHaveBeenCalled();
+    const preservedLog = log.mock.calls.find(([msg]) =>
+      String(msg).includes("Preserving meter accumulator"),
+    );
+    expect(preservedLog).toBeDefined();
+  });
 });

--- a/src/cp/domain/persistence/ConnectorRuntimeRepository.ts
+++ b/src/cp/domain/persistence/ConnectorRuntimeRepository.ts
@@ -15,12 +15,6 @@ import type { OCPPAvailability, OCPPStatus } from "../types/OcppTypes";
  *     the connector is in a non-Operative state mid-conversation with
  *     the CSMS; resyncing them after a restart loses no information of
  *     value to the operator.
- *   - Scenario execution position: the daemon doesn't yet know how to
- *     freeze and thaw a Robot3 service mid-flow, so we let scenarios
- *     re-arm from the top on restart. A connector that was Charging
- *     will resume the OCPP transaction (StopTransaction goes out
- *     correctly on the next RemoteStop), but its scenario node
- *     position is lost.
  *   - Auto-meter scheduler state: the schedule itself is reproducible
  *     from {@link ConnectorSettingsRepository}'s `auto_meter` row and
  *     the restored `meterValueWh`, so we don't store the scheduler's
@@ -41,6 +35,52 @@ export interface ConnectorRuntimeSnapshot {
    *  restart, which would otherwise reset the connector to the
    *  scenario's first node. */
   lastAutoStartedScenarioKey: string | null;
+  /** Position of the in-flight scenario on this connector, persisted so
+   *  a daemon restart mid-transaction can resume the scenario at the saved
+   *  node rather than replaying from `start`. Null when no scenario is
+   *  running, or when the scenario has finished. See
+   *  {@link ScenarioPositionSnapshot} for the contract on resume semantics.
+   *
+   *  Optional for backward compatibility: snapshots written by older
+   *  daemon builds (pre-v3 schema) won't carry this field, and load
+   *  callers should treat its absence as "no resume info; start from top".
+   */
+  scenarioPosition?: ScenarioPositionSnapshot | null;
+}
+
+/**
+ * Per-connector scenario execution checkpoint. Persisted on every node
+ * completion so a daemon restart mid-flow can resume the scenario at the
+ * node *after* the last completed one.
+ *
+ * Why `lastCompletedNodeId` and not `currentNodeId`?
+ *   - Many scenario nodes have side effects (Plug In, Start Transaction).
+ *     Re-running a side-effecting node on resume would double-send
+ *     OCPP messages or contradict the restored connector state.
+ *   - Saving "the node we finished" means resume walks the outgoing edge
+ *     from that node, picking up at the next node — every node already
+ *     in `executedNodes` is treated as "do not re-execute".
+ *
+ * `scenarioKey` identifies the executor instance the position belongs to
+ * (the same key used by `Connector.lastAutoStartedScenarioKey`). The
+ * resume path verifies the key matches the scenario the executor is
+ * being re-armed with; a mismatch means the scenario tree changed and
+ * we fall back to a fresh start (logged as a warning).
+ */
+export interface ScenarioPositionSnapshot {
+  /** Stable identifier of the scenario instance, e.g.
+   *  `essential-cp-behavior-shiv3-cp7-c1-1780480212898-z3cggj`. */
+  scenarioKey: string;
+  /** ID of the last node that finished executing. The resume path walks
+   *  the outgoing edge from this node. Null when execution hasn't reached
+   *  the first node yet — equivalent to "no resume info" and falls back
+   *  to a fresh start. */
+  lastCompletedNodeId: string | null;
+  /** Full list of nodes that have been visited so far. Used by the resume
+   *  path to skip nodes (so a parallel branch that already executed half
+   *  its nodes doesn't re-execute them) and as the seed for the executor
+   *  context's `executedNodes` after restore. */
+  executedNodes: string[];
 }
 
 /**

--- a/src/cp/domain/persistence/SqliteConnectorRuntimeRepository.ts
+++ b/src/cp/domain/persistence/SqliteConnectorRuntimeRepository.ts
@@ -4,6 +4,7 @@ import type { OCPPAvailability, OCPPStatus } from "../types/OcppTypes";
 import type {
   ConnectorRuntimeRepository,
   ConnectorRuntimeSnapshot,
+  ScenarioPositionSnapshot,
 } from "./ConnectorRuntimeRepository";
 
 interface ConnectorRuntimeRow {
@@ -14,6 +15,7 @@ interface ConnectorRuntimeRow {
   meter_value_wh: number;
   soc_percent: number | null;
   last_auto_started_scenario_key: string | null;
+  scenario_position_json: string | null;
 }
 
 /**
@@ -30,7 +32,8 @@ export class SqliteConnectorRuntimeRepository
   load(cpId: string, connectorId: number): ConnectorRuntimeSnapshot | null {
     const row = this.database.get<ConnectorRuntimeRow>(
       "SELECT status, availability, scheduled_availability, transaction_json, " +
-        "meter_value_wh, soc_percent, last_auto_started_scenario_key " +
+        "meter_value_wh, soc_percent, last_auto_started_scenario_key, " +
+        "scenario_position_json " +
         "FROM connector_runtime WHERE cp_id = ? AND connector_id = ?",
       [cpId, connectorId],
     );
@@ -46,6 +49,7 @@ export class SqliteConnectorRuntimeRepository
       meterValueWh: row.meter_value_wh,
       socPercent: row.soc_percent,
       lastAutoStartedScenarioKey: row.last_auto_started_scenario_key,
+      scenarioPosition: deserializeScenarioPosition(row.scenario_position_json),
     };
   }
 
@@ -58,8 +62,8 @@ export class SqliteConnectorRuntimeRepository
       "INSERT INTO connector_runtime " +
         "(cp_id, connector_id, status, availability, scheduled_availability, " +
         " transaction_json, meter_value_wh, soc_percent, " +
-        " last_auto_started_scenario_key, updated_at) " +
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) " +
+        " last_auto_started_scenario_key, scenario_position_json, updated_at) " +
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) " +
         "ON CONFLICT (cp_id, connector_id) DO UPDATE SET " +
         "  status = excluded.status, " +
         "  availability = excluded.availability, " +
@@ -69,6 +73,7 @@ export class SqliteConnectorRuntimeRepository
         "  soc_percent = excluded.soc_percent, " +
         "  last_auto_started_scenario_key = " +
         "    excluded.last_auto_started_scenario_key, " +
+        "  scenario_position_json = excluded.scenario_position_json, " +
         "  updated_at = excluded.updated_at",
       [
         cpId,
@@ -80,6 +85,7 @@ export class SqliteConnectorRuntimeRepository
         snapshot.meterValueWh,
         snapshot.socPercent,
         snapshot.lastAutoStartedScenarioKey,
+        serializeScenarioPosition(snapshot.scenarioPosition ?? null),
         new Date().toISOString(),
       ],
     );
@@ -117,6 +123,44 @@ function deserializeTransaction(raw: string | null): Transaction | null {
       parsed.stopTime = new Date(parsed.stopTime as unknown as string);
     }
     return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function serializeScenarioPosition(
+  pos: ScenarioPositionSnapshot | null,
+): string | null {
+  if (!pos) return null;
+  return JSON.stringify(pos);
+}
+
+function deserializeScenarioPosition(
+  raw: string | null,
+): ScenarioPositionSnapshot | null {
+  if (raw == null) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<ScenarioPositionSnapshot>;
+    // Light shape validation: reject silently if the row was hand-edited
+    // or written by some future shape we don't recognise. Returning null
+    // is equivalent to "no resume info; start from top" — the safe
+    // fallback.
+    if (
+      typeof parsed.scenarioKey !== "string" ||
+      !Array.isArray(parsed.executedNodes)
+    ) {
+      return null;
+    }
+    return {
+      scenarioKey: parsed.scenarioKey,
+      lastCompletedNodeId:
+        typeof parsed.lastCompletedNodeId === "string"
+          ? parsed.lastCompletedNodeId
+          : null,
+      executedNodes: parsed.executedNodes.filter(
+        (n): n is string => typeof n === "string",
+      ),
+    };
   } catch {
     return null;
   }

--- a/src/cp/domain/persistence/__tests__/BunSqliteDatabase.bun.test.ts
+++ b/src/cp/domain/persistence/__tests__/BunSqliteDatabase.bun.test.ts
@@ -176,6 +176,111 @@ describe("BunSqliteDatabase", () => {
     }
   });
 
+  it("round-trips a scenario position when one is set", () => {
+    const db = BunSqliteDatabase.open(":memory:");
+    try {
+      const repo = new SqliteConnectorRuntimeRepository(db);
+      const snap: ConnectorRuntimeSnapshot = {
+        status: OCPPStatus.Charging,
+        availability: "Operative",
+        scheduledAvailability: null,
+        transaction: null,
+        meterValueWh: 12000,
+        socPercent: null,
+        lastAutoStartedScenarioKey: null,
+        scenarioPosition: {
+          scenarioKey: "essential-cp-behavior",
+          lastCompletedNodeId: "tx-start",
+          executedNodes: [
+            "start-1",
+            "delay-2s",
+            "plug-in",
+            "delay-1s",
+            "trigger-remote-start",
+            "tx-start",
+          ],
+        },
+      };
+      repo.save("shiv3-cp7", 1, snap);
+      const loaded = repo.load("shiv3-cp7", 1);
+      expect(loaded?.scenarioPosition?.lastCompletedNodeId).toBe("tx-start");
+      expect(loaded?.scenarioPosition?.executedNodes).toEqual([
+        "start-1",
+        "delay-2s",
+        "plug-in",
+        "delay-1s",
+        "trigger-remote-start",
+        "tx-start",
+      ]);
+      expect(loaded?.scenarioPosition?.scenarioKey).toBe(
+        "essential-cp-behavior",
+      );
+    } finally {
+      db.close();
+    }
+  });
+
+  it("treats absent scenarioPosition as null on load", () => {
+    const db = BunSqliteDatabase.open(":memory:");
+    try {
+      const repo = new SqliteConnectorRuntimeRepository(db);
+      // Save without scenarioPosition — backward-compat path.
+      const snap: ConnectorRuntimeSnapshot = {
+        status: OCPPStatus.Available,
+        availability: "Operative",
+        scheduledAvailability: null,
+        transaction: null,
+        meterValueWh: 0,
+        socPercent: null,
+        lastAutoStartedScenarioKey: null,
+      };
+      repo.save("cp-a", 1, snap);
+      const loaded = repo.load("cp-a", 1);
+      // Implementation may return undefined or null depending on
+      // serialisation path; both mean "no resume info, fresh start".
+      expect(loaded?.scenarioPosition ?? null).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("clears scenarioPosition when saved as null", () => {
+    const db = BunSqliteDatabase.open(":memory:");
+    try {
+      const repo = new SqliteConnectorRuntimeRepository(db);
+      repo.save("cp-a", 1, {
+        status: OCPPStatus.Charging,
+        availability: "Operative",
+        scheduledAvailability: null,
+        transaction: null,
+        meterValueWh: 0,
+        socPercent: null,
+        lastAutoStartedScenarioKey: null,
+        scenarioPosition: {
+          scenarioKey: "x",
+          lastCompletedNodeId: "n1",
+          executedNodes: ["n1"],
+        },
+      });
+      // Same row again, this time with scenarioPosition explicitly null
+      // (simulates the scenario-finished cleanup path).
+      repo.save("cp-a", 1, {
+        status: OCPPStatus.Available,
+        availability: "Operative",
+        scheduledAvailability: null,
+        transaction: null,
+        meterValueWh: 0,
+        socPercent: null,
+        lastAutoStartedScenarioKey: null,
+        scenarioPosition: null,
+      });
+      const loaded = repo.load("cp-a", 1);
+      expect(loaded?.scenarioPosition ?? null).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+
   it("refuses to open a DB whose schema version is newer than the build", () => {
     const db = BunSqliteDatabase.open(":memory:");
     try {

--- a/src/cp/domain/persistence/schema.ts
+++ b/src/cp/domain/persistence/schema.ts
@@ -13,7 +13,7 @@
  * persistence layer was localStorage and we explicitly do NOT carry it
  * forward (see plan).
  */
-export const SCHEMA_VERSION = 2;
+export const SCHEMA_VERSION = 3;
 
 export const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS schema_meta (
@@ -134,13 +134,12 @@ CREATE TABLE IF NOT EXISTS charge_point_state (
 -- StatusNotification / MeterValues stop arriving until an operator
 -- manually intervenes.
 --
--- Scope is deliberately small: just the OCPP-visible state plus the
--- in-flight transaction JSON and the meter accumulator. Scenario
--- execution position is NOT persisted yet (see follow-up), so a
--- restored Charging connector won't keep advancing through scenario
--- nodes on its own. It will, however, accept RemoteStopTransaction
--- through the daemon's default handler and emit a correctly-numbered
--- StopTransaction.req.
+-- Scope is the OCPP-visible state plus the in-flight transaction JSON
+-- and the meter accumulator. Since v3 we also persist scenario execution
+-- position so that a daemon restart mid-transaction resumes the same
+-- scenario node instead of replaying from the top (which previously left
+-- the Charging connector parked at "Wait for RemoteStartTransaction"
+-- forever, since the scenario never reaches its meterValue node again).
 CREATE TABLE IF NOT EXISTS connector_runtime (
   cp_id                            TEXT NOT NULL,
   connector_id                     INTEGER NOT NULL,
@@ -151,6 +150,7 @@ CREATE TABLE IF NOT EXISTS connector_runtime (
   meter_value_wh                   INTEGER NOT NULL DEFAULT 0,
   soc_percent                      REAL,
   last_auto_started_scenario_key   TEXT,
+  scenario_position_json           TEXT,
   updated_at                       TEXT NOT NULL,
   PRIMARY KEY (cp_id, connector_id)
 );
@@ -204,6 +204,22 @@ export function runMigrations(db: Database): void {
   const stored = row ? Number(row.value) : 0;
   if (Number.isFinite(stored) && stored > SCHEMA_VERSION) {
     throw new SchemaVersionMismatchError(stored, SCHEMA_VERSION);
+  }
+
+  // v2 → v3: add `scenario_position_json` column to `connector_runtime`
+  // so a daemon restart can resume the scenario at the saved node instead
+  // of replaying from the START node. SQLite has no `ADD COLUMN IF NOT
+  // EXISTS`, so we probe pragma table_info first.
+  if (stored < 3) {
+    const cols = db.all<{ name: string }>(
+      "PRAGMA table_info(connector_runtime)",
+    );
+    const have = new Set(cols.map((c) => c.name));
+    if (!have.has("scenario_position_json")) {
+      db.exec(
+        "ALTER TABLE connector_runtime ADD COLUMN scenario_position_json TEXT",
+      );
+    }
   }
 
   // (Place future forward migrations here, gated on `stored < N`.)

--- a/src/utils/scenarios/essential-cp-behavior.json
+++ b/src/utils/scenarios/essential-cp-behavior.json
@@ -1,12 +1,19 @@
 {
   "id": "essential-cp-behavior",
   "name": "Essential CP Behavior",
-  "description": "Auto-start on connect: plug in, wait for RemoteStart, run a transaction with auto-meter, then plug out.",
+  "description": "Auto-start on connect: plug in, wait for RemoteStart, run a transaction with auto-meter (stops at the EV's target SoC), then plug out.",
   "targetType": "connector",
   "targetId": 1,
   "trigger": { "type": "manual" },
   "defaultExecutionMode": "oneshot",
   "enabled": true,
+  "evSettings": {
+    "modelName": "Generic EV",
+    "batteryCapacityKwh": 75,
+    "maxChargingPowerKw": 150,
+    "initialSoc": 20,
+    "targetSoc": 80
+  },
   "nodes": [
     {
       "id": "start-1",
@@ -57,10 +64,10 @@
         "value": 0,
         "sendMessage": true,
         "autoIncrement": true,
+        "outputKw": 50,
         "incrementInterval": 5,
-        "incrementAmount": 1000,
-        "maxValue": 0,
-        "maxTime": 0
+        "incrementAmount": 69.44,
+        "stopMode": "evSettings"
       }
     },
     {


### PR DESCRIPTION
## Summary

Two cooperating changes. The first closes a long-standing daemon-restart-mid-charge hole; the second simplifies the most-edited scenario node.

### 1. Persist scenario execution position across daemon restarts

Until now, the persistence layer would faithfully bring \`connector_runtime.status = Charging\` plus the in-flight \`transaction_json\` back into memory on daemon startup, but the scenario would re-arm from its first node every time. Since the bundled \`essential-cp-behavior\` template only reaches its \`meterValue\` node by walking through \`tx-start\`, restoring with a saved transaction meant the auto-meter scheduler never started — no MeterValues messages, no \`ocpp_end_meter_value\` updates, and the CSMS-side transaction stayed \`Charging\` until a manual RemoteStop.

What changed:

- **Schema** bumped v2 → v3 with an additive \`connector_runtime.scenario_position_json\` column (nullable; old snapshots load with the field as \`null\` and fall back to a fresh start).
- **\`ConnectorRuntimeSnapshot\`** gains an optional \`scenarioPosition: { scenarioKey, lastCompletedNodeId, executedNodes }\`.
- **\`ScenarioExecutor.start({ resumeFromNodeId, executedNodes })\`** accepts a resume hint; the executor finds the resume node, seeds the state-machine context with the previously-executed nodes, and walks the outgoing edge from there. Every node up to and including \`resumeFromNodeId\` is treated as already executed and is NOT re-fired, so side-effecting nodes (Plug In, Start Transaction) don't double-emit OCPP traffic.
- If \`resumeFromNodeId\` no longer exists in the graph (scenario edited between runs), the executor logs a warning and falls back to a fresh start.
- **\`CLIChargePointService\`** subscribes to the executor's \`node.complete\` event, pushes the position into the connector_runtime row on every step, and clears it when the executor exits cleanly. \`restoreConnectorRuntimeFromDatabase\` stashes the loaded position in a per-connector map; \`runScenario\` consumes it on the next auto-start whose \`scenarioId\` matches the saved \`scenarioKey\`.

### 2. MeterValue node editor: kW / kWh simple inputs

The MeterValue node editor used to expose five raw inputs (Initial value Wh, Increment interval s, Increment amount Wh, Max time s, Max value Wh). The two questions the operator actually cares about are \"how fast?\" and \"how much?\" — measured in kW and kWh.

What changed:

- Two new optional \`MeterValueNodeData\` fields:
  - \`outputKw\` — the editor re-derives \`incrementAmount = outputKw × intervalSec × 1000/3600\` on every save, so the runtime contract is unchanged.
  - \`maxChargeKwh\` — mirrored into \`maxValue\` (Wh) on save so older daemon builds keep stopping at the same point.
- Simple section is always visible (Output (kW) + Max charge (kWh)) with a \"1 tick = N Wh at S s interval\" hint.
- Advanced section is collapsed by default — except for legacy scenarios that have raw \`incrementAmount\` and no \`outputKw\`, where it auto-expands so existing values remain visible.
- Editing the raw \`incrementAmount\` or \`maxValue\` clears the simple field so the next save doesn't overwrite the operator's manual value.
- Touching Output (kW) implicitly enables \`autoIncrement\` and \`sendMessage\` so the operator doesn't have to scroll into Advanced just to turn the scheduler on.

## Test plan

- [x] \`bun test\` + \`vitest run\`: 89/89 pass (3 new ScenarioExecutor.resume cases + 3 new SqliteConnectorRuntimeRepository round-trip cases for scenarioPosition).
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean on touched files.
- [ ] Manual: launch the daemon mid-transaction, kill it, restart with the same \`--state-db\` — verify the scenario resumes from after \`tx-start\` (MeterValues flow without a fresh \"Plug In\" replay).
- [ ] Manual: open the scenario editor, click a MeterValue node — verify the simple panel shows kW / kWh and the advanced toggle reveals the existing fields with values intact for legacy scenarios.

## Backward compatibility

- Existing snapshots written by older daemon builds load with \`scenarioPosition\` = null → fresh start, identical to today's behaviour.
- Scenarios authored with the new simple inputs round-trip through pre-v3 daemons because the raw \`incrementAmount\` / \`maxValue\` fields are still written; older daemons ignore \`outputKw\` and \`maxChargeKwh\`.