### PR TITLE
docs: highlight AI agent testing use case in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/shiv3/ocpp-cp-simulator)
 
-OCPP 1.6J charge point simulator with three interfaces: a browser-based UI, a legacy web version (v1), and a headless CLI for automation.
+OCPP 1.6J charge point simulator for **AI agent testing**, CI automation, and CSMS development. Comes with a browser UI, a headless CLI, and an HTTP control API that any agent or script can drive.
 
 | Interface     | Description                                              | Docs                               |
 | ------------- | -------------------------------------------------------- | ---------------------------------- |
@@ -28,7 +28,10 @@ bun src/cli/main.ts --ws-url ws://localhost:9000/ocpp --cp-id CP001
 ### Install as a global command (`ocpp-cp-sim`)
 
 ```bash
-# Prebuilt release tarball (includes the web-console bundle in dist/)
+# pnpm (recommended)
+pnpm install -g https://github.com/shiv3/ocpp-cp-simulator/releases/latest/download/ocpp-cp-simulator.tgz
+
+# bun
 bun install -g https://github.com/shiv3/ocpp-cp-simulator/releases/latest/download/ocpp-cp-simulator.tgz
 
 # Or pin to a specific CLI release
@@ -66,6 +69,37 @@ ocpp-cp-sim --http-port 5172 --web-console \
 ```
 
 `--web-console` serves the browser UI (built into `dist/` and shipped inside the release tarball) from the same HTTP port as the control API, so a single port is all you need to expose. See [docs/cli.md](docs/cli.md) for the full flag reference and [docs/server.md](docs/server.md) for the HTTP / WebSocket protocol.
+
+## AI Agent & Automation Testing
+
+The daemon exposes an HTTP/WebSocket control API and emits structured logs, making it a scriptable OCPP stub that any AI agent or test harness can drive.
+
+| Feature                                     | What it enables                                                 |
+| ------------------------------------------- | --------------------------------------------------------------- |
+| `--log-format json`                         | One JSON object per line — easy to parse or feed to an LLM      |
+| HTTP REST API (`POST /v1/cp/:cpId/command`) | Send OCPP commands from any language or agent                   |
+| Scenario templates (JSON)                   | Declare a full charging flow, inject at runtime without restart |
+| `WS /v1/cp/:cpId/events`                    | Subscribe to real-time OCPP events for assertions               |
+| `--state-db`                                | Persist CP state across restarts — no re-bootstrap needed       |
+
+**Minimal setup for an AI agent:**
+
+```bash
+# 1. Start daemon with structured logs
+ocpp-cp-sim --http-port 5172 --cp-id CP001 --connectors 1 \
+            --ws-url wss://your-csms/ocpp/ \
+            --state-db ./state.db --log-format json
+
+# 2. Trigger a transaction (agent POSTs this)
+curl -X POST http://127.0.0.1:5172/v1/cp/CP001/command \
+     -H 'Content-Type: application/json' \
+     -d '{"command":"start_transaction","params":{"connector":1,"tagId":"TAG001"}}'
+
+# 3. Stream events back to the agent
+wscat -c ws://127.0.0.1:5172/v1/cp/CP001/events
+```
+
+See [docs/server.md](docs/server.md) for the full HTTP API reference.
 
 ## Persistence
 


### PR DESCRIPTION
## Summary

- Update top description to lead with AI agent testing / CSMS development framing
- Add pnpm install command alongside bun
- Add "AI Agent & Automation Testing" section covering HTTP API, JSON-line logs, scenario templates, and WebSocket event stream

## Test plan

- [ ] README renders correctly on GitHub