### PR TITLE
feat: add OCPP 2.0.1 support and migrate to @cshil/ocpp-tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,9 @@
     "": {
       "name": "ocpp-cp-simulator",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
+        "@cshil/ocpp-tools": "^1.3.2",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -17,11 +19,11 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tauri-apps/api": "^2.7.0",
-        "@voltbras/ts-ocpp": "^2.7.3",
         "@xyflow/react": "^12.9.0",
         "eventemitter2": "^6.4.9",
         "flowbite": "^3.1.2",
         "flowbite-react": "^0.12.10",
+        "idb-keyval": "^6.2.4",
         "jotai": "^2.12.5",
         "jotai-location": "^0.5.5",
         "jotai-zustand": "^0.4.0",
@@ -31,7 +33,11 @@
         "react-robot": "^1.2.0",
         "react-router-dom": "^6.30.1",
         "robot3": "^1.2.0",
+        "sql.js": "^1.14.1",
         "zustand": "^4.5.7"
+      },
+      "bin": {
+        "ocpp-cp-sim": "src/cli/main.ts"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2.7.0",
@@ -39,6 +45,7 @@
         "@types/eventemitter2": "^2.2.1",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
+        "@types/sql.js": "^1.4.11",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
@@ -72,6 +79,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@cshil/ocpp-tools": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@cshil/ocpp-tools/-/ocpp-tools-1.3.2.tgz",
+      "integrity": "sha512-OcADGozjV65ah+UA4hvSPvmb5qjhyzqH5ZlqqNMmTeZVlSvuB/YrHBPw0oRSV+z78qfTWVFJfutnW7iyjJXEWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
+        "uuid": "14.0.0"
+      }
+    },
+    "node_modules/@cshil/ocpp-tools/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@cshil/ocpp-tools/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@cshil/ocpp-tools/node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1667,7 +1720,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1681,7 +1733,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1695,7 +1746,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1709,7 +1759,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1723,7 +1772,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1737,7 +1785,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1751,7 +1798,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1765,7 +1811,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1779,7 +1824,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1793,7 +1837,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1807,7 +1850,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1821,7 +1863,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1835,7 +1876,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1849,7 +1889,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1863,7 +1902,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1877,7 +1915,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2370,6 +2407,13 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2381,12 +2425,6 @@
       "resolved": "https://registry.npmjs.org/@types/eventemitter2/-/eventemitter2-2.2.1.tgz",
       "integrity": "sha512-pSQMP0ZoLV5RG7etHH/SZp+xSA+swYMOwutKh+UCF4Opy2/1oq5AAWQ8aje/kfc40aEBIeg2TZDw7+kZJKZqTg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2430,6 +2468,17 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/sql.js": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
+      "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -2824,28 +2873,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@voltbras/ts-ocpp": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/@voltbras/ts-ocpp/-/ts-ocpp-2.7.3.tgz",
-      "integrity": "sha512-ArlGLdKyj1CsgRdgy9UN++MRNqS9OhmLNAsIFn2m2ct17j0f0TqKg0sUFNglfqE03OHZYXZeCJtE7lcOrs6Q9w==",
-      "license": "MIT",
-      "dependencies": {
-        "jsonschema": "^1.4.0",
-        "purify-ts": "^0.16.1",
-        "soap": "^0.37.0",
-        "uuid": "^8.3.2",
-        "ws": "^7.4.4"
-      }
-    },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
-      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@xyflow/react": {
       "version": "12.9.0",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.9.0.tgz",
@@ -2905,6 +2932,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2916,6 +2944,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "7.0.0",
@@ -3017,24 +3084,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3056,12 +3105,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
@@ -3100,35 +3143,11 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT"
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -3252,12 +3271,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -3486,18 +3499,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -3532,12 +3533,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -3677,18 +3672,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/debounce": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
@@ -3752,25 +3735,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/des.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
-      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -3820,16 +3784,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.187",
@@ -4211,21 +4165,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4264,6 +4203,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -4272,6 +4212,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -4535,29 +4491,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -4622,27 +4555,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
       }
     },
     "node_modules/glob": {
@@ -4746,29 +4658,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4789,54 +4678,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
-    "node_modules/httpntlm": {
-      "version": "1.8.13",
-      "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.8.13.tgz",
-      "integrity": "sha512-2F2FDPiWT4rewPzNMg3uPhNkP3NExENlUGADRUDPQvuftuUTGW98nLZtGemCIW3G40VhWZYgkIDcQFAwZ3mf2Q==",
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://www.paypal.com/donate/?hosted_button_id=2CKNJLZJBW8ZC"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/samdecrock"
-        }
-      ],
-      "dependencies": {
-        "des.js": "^1.0.1",
-        "httpreq": ">=0.4.22",
-        "js-md4": "^0.3.2",
-        "underscore": "~1.12.1"
-      },
-      "engines": {
-        "node": ">=10.4.0"
-      }
-    },
-    "node_modules/httpreq": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-1.1.1.tgz",
-      "integrity": "sha512-uhSZLPPD2VXXOSN8Cni3kIsoFHaU2pT/nySEU/fHr/ePbqHYr0jeiQRmUKLEirC09SFPsdMoA7LU7UXMd/w0Kw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.15.1"
       }
     },
     "node_modules/human-signals": {
@@ -4863,6 +4704,12 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.5.tgz",
+      "integrity": "sha512-eKQkTnS0relYsSOYomx8ozIbmdsQCKUdhyuIaQ2DZgKuaxtyQQMkyD/wlnQN32pO3yutN1b1L8uqwcDKaJd7/Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -4917,6 +4764,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-binary-path": {
@@ -5014,23 +4862,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -5094,12 +4930,6 @@
         "jotai": ">=2.0.0"
       }
     },
-    "node_modules/js-md4": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
-      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
-      "license": "MIT"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5119,12 +4949,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -5132,16 +4956,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -5150,36 +4969,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
-    },
-    "node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -5397,12 +5186,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5622,27 +5405,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -5677,12 +5439,6 @@
       "bin": {
         "mini-svg-data-uri": "cli.js"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "9.0.5",
@@ -5801,15 +5557,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/object-assign": {
@@ -6008,12 +5755,6 @@
       "engines": {
         "node": ">= 14.16"
       }
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6231,37 +5972,14 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "license": "MIT"
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/purify-ts": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/purify-ts/-/purify-ts-0.16.3.tgz",
-      "integrity": "sha512-ZEmLC0myQiV672QM5ZD//KyoCDXQltBvdR9q12NUk5d1tS1d7paut0U8/13Xl4dJ/pA1JYJg6gHhoiaqy2O1bg==",
-      "license": "ISC",
-      "dependencies": {
-        "@types/json-schema": "7.0.7"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/queue-microtask": {
@@ -6458,46 +6176,13 @@
         "node": ">= 4"
       }
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -6668,38 +6353,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC"
-    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -6814,26 +6467,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/soap": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/soap/-/soap-0.37.0.tgz",
-      "integrity": "sha512-AFVq9EzLcZBoqhi06reLfAyYj6oj0GfBX+yyt7beMW/BdfH8MeL/OhgUabKvpNEqW5vo94VNIHEgN1r8GBH3dQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^6.0.0",
-        "httpntlm": "^1.5.2",
-        "lodash": "^4.17.19",
-        "request": ">=2.9.0",
-        "sax": ">=0.6",
-        "strip-bom": "^3.0.0",
-        "uuid": "^8.3.0",
-        "xml-crypto": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6852,30 +6485,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "license": "MIT"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -6989,15 +6603,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/strip-final-newline": {
@@ -7268,19 +6873,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -7305,24 +6897,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7361,12 +6935,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
-      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -7409,6 +6977,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -7471,29 +7040,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "node_modules/vite": {
       "version": "5.4.19",
@@ -7785,48 +7331,6 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/xml-crypto": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.6.tgz",
-      "integrity": "sha512-jjvpO8vHNV8QFhW5bMypP+k4BjBqHe/HrpIwpPcdUnUTIJakSIuN96o3Sdah4tKu2z64kM/JHEH8iEHGCc6Gyw==",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.7.9",
-        "xpath": "0.0.32"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/xpath": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
-      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0"
-      }
     },
     "node_modules/yaml": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "cli": "bun src/cli/main.ts"
   },
   "dependencies": {
+    "@cshil/ocpp-tools": "^1.3.2",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -41,7 +42,6 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tauri-apps/api": "^2.7.0",
-    "@voltbras/ts-ocpp": "^2.7.3",
     "@xyflow/react": "^12.9.0",
     "eventemitter2": "^6.4.9",
     "flowbite": "^3.1.2",

--- a/src/components/ChargePointConfigModal.tsx
+++ b/src/components/ChargePointConfigModal.tsx
@@ -273,6 +273,7 @@ const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="OCPP-1.6J">OCPP 1.6J</SelectItem>
+                    <SelectItem value="OCPP-2.0.1">OCPP 2.0.1</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -6,6 +6,8 @@ import { Connector } from "../connector/Connector";
 import type { ChargePointEvents } from "./ChargePointEvents";
 import { ConfigurationStore } from "./ConfigurationStore";
 import { OCPPMessageHandler } from "../../infrastructure/transport/OCPPMessageHandler";
+import { OCPPMessageHandlerV201 } from "../../infrastructure/transport/OCPPMessageHandlerV201";
+import type { IChargePointMessageHandler } from "../../infrastructure/transport/IChargePointMessageHandler";
 import { OCPPWebSocket } from "../../infrastructure/transport/OCPPWebSocket";
 import type { Database } from "../persistence/Database";
 import { LogRepository } from "../persistence/LogRepository";
@@ -41,7 +43,7 @@ export class ChargePoint {
   private readonly _logger = new Logger();
   private readonly _events = new EventEmitter<ChargePointEvents>();
   private readonly _webSocket: OCPPWebSocket;
-  private readonly _messageHandler: OCPPMessageHandler;
+  private readonly _messageHandler: IChargePointMessageHandler;
   private readonly _heartbeat: HeartbeatService;
   private readonly _stateManager: StateManager;
   private readonly _logRepository: LogRepository;
@@ -89,6 +91,7 @@ export class ChargePoint {
      *  pick the same values up. CLI-only (DOM WebSocket ignores headers). */
     extraWsHeaders: Record<string, string> = {},
     extraWsSubprotocols: ReadonlyArray<string> = [],
+    ocppVersion: string = "OCPP-1.6J",
   ) {
     this._autoMeterValueSetting = autoMeterValueSetting;
     this._logger.setCpId(this._id);
@@ -166,12 +169,12 @@ export class ChargePoint {
       basicAuthSettings,
       extraWsHeaders,
       extraWsSubprotocols,
+      ocppVersion,
     );
-    this._messageHandler = new OCPPMessageHandler(
-      this,
-      this._webSocket,
-      this._logger,
-    );
+    this._messageHandler =
+      ocppVersion === "OCPP-2.0.1"
+        ? new OCPPMessageHandlerV201(this, this._webSocket, this._logger)
+        : new OCPPMessageHandler(this, this._webSocket, this._logger);
 
     this._heartbeat = new HeartbeatService(this._logger);
     this._heartbeat.setHeartbeatCallback(() =>

--- a/src/cp/domain/types/OcppTypes.ts
+++ b/src/cp/domain/types/OcppTypes.ts
@@ -1,14 +1,18 @@
-import { ErrorCode, MessageType } from "@voltbras/ts-ocpp/dist/ws";
 import {
-  BootNotificationRequest,
-  ReserveNowRequest,
-  CancelReservationRequest,
-} from "@voltbras/ts-ocpp/dist/messages/json/request";
-import {
-  ReserveNowResponse,
-  CancelReservationResponse,
-} from "@voltbras/ts-ocpp/dist/messages/json/response";
+  OCPPErrorCodeV16,
+  type BootNotificationRequestV16,
+  type ReserveNowRequestV16,
+  type ReserveNowResponseV16,
+  type CancelReservationRequestV16,
+  type CancelReservationResponseV16,
+} from "@cshil/ocpp-tools";
 import { LogLevel, LogType } from "../../shared/Logger";
+
+export enum OCPPMessageType {
+  CALL = 2,
+  CALLRESULT = 3,
+  CALLERROR = 4,
+}
 
 export enum OCPPStatus {
   Available = "Available",
@@ -100,9 +104,6 @@ export const ALL_CHARGE_POINT_ERROR_CODES: ChargePointErrorCode[] = [
   "WeakSignal",
 ];
 
-// Re-export MessageType from ts-ocpp for convenience
-export { MessageType as OCPPMessageType };
-
 export enum OCPPAction {
   // Core actions
   Authorize = "Authorize",
@@ -164,10 +165,9 @@ export type OcppConfigurationKey = {
   value?: string;
 };
 
-export type OCPPErrorCode = ErrorCode;
+export type OCPPErrorCode = OCPPErrorCodeV16;
 
-// Re-export BootNotificationRequest from ts-ocpp
-export type BootNotification = BootNotificationRequest;
+export type BootNotification = BootNotificationRequestV16;
 
 export const DefaultBootNotification: BootNotification = {
   chargeBoxSerialNumber: "123456",
@@ -207,11 +207,10 @@ export enum CancelReservationStatus {
   Rejected = "Rejected",
 }
 
-// Re-export reservation request/response types from ts-ocpp
-export type ReserveNow = ReserveNowRequest;
-export type ReserveNowResponseType = ReserveNowResponse;
-export type CancelReservation = CancelReservationRequest;
-export type CancelReservationResponseType = CancelReservationResponse;
+export type ReserveNow = ReserveNowRequestV16;
+export type ReserveNowResponseType = ReserveNowResponseV16;
+export type CancelReservation = CancelReservationRequestV16;
+export type CancelReservationResponseType = CancelReservationResponseV16;
 
 // ============================================
 // Smart Charging Profile Types (OCPP 1.6)

--- a/src/cp/infrastructure/transport/IChargePointMessageHandler.ts
+++ b/src/cp/infrastructure/transport/IChargePointMessageHandler.ts
@@ -1,0 +1,45 @@
+import type {
+  BootNotification,
+  ChargePointErrorCode,
+  OCPPStatus,
+} from "../../domain/types/OcppTypes";
+import type { Transaction } from "../../domain/connector/Transaction";
+import type { ReadingContext } from "../../domain/connector/MeterValueBuilder";
+import type { DataTransferHandler } from "./handlers";
+
+export interface IChargePointMessageHandler {
+  sendBootNotification(bootPayload: BootNotification): void;
+  sendHeartbeat(): void;
+  sendStatusNotification(
+    connectorId: number,
+    status: OCPPStatus,
+    opts?: {
+      errorCode?: ChargePointErrorCode;
+      info?: string;
+      vendorErrorCode?: string;
+      vendorId?: string;
+      timestamp?: Date;
+    },
+  ): void;
+  authorize(tagId: string): void;
+  startTransaction(transaction: Transaction, connectorId: number): void;
+  stopTransaction(transaction: Transaction, connectorId: number): void;
+  sendMeterValue(
+    transactionId: number | undefined,
+    connectorId: number,
+    context?: ReadingContext,
+  ): void;
+  sendDataTransfer(vendorId: string, messageId: string, data?: string): void;
+  sendDiagnosticsStatusNotification(status: string): void;
+  sendFirmwareStatusNotification(status: string): void;
+  setBootStatus(
+    status:
+      | { status: "Idle" }
+      | { status: "Accepted" }
+      | { status: "Pending" }
+      | { status: "Rejected"; retryAfter: Date },
+  ): void;
+  getDataTransferHandler(): DataTransferHandler;
+  onWebSocketClosed(): void;
+  flushPendingQueue(): void;
+}

--- a/src/cp/infrastructure/transport/OCPPMessageHandler.ts
+++ b/src/cp/infrastructure/transport/OCPPMessageHandler.ts
@@ -1,3 +1,43 @@
+import type {
+  AuthorizeRequestV16,
+  AuthorizeResponseV16,
+  BootNotificationResponseV16,
+  CancelReservationRequestV16,
+  ChangeAvailabilityRequestV16,
+  ChangeConfigurationRequestV16,
+  ChangeConfigurationResponseV16,
+  ClearCacheRequestV16,
+  ClearChargingProfileRequestV16,
+  DataTransferRequestV16,
+  DataTransferResponseV16,
+  DiagnosticsStatusNotificationRequestV16,
+  DiagnosticsStatusNotificationResponseV16,
+  FirmwareStatusNotificationRequestV16,
+  FirmwareStatusNotificationResponseV16,
+  GetCompositeScheduleRequestV16,
+  GetConfigurationRequestV16,
+  GetDiagnosticsRequestV16,
+  GetLocalListVersionRequestV16,
+  HeartbeatRequestV16,
+  HeartbeatResponseV16,
+  MeterValuesRequestV16,
+  MeterValuesResponseV16,
+  RemoteStartTransactionRequestV16,
+  RemoteStopTransactionRequestV16,
+  ReserveNowRequestV16,
+  ResetRequestV16,
+  SendLocalListRequestV16,
+  SetChargingProfileRequestV16,
+  StartTransactionRequestV16,
+  StartTransactionResponseV16,
+  StatusNotificationRequestV16,
+  StatusNotificationResponseV16,
+  StopTransactionRequestV16,
+  StopTransactionResponseV16,
+  TriggerMessageRequestV16,
+  UnlockConnectorRequestV16,
+  UpdateFirmwareRequestV16,
+} from "@cshil/ocpp-tools";
 import {
   OcppMessageErrorPayload,
   OcppMessagePayload,
@@ -21,9 +61,6 @@ import {
   OCPPMessageType,
   OCPPStatus,
 } from "../../domain/types/OcppTypes";
-
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
 
 // Import handler registry and handlers
 import {
@@ -59,33 +96,33 @@ import {
 } from "./handlers";
 
 type CoreOcppMessagePayloadCall =
-  | request.ChangeAvailabilityRequest
-  | request.ChangeConfigurationRequest
-  | request.ClearCacheRequest
-  | request.GetConfigurationRequest
-  | request.RemoteStartTransactionRequest
-  | request.RemoteStopTransactionRequest
-  | request.ResetRequest
-  | request.UnlockConnectorRequest;
+  | ChangeAvailabilityRequestV16
+  | ChangeConfigurationRequestV16
+  | ClearCacheRequestV16
+  | GetConfigurationRequestV16
+  | RemoteStartTransactionRequestV16
+  | RemoteStopTransactionRequestV16
+  | ResetRequestV16
+  | UnlockConnectorRequestV16;
 
 type FirmwareManagementOcppMessagePayloadCall =
-  | request.GetDiagnosticsRequest
-  | request.UpdateFirmwareRequest;
+  | GetDiagnosticsRequestV16
+  | UpdateFirmwareRequestV16;
 
 type LocalAuthListManagementOcppMessagePayloadCall =
-  | request.GetLocalListVersionRequest
-  | request.SendLocalListRequest;
+  | GetLocalListVersionRequestV16
+  | SendLocalListRequestV16;
 
 type ReservationOcppMessagePayloadCall =
-  | request.CancelReservationRequest
-  | request.ReserveNowRequest;
+  | CancelReservationRequestV16
+  | ReserveNowRequestV16;
 
 type SmartChargingOcppMessagePayloadCall =
-  | request.ClearChargingProfileRequest
-  | request.GetCompositeScheduleRequest
-  | request.SetChargingProfileRequest;
+  | ClearChargingProfileRequestV16
+  | GetCompositeScheduleRequestV16
+  | SetChargingProfileRequestV16;
 
-type RemoteTriggerOcppMessagePayloadCall = request.TriggerMessageRequest;
+type RemoteTriggerOcppMessagePayloadCall = TriggerMessageRequestV16;
 
 type OcppMessagePayloadCall =
   | CoreOcppMessagePayloadCall
@@ -96,19 +133,19 @@ type OcppMessagePayloadCall =
   | RemoteTriggerOcppMessagePayloadCall;
 
 type CoreOcppMessagePayloadCallResult =
-  | response.AuthorizeResponse
-  | response.BootNotificationResponse
-  | response.ChangeConfigurationResponse
-  | response.DataTransferResponse
-  | response.HeartbeatResponse
-  | response.MeterValuesResponse
-  | response.StartTransactionResponse
-  | response.StatusNotificationResponse
-  | response.StopTransactionResponse;
+  | AuthorizeResponseV16
+  | BootNotificationResponseV16
+  | ChangeConfigurationResponseV16
+  | DataTransferResponseV16
+  | HeartbeatResponseV16
+  | MeterValuesResponseV16
+  | StartTransactionResponseV16
+  | StatusNotificationResponseV16
+  | StopTransactionResponseV16;
 
 type FirmwareManagementOcppMessagePayloadCallResult =
-  | response.DiagnosticsStatusNotificationResponse
-  | response.FirmwareStatusNotificationResponse;
+  | DiagnosticsStatusNotificationResponseV16
+  | FirmwareStatusNotificationResponseV16;
 
 type OcppMessagePayloadCallResult =
   | CoreOcppMessagePayloadCallResult
@@ -381,13 +418,13 @@ export class OCPPMessageHandler {
 
   public authorize(tagId: string): void {
     const messageId = this.generateMessageId();
-    const payload: request.AuthorizeRequest = { idTag: tagId };
+    const payload: AuthorizeRequestV16 = { idTag: tagId };
     this.sendRequest(OCPPAction.Authorize, messageId, payload);
   }
 
   public startTransaction(transaction: Transaction, connectorId: number): void {
     const messageId = this.generateMessageId();
-    const payload: request.StartTransactionRequest = {
+    const payload: StartTransactionRequestV16 = {
       connectorId: connectorId,
       idTag: transaction.tagId,
       meterStart: transaction.meterStart,
@@ -413,7 +450,7 @@ export class OCPPMessageHandler {
     // transaction.stopReason in non-default stop paths (Remote / Reset /
     // EVDisconnected / UnlockCommand / DeAuthorized / …).
     const reason = transaction.stopReason;
-    const payload: request.StopTransactionRequest = {
+    const payload: StopTransactionRequestV16 = {
       transactionId: transaction.id!,
       idTag: transaction.tagId,
       meterStop: transaction.meterStop!,
@@ -436,7 +473,7 @@ export class OCPPMessageHandler {
 
   public sendHeartbeat(): void {
     const messageId = this.generateMessageId();
-    const payload: request.HeartbeatRequest = {};
+    const payload: HeartbeatRequestV16 = {};
     this.sendRequest(OCPPAction.Heartbeat, messageId, payload);
   }
 
@@ -452,7 +489,7 @@ export class OCPPMessageHandler {
     data?: string,
   ): void {
     const id = this.generateMessageId();
-    const payload: request.DataTransferRequest = {
+    const payload: DataTransferRequestV16 = {
       vendorId,
       ...(messageId !== undefined ? { messageId } : {}),
       ...(data !== undefined ? { data } : {}),
@@ -470,7 +507,7 @@ export class OCPPMessageHandler {
     status: "Idle" | "Uploaded" | "UploadFailed" | "Uploading",
   ): void {
     const messageId = this.generateMessageId();
-    const payload: request.DiagnosticsStatusNotificationRequest = { status };
+    const payload: DiagnosticsStatusNotificationRequestV16 = { status };
     this.sendRequest(
       OCPPAction.DiagnosticsStatusNotification,
       messageId,
@@ -495,7 +532,7 @@ export class OCPPMessageHandler {
       | "Installed",
   ): void {
     const messageId = this.generateMessageId();
-    const payload: request.FirmwareStatusNotificationRequest = { status };
+    const payload: FirmwareStatusNotificationRequestV16 = { status };
     this.sendRequest(OCPPAction.FirmwareStatusNotification, messageId, payload);
   }
 
@@ -526,7 +563,7 @@ export class OCPPMessageHandler {
     ) ?? ["Energy.Active.Import.Register"];
     const sampledValue = buildSampledValues(connector, measurands, context);
 
-    const payload: request.MeterValuesRequest = {
+    const payload: MeterValuesRequestV16 = {
       transactionId,
       connectorId,
       meterValue: [
@@ -537,7 +574,7 @@ export class OCPPMessageHandler {
           // generated type is a strict union. Cast at this boundary
           // rather than mirror the entire enum.
           sampledValue:
-            sampledValue as unknown as request.MeterValuesRequest["meterValue"][0]["sampledValue"],
+            sampledValue as unknown as MeterValuesRequestV16["meterValue"][0]["sampledValue"],
         },
       ],
     };
@@ -561,7 +598,7 @@ export class OCPPMessageHandler {
     },
   ): void {
     const messageId = this.generateMessageId();
-    const payload: request.StatusNotificationRequest = {
+    const payload: StatusNotificationRequestV16 = {
       connectorId,
       errorCode: opts?.errorCode ?? "NoError",
       status,
@@ -825,7 +862,7 @@ export class OCPPMessageHandler {
         handler = new StopTransactionResultHandler(request.connectorId || 1);
       } else if (action === OCPPAction.MeterValues) {
         handler = new MeterValuesResultHandler(
-          request.payload as request.MeterValuesRequest,
+          request.payload as MeterValuesRequestV16,
         );
       }
     }

--- a/src/cp/infrastructure/transport/OCPPMessageHandlerV201.ts
+++ b/src/cp/infrastructure/transport/OCPPMessageHandlerV201.ts
@@ -1,0 +1,372 @@
+import type {
+  BootNotificationRequestV201,
+  HeartbeatRequestV201,
+  HeartbeatResponseV201,
+  BootNotificationResponseV201,
+  StatusNotificationRequestV201,
+  StatusNotificationResponseV201,
+  TransactionEventRequestV201,
+  TransactionEventResponseV201,
+  MeterValuesRequestV201,
+  MeterValuesResponseV201,
+  AuthorizeRequestV201,
+  AuthorizeResponseV201,
+} from "@cshil/ocpp-tools";
+import { OCPPWebSocket } from "./OCPPWebSocket";
+import { Logger, LogType } from "../../shared/Logger";
+import {
+  BootNotification,
+  ChargePointErrorCode,
+  OCPPMessageType,
+  OCPPStatus,
+} from "../../domain/types/OcppTypes";
+import { Transaction } from "../../domain/connector/Transaction";
+import {
+  buildSampledValues,
+  type ReadingContext,
+} from "../../domain/connector/MeterValueBuilder";
+import { ChargePoint } from "../../domain/charge-point/ChargePoint";
+import type { IChargePointMessageHandler } from "./IChargePointMessageHandler";
+import { DataTransferHandler } from "./handlers";
+
+type V201Action =
+  | "BootNotification"
+  | "Heartbeat"
+  | "StatusNotification"
+  | "TransactionEvent"
+  | "MeterValues"
+  | "Authorize";
+
+type V201RequestPayload =
+  | BootNotificationRequestV201
+  | HeartbeatRequestV201
+  | StatusNotificationRequestV201
+  | TransactionEventRequestV201
+  | MeterValuesRequestV201
+  | AuthorizeRequestV201;
+
+type V201ResponsePayload =
+  | BootNotificationResponseV201
+  | HeartbeatResponseV201
+  | StatusNotificationResponseV201
+  | TransactionEventResponseV201
+  | MeterValuesResponseV201
+  | AuthorizeResponseV201;
+
+function ocppStatusToV201(
+  status: OCPPStatus,
+): StatusNotificationRequestV201["connectorStatus"] {
+  switch (status) {
+    case OCPPStatus.Available:
+      return "Available";
+    case OCPPStatus.Reserved:
+      return "Reserved";
+    case OCPPStatus.Unavailable:
+      return "Unavailable";
+    case OCPPStatus.Faulted:
+      return "Faulted";
+    default:
+      return "Occupied";
+  }
+}
+
+export class OCPPMessageHandlerV201 implements IChargePointMessageHandler {
+  private readonly _chargePoint: ChargePoint;
+  private readonly _webSocket: OCPPWebSocket;
+  private readonly _logger: Logger;
+  private readonly _dataTransferHandler: DataTransferHandler =
+    new DataTransferHandler();
+  private _bootStatus:
+    | { status: "Idle" }
+    | { status: "Accepted" }
+    | { status: "Pending" }
+    | { status: "Rejected"; retryAfter: Date } = { status: "Idle" };
+  private _seqNo = 0;
+  private readonly _transactionIds = new Map<number, string>();
+
+  constructor(
+    chargePoint: ChargePoint,
+    webSocket: OCPPWebSocket,
+    logger: Logger,
+  ) {
+    this._chargePoint = chargePoint;
+    this._webSocket = webSocket;
+    this._logger = logger;
+
+    this._webSocket.setMessageHandler(this.handleIncomingMessage.bind(this));
+  }
+
+  private generateMessageId(): string {
+    return crypto.randomUUID();
+  }
+
+  private nextSeqNo(): number {
+    return this._seqNo++;
+  }
+
+  private getOrCreateTransactionId(numericId: number): string {
+    let id = this._transactionIds.get(numericId);
+    if (!id) {
+      id = crypto.randomUUID();
+      this._transactionIds.set(numericId, id);
+    }
+    return id;
+  }
+
+  private send(
+    action: V201Action,
+    messageId: string,
+    payload: V201RequestPayload,
+  ): void {
+    if (!this._webSocket.isConnected()) {
+      this._logger.warn(
+        `[v2.0.1] Not connected, dropping ${action}`,
+        LogType.WEBSOCKET,
+      );
+      return;
+    }
+    this._webSocket.sendAction(messageId, action as never, payload as never);
+  }
+
+  private handleIncomingMessage(
+    messageType: OCPPMessageType,
+    messageId: string,
+    _action: string,
+    payload: unknown,
+  ): void {
+    if (messageType === OCPPMessageType.CALLRESULT) {
+      this.handleCallResult(messageId, payload as V201ResponsePayload);
+    } else if (messageType === OCPPMessageType.CALLERROR) {
+      this._logger.warn(`[v2.0.1] CALLERROR for ${messageId}`, LogType.OCPP);
+    }
+  }
+
+  private handleCallResult(
+    messageId: string,
+    payload: V201ResponsePayload,
+  ): void {
+    const bootResult = payload as BootNotificationResponseV201;
+    if (
+      bootResult.status !== undefined &&
+      bootResult.currentTime !== undefined &&
+      bootResult.interval !== undefined
+    ) {
+      this._logger.info(
+        `[v2.0.1] BootNotification response: ${bootResult.status}`,
+        LogType.OCPP,
+      );
+      if (bootResult.status === "Accepted") {
+        this._chargePoint.onBootNotificationAccepted(
+          bootResult.currentTime,
+          bootResult.interval,
+        );
+      } else if (bootResult.status === "Pending") {
+        this._chargePoint.onBootNotificationPending(bootResult.interval);
+      } else {
+        this._chargePoint.onBootNotificationRejected(bootResult.interval);
+      }
+    }
+  }
+
+  public sendBootNotification(bootPayload: BootNotification): void {
+    const messageId = this.generateMessageId();
+    const payload: BootNotificationRequestV201 = {
+      reason: "PowerUp",
+      chargingStation: {
+        model: bootPayload.chargePointModel,
+        vendorName: bootPayload.chargePointVendor,
+        serialNumber: bootPayload.chargePointSerialNumber,
+        firmwareVersion: bootPayload.firmwareVersion,
+        modem:
+          bootPayload.iccid || bootPayload.imsi
+            ? { iccid: bootPayload.iccid, imsi: bootPayload.imsi }
+            : undefined,
+      },
+    };
+    this.send("BootNotification", messageId, payload);
+  }
+
+  public sendHeartbeat(): void {
+    const messageId = this.generateMessageId();
+    const payload: HeartbeatRequestV201 = {};
+    this.send("Heartbeat", messageId, payload);
+  }
+
+  public sendStatusNotification(
+    connectorId: number,
+    status: OCPPStatus,
+    _opts?: {
+      errorCode?: ChargePointErrorCode;
+      info?: string;
+      vendorErrorCode?: string;
+      vendorId?: string;
+      timestamp?: Date;
+    },
+  ): void {
+    if (connectorId === 0) return;
+
+    const messageId = this.generateMessageId();
+    const payload: StatusNotificationRequestV201 = {
+      timestamp: new Date().toISOString(),
+      connectorStatus: ocppStatusToV201(status),
+      evseId: connectorId,
+      connectorId: 1,
+    };
+    this.send("StatusNotification", messageId, payload);
+  }
+
+  public authorize(tagId: string): void {
+    const messageId = this.generateMessageId();
+    const payload: AuthorizeRequestV201 = {
+      idToken: { idToken: tagId, type: "ISO14443" },
+    };
+    this.send("Authorize", messageId, payload);
+  }
+
+  public startTransaction(transaction: Transaction, connectorId: number): void {
+    const transactionId = this.getOrCreateTransactionId(connectorId);
+    const messageId = this.generateMessageId();
+    const payload: TransactionEventRequestV201 = {
+      eventType: "Started",
+      timestamp: transaction.startTime.toISOString(),
+      triggerReason: "Authorized",
+      seqNo: this.nextSeqNo(),
+      transaction: {
+        transactionId,
+        chargingState: "Charging",
+      },
+      idToken: { idToken: transaction.tagId, type: "ISO14443" },
+      evse: { id: connectorId, connectorId: 1 },
+      meterValue: [
+        {
+          timestamp: transaction.startTime.toISOString(),
+          sampledValue: [
+            {
+              value: String(transaction.meterStart / 1000),
+              measurand: "Energy.Active.Import.Register",
+              unitOfMeasure: { unit: "kWh" },
+            },
+          ],
+        },
+      ],
+    };
+    this.send("TransactionEvent", messageId, payload);
+  }
+
+  public stopTransaction(transaction: Transaction, connectorId: number): void {
+    const transactionId = this.getOrCreateTransactionId(connectorId);
+    const messageId = this.generateMessageId();
+    const payload: TransactionEventRequestV201 = {
+      eventType: "Ended",
+      timestamp: new Date().toISOString(),
+      triggerReason: "StopAuthorized",
+      seqNo: this.nextSeqNo(),
+      transaction: {
+        transactionId,
+        stoppedReason: "Local",
+      },
+      evse: { id: connectorId, connectorId: 1 },
+      meterValue:
+        transaction.meterStop !== null
+          ? [
+              {
+                timestamp: new Date().toISOString(),
+                sampledValue: [
+                  {
+                    value: String(transaction.meterStop / 1000),
+                    measurand: "Energy.Active.Import.Register",
+                    unitOfMeasure: { unit: "kWh" },
+                  },
+                ],
+              },
+            ]
+          : undefined,
+    };
+    this.send("TransactionEvent", messageId, payload);
+    this._transactionIds.delete(connectorId);
+  }
+
+  public sendMeterValue(
+    _transactionId: number | undefined,
+    connectorId: number,
+    context: ReadingContext = "Sample.Periodic",
+  ): void {
+    const messageId = this.generateMessageId();
+    const connector = this._chargePoint.getConnector(connectorId);
+    if (!connector) {
+      this._logger.warn(
+        `[v2.0.1] sendMeterValue: connector ${connectorId} not found`,
+        LogType.METER_VALUE,
+      );
+      return;
+    }
+
+    const measurands = this._chargePoint.configuration.getArray(
+      "MeterValuesSampledData",
+    ) ?? ["Energy.Active.Import.Register"];
+    const sampledValues = buildSampledValues(connector, measurands, context);
+
+    const payload: MeterValuesRequestV201 = {
+      evseId: connectorId,
+      meterValue: [
+        {
+          timestamp: new Date().toISOString(),
+          sampledValue: sampledValues.map((sv) => ({
+            value: String(sv.value),
+            measurand:
+              sv.measurand as MeterValuesRequestV201["meterValue"][0]["sampledValue"][0]["measurand"],
+            unitOfMeasure: sv.unit ? { unit: sv.unit } : undefined,
+          })),
+        },
+      ],
+    };
+    this.send("MeterValues", messageId, payload);
+  }
+
+  public sendDataTransfer(
+    _vendorId: string,
+    _messageId: string,
+    _data?: string,
+  ): void {
+    this._logger.warn(
+      "[v2.0.1] DataTransfer not supported in OCPP 2.0.1",
+      LogType.OCPP,
+    );
+  }
+
+  public sendDiagnosticsStatusNotification(_status: string): void {
+    this._logger.warn(
+      "[v2.0.1] DiagnosticsStatusNotification not supported in OCPP 2.0.1",
+      LogType.OCPP,
+    );
+  }
+
+  public sendFirmwareStatusNotification(_status: string): void {
+    this._logger.warn(
+      "[v2.0.1] FirmwareStatusNotification not supported in OCPP 2.0.1",
+      LogType.OCPP,
+    );
+  }
+
+  public setBootStatus(
+    status:
+      | { status: "Idle" }
+      | { status: "Accepted" }
+      | { status: "Pending" }
+      | { status: "Rejected"; retryAfter: Date },
+  ): void {
+    this._bootStatus = status;
+  }
+
+  public getDataTransferHandler(): DataTransferHandler {
+    return this._dataTransferHandler;
+  }
+
+  public onWebSocketClosed(): void {
+    this._seqNo = 0;
+  }
+
+  public flushPendingQueue(): void {
+    // OCPP 2.0.1: pending queue handled by TransactionEvent seqNo mechanism
+  }
+}

--- a/src/cp/infrastructure/transport/OCPPWebSocket.ts
+++ b/src/cp/infrastructure/transport/OCPPWebSocket.ts
@@ -5,8 +5,23 @@ import {
   OCPPErrorCode,
   OCPPMessageType,
 } from "../../domain/types/OcppTypes";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import type {
+  AuthorizeRequestV16,
+  BootNotificationRequestV16,
+  HeartbeatRequestV16,
+  MeterValuesRequestV16,
+  StartTransactionRequestV16,
+  StatusNotificationRequestV16,
+  StopTransactionRequestV16,
+  ChangeConfigurationResponseV16,
+  GetConfigurationResponseV16,
+  GetDiagnosticsResponseV16,
+  RemoteStartTransactionResponseV16,
+  RemoteStopTransactionResponseV16,
+  ResetResponseV16,
+  TriggerMessageResponseV16,
+  UnlockConnectorResponseV16,
+} from "@cshil/ocpp-tools";
 
 export type OcppMessagePayload =
   | OcppMessageRequestPayload
@@ -14,23 +29,23 @@ export type OcppMessagePayload =
   | OcppMessageErrorPayload;
 
 export type OcppMessageRequestPayload =
-  | request.AuthorizeRequest
-  | request.BootNotificationRequest
-  | request.HeartbeatRequest
-  | request.MeterValuesRequest
-  | request.StartTransactionRequest
-  | request.StatusNotificationRequest
-  | request.StopTransactionRequest;
+  | AuthorizeRequestV16
+  | BootNotificationRequestV16
+  | HeartbeatRequestV16
+  | MeterValuesRequestV16
+  | StartTransactionRequestV16
+  | StatusNotificationRequestV16
+  | StopTransactionRequestV16;
 
 export type OcppMessageResponsePayload =
-  | response.ChangeConfigurationResponse
-  | response.GetConfigurationResponse
-  | response.GetDiagnosticsResponse
-  | response.RemoteStartTransactionResponse
-  | response.RemoteStopTransactionResponse
-  | response.ResetResponse
-  | response.TriggerMessageResponse
-  | response.UnlockConnectorResponse;
+  | ChangeConfigurationResponseV16
+  | GetConfigurationResponseV16
+  | GetDiagnosticsResponseV16
+  | RemoteStartTransactionResponseV16
+  | RemoteStopTransactionResponseV16
+  | ResetResponseV16
+  | TriggerMessageResponseV16
+  | UnlockConnectorResponseV16;
 
 export type OcppMessageErrorPayload = {
   readonly errorCode: OCPPErrorCode;
@@ -66,6 +81,7 @@ export class OCPPWebSocket {
   // the runtime fallback in openOcppWebSocket handles that.
   private _extraHeaders: Record<string, string>;
   private _extraSubprotocols: ReadonlyArray<string>;
+  private _ocppVersion: string;
 
   constructor(
     url: string,
@@ -74,9 +90,11 @@ export class OCPPWebSocket {
     basicAuthSettings: { username: string; password: string } | null = null,
     extraHeaders: Record<string, string> = {},
     extraSubprotocols: ReadonlyArray<string> = [],
+    ocppVersion: string = "OCPP-1.6J",
   ) {
     this._url = url;
     this._chargePointId = chargePointId;
+    this._ocppVersion = ocppVersion;
     this._logger = logger;
     if (basicAuthSettings) {
       this._basicAuth = {
@@ -108,6 +126,7 @@ export class OCPPWebSocket {
       basicAuth: this._basicAuth,
       extraHeaders: this._extraHeaders,
       extraSubprotocols: this._extraSubprotocols,
+      ocppVersion: this._ocppVersion,
     });
     this._ws.onopen = () => {
       this.handleOpen();

--- a/src/cp/infrastructure/transport/handlers/MessageHandlerRegistry.ts
+++ b/src/cp/infrastructure/transport/handlers/MessageHandlerRegistry.ts
@@ -1,8 +1,44 @@
+import type {
+  AuthorizeResponseV16,
+  BootNotificationResponseV16,
+  CancelReservationRequestV16,
+  CancelReservationResponseV16,
+  ChangeConfigurationRequestV16,
+  ChangeConfigurationResponseV16,
+  ClearCacheRequestV16,
+  ClearCacheResponseV16,
+  DataTransferResponseV16,
+  GetConfigurationRequestV16,
+  GetConfigurationResponseV16,
+  GetDiagnosticsRequestV16,
+  GetDiagnosticsResponseV16,
+  GetLocalListVersionRequestV16,
+  GetLocalListVersionResponseV16,
+  HeartbeatResponseV16,
+  MeterValuesResponseV16,
+  RemoteStartTransactionRequestV16,
+  RemoteStartTransactionResponseV16,
+  RemoteStopTransactionRequestV16,
+  RemoteStopTransactionResponseV16,
+  ReserveNowRequestV16,
+  ReserveNowResponseV16,
+  ResetRequestV16,
+  ResetResponseV16,
+  SendLocalListRequestV16,
+  SendLocalListResponseV16,
+  StartTransactionResponseV16,
+  StatusNotificationResponseV16,
+  StopTransactionResponseV16,
+  TriggerMessageRequestV16,
+  TriggerMessageResponseV16,
+  UnlockConnectorRequestV16,
+  UnlockConnectorResponseV16,
+  UpdateFirmwareRequestV16,
+  UpdateFirmwareResponseV16,
+} from "@cshil/ocpp-tools";
 import { OCPPAction } from "../../../../domain/types/OcppTypes";
 import { ChargePoint } from "../../../../domain/charge-point/ChargePoint";
 import { Logger } from "../../../../shared/Logger";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
 
 /**
  * Context provided to message handlers
@@ -92,67 +128,67 @@ export class MessageHandlerRegistry {
 // Type-safe handler factory helpers
 export type CallHandlerMap = {
   [OCPPAction.RemoteStartTransaction]: CallHandler<
-    request.RemoteStartTransactionRequest,
-    response.RemoteStartTransactionResponse
+    RemoteStartTransactionRequestV16,
+    RemoteStartTransactionResponseV16
   >;
   [OCPPAction.RemoteStopTransaction]: CallHandler<
-    request.RemoteStopTransactionRequest,
-    response.RemoteStopTransactionResponse
+    RemoteStopTransactionRequestV16,
+    RemoteStopTransactionResponseV16
   >;
-  [OCPPAction.Reset]: CallHandler<request.ResetRequest, response.ResetResponse>;
+  [OCPPAction.Reset]: CallHandler<ResetRequestV16, ResetResponseV16>;
   [OCPPAction.GetDiagnostics]: CallHandler<
-    request.GetDiagnosticsRequest,
-    response.GetDiagnosticsResponse
+    GetDiagnosticsRequestV16,
+    GetDiagnosticsResponseV16
   >;
   [OCPPAction.TriggerMessage]: CallHandler<
-    request.TriggerMessageRequest,
-    response.TriggerMessageResponse
+    TriggerMessageRequestV16,
+    TriggerMessageResponseV16
   >;
   [OCPPAction.GetConfiguration]: CallHandler<
-    request.GetConfigurationRequest,
-    response.GetConfigurationResponse
+    GetConfigurationRequestV16,
+    GetConfigurationResponseV16
   >;
   [OCPPAction.ChangeConfiguration]: CallHandler<
-    request.ChangeConfigurationRequest,
-    response.ChangeConfigurationResponse
+    ChangeConfigurationRequestV16,
+    ChangeConfigurationResponseV16
   >;
   [OCPPAction.ClearCache]: CallHandler<
-    request.ClearCacheRequest,
-    response.ClearCacheResponse
+    ClearCacheRequestV16,
+    ClearCacheResponseV16
   >;
   [OCPPAction.UnlockConnector]: CallHandler<
-    request.UnlockConnectorRequest,
-    response.UnlockConnectorResponse
+    UnlockConnectorRequestV16,
+    UnlockConnectorResponseV16
   >;
   [OCPPAction.ReserveNow]: CallHandler<
-    request.ReserveNowRequest,
-    response.ReserveNowResponse
+    ReserveNowRequestV16,
+    ReserveNowResponseV16
   >;
   [OCPPAction.CancelReservation]: CallHandler<
-    request.CancelReservationRequest,
-    response.CancelReservationResponse
+    CancelReservationRequestV16,
+    CancelReservationResponseV16
   >;
   [OCPPAction.GetLocalListVersion]: CallHandler<
-    request.GetLocalListVersionRequest,
-    response.GetLocalListVersionResponse
+    GetLocalListVersionRequestV16,
+    GetLocalListVersionResponseV16
   >;
   [OCPPAction.SendLocalList]: CallHandler<
-    request.SendLocalListRequest,
-    response.SendLocalListResponse
+    SendLocalListRequestV16,
+    SendLocalListResponseV16
   >;
   [OCPPAction.UpdateFirmware]: CallHandler<
-    request.UpdateFirmwareRequest,
-    response.UpdateFirmwareResponse
+    UpdateFirmwareRequestV16,
+    UpdateFirmwareResponseV16
   >;
 };
 
 export type CallResultHandlerMap = {
-  [OCPPAction.BootNotification]: CallResultHandler<response.BootNotificationResponse>;
-  [OCPPAction.Authorize]: CallResultHandler<response.AuthorizeResponse>;
-  [OCPPAction.StartTransaction]: CallResultHandler<response.StartTransactionResponse>;
-  [OCPPAction.StopTransaction]: CallResultHandler<response.StopTransactionResponse>;
-  [OCPPAction.Heartbeat]: CallResultHandler<response.HeartbeatResponse>;
-  [OCPPAction.MeterValues]: CallResultHandler<response.MeterValuesResponse>;
-  [OCPPAction.StatusNotification]: CallResultHandler<response.StatusNotificationResponse>;
-  [OCPPAction.DataTransfer]: CallResultHandler<response.DataTransferResponse>;
+  [OCPPAction.BootNotification]: CallResultHandler<BootNotificationResponseV16>;
+  [OCPPAction.Authorize]: CallResultHandler<AuthorizeResponseV16>;
+  [OCPPAction.StartTransaction]: CallResultHandler<StartTransactionResponseV16>;
+  [OCPPAction.StopTransaction]: CallResultHandler<StopTransactionResponseV16>;
+  [OCPPAction.Heartbeat]: CallResultHandler<HeartbeatResponseV16>;
+  [OCPPAction.MeterValues]: CallResultHandler<MeterValuesResponseV16>;
+  [OCPPAction.StatusNotification]: CallResultHandler<StatusNotificationResponseV16>;
+  [OCPPAction.DataTransfer]: CallResultHandler<DataTransferResponseV16>;
 };

--- a/src/cp/infrastructure/transport/handlers/call/ChangeAvailabilityHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/ChangeAvailabilityHandler.ts
@@ -1,6 +1,5 @@
 import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import type {} from "@cshil/ocpp-tools";
 import { LogType } from "../../../../shared/Logger";
 import {
   OCPPAvailability,
@@ -23,15 +22,12 @@ import {
  */
 export class ChangeAvailabilityHandler
   implements
-    CallHandler<
-      request.ChangeAvailabilityRequest,
-      response.ChangeAvailabilityResponse
-    >
+    CallHandler<ChangeAvailabilityRequestV16, ChangeAvailabilityResponseV16>
 {
   handle(
-    payload: request.ChangeAvailabilityRequest,
+    payload: ChangeAvailabilityRequestV16,
     context: HandlerContext,
-  ): response.ChangeAvailabilityResponse {
+  ): ChangeAvailabilityResponseV16 {
     const target: OCPPAvailability =
       payload.type === "Operative" ? "Operative" : "Inoperative";
 
@@ -49,7 +45,7 @@ export class ChangeAvailabilityHandler
   private applyChargePoint(
     target: OCPPAvailability,
     context: HandlerContext,
-  ): response.ChangeAvailabilityResponse {
+  ): ChangeAvailabilityResponseV16 {
     const { chargePoint } = context;
     // §5.2: if any connector has an active transaction we have to defer,
     // even for the CP-wide form.
@@ -80,7 +76,7 @@ export class ChangeAvailabilityHandler
     connectorId: number,
     target: OCPPAvailability,
     context: HandlerContext,
-  ): response.ChangeAvailabilityResponse {
+  ): ChangeAvailabilityResponseV16 {
     const connector = context.chargePoint.getConnector(connectorId);
     if (!connector) {
       // Unknown connector id — spec doesn't have an explicit status for

--- a/src/cp/infrastructure/transport/handlers/call/DataTransferHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/DataTransferHandler.ts
@@ -1,6 +1,5 @@
 import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import type {} from "@cshil/ocpp-tools";
 import { LogType } from "../../../../shared/Logger";
 
 /**
@@ -29,8 +28,7 @@ export interface DataTransferResponder {
  * between charge points.
  */
 export class DataTransferHandler
-  implements
-    CallHandler<request.DataTransferRequest, response.DataTransferResponse>
+  implements CallHandler<DataTransferRequestV16, DataTransferResponseV16>
 {
   private readonly vendors = new Map<string, DataTransferResponder>();
 
@@ -47,9 +45,9 @@ export class DataTransferHandler
   }
 
   handle(
-    payload: request.DataTransferRequest,
+    payload: DataTransferRequestV16,
     context: HandlerContext,
-  ): response.DataTransferResponse {
+  ): DataTransferResponseV16 {
     context.logger.info(
       `DataTransfer received: vendorId=${payload.vendorId}` +
         (payload.messageId ? ` messageId=${payload.messageId}` : ""),

--- a/src/cp/infrastructure/transport/handlers/call/GetConfigurationHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/GetConfigurationHandler.ts
@@ -1,6 +1,5 @@
 import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import type {} from "@cshil/ocpp-tools";
 import type {
   ConfigurationValue,
   StringConfigurationValue,
@@ -13,15 +12,12 @@ import { LogType } from "../../../../shared/Logger";
 
 export class GetConfigurationHandler
   implements
-    CallHandler<
-      request.GetConfigurationRequest,
-      response.GetConfigurationResponse
-    >
+    CallHandler<GetConfigurationRequestV16, GetConfigurationResponseV16>
 {
   handle(
-    payload: request.GetConfigurationRequest,
+    payload: GetConfigurationRequestV16,
     context: HandlerContext,
-  ): response.GetConfigurationResponse {
+  ): GetConfigurationResponseV16 {
     context.logger.info(
       `GetConfiguration request: ${JSON.stringify(payload.key ?? "<all>")}`,
       LogType.CONFIGURATION,

--- a/src/cp/infrastructure/transport/handlers/call/GetDiagnosticsHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/GetDiagnosticsHandler.ts
@@ -1,6 +1,5 @@
 import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import type {} from "@cshil/ocpp-tools";
 import { UploadFile } from "../../../file_upload";
 import { LogType } from "../../../../shared/Logger";
 
@@ -15,13 +14,12 @@ import { LogType } from "../../../../shared/Logger";
  * UploadFailed.
  */
 export class GetDiagnosticsHandler
-  implements
-    CallHandler<request.GetDiagnosticsRequest, response.GetDiagnosticsResponse>
+  implements CallHandler<GetDiagnosticsRequestV16, GetDiagnosticsResponseV16>
 {
   handle(
-    payload: request.GetDiagnosticsRequest,
+    payload: GetDiagnosticsRequestV16,
     context: HandlerContext,
-  ): response.GetDiagnosticsResponse {
+  ): GetDiagnosticsResponseV16 {
     context.logger.info(
       `Get diagnostics request received: ${payload.location}`,
       LogType.DIAGNOSTICS,

--- a/src/cp/infrastructure/transport/handlers/call/LocalAuthListHandlers.ts
+++ b/src/cp/infrastructure/transport/handlers/call/LocalAuthListHandlers.ts
@@ -1,6 +1,5 @@
 import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import type {} from "@cshil/ocpp-tools";
 import { LogType } from "../../../../shared/Logger";
 import type { SendLocalListItem } from "../../../../domain/auth/LocalAuthList";
 
@@ -35,15 +34,12 @@ function maxSendLength(context: HandlerContext): number {
  */
 export class GetLocalListVersionHandler
   implements
-    CallHandler<
-      request.GetLocalListVersionRequest,
-      response.GetLocalListVersionResponse
-    >
+    CallHandler<GetLocalListVersionRequestV16, GetLocalListVersionResponseV16>
 {
   handle(
-    _payload: request.GetLocalListVersionRequest,
+    _payload: GetLocalListVersionRequestV16,
     context: HandlerContext,
-  ): response.GetLocalListVersionResponse {
+  ): GetLocalListVersionResponseV16 {
     if (!isFeatureEnabled(context)) {
       context.logger.info(
         "GetLocalListVersion: LocalAuthListEnabled=false, returning -1",
@@ -63,13 +59,12 @@ export class GetLocalListVersionHandler
  * CP returns `NotSupported` when LocalAuthListManagement is disabled.
  */
 export class SendLocalListHandler
-  implements
-    CallHandler<request.SendLocalListRequest, response.SendLocalListResponse>
+  implements CallHandler<SendLocalListRequestV16, SendLocalListResponseV16>
 {
   handle(
-    payload: request.SendLocalListRequest,
+    payload: SendLocalListRequestV16,
     context: HandlerContext,
-  ): response.SendLocalListResponse {
+  ): SendLocalListResponseV16 {
     if (!isFeatureEnabled(context)) {
       context.logger.warn(
         "SendLocalList: LocalAuthListEnabled=false → NotSupported",

--- a/src/cp/infrastructure/transport/handlers/call/OtherCallHandlers.ts
+++ b/src/cp/infrastructure/transport/handlers/call/OtherCallHandlers.ts
@@ -1,19 +1,15 @@
 import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import type {} from "@cshil/ocpp-tools";
 import { LogType } from "../../../../shared/Logger";
 
 export class ChangeConfigurationHandler
   implements
-    CallHandler<
-      request.ChangeConfigurationRequest,
-      response.ChangeConfigurationResponse
-    >
+    CallHandler<ChangeConfigurationRequestV16, ChangeConfigurationResponseV16>
 {
   handle(
-    payload: request.ChangeConfigurationRequest,
+    payload: ChangeConfigurationRequestV16,
     context: HandlerContext,
-  ): response.ChangeConfigurationResponse {
+  ): ChangeConfigurationResponseV16 {
     const status = context.chargePoint.configuration.applyChange(
       payload.key,
       payload.value,
@@ -27,13 +23,12 @@ export class ChangeConfigurationHandler
 }
 
 export class TriggerMessageHandler
-  implements
-    CallHandler<request.TriggerMessageRequest, response.TriggerMessageResponse>
+  implements CallHandler<TriggerMessageRequestV16, TriggerMessageResponseV16>
 {
   handle(
-    payload: request.TriggerMessageRequest,
+    payload: TriggerMessageRequestV16,
     context: HandlerContext,
-  ): response.TriggerMessageResponse {
+  ): TriggerMessageResponseV16 {
     context.logger.info(
       `Trigger message request received: ${payload.requestedMessage}` +
         (payload.connectorId !== undefined
@@ -100,13 +95,12 @@ export class TriggerMessageHandler
 }
 
 export class ClearCacheHandler
-  implements
-    CallHandler<request.ClearCacheRequest, response.ClearCacheResponse>
+  implements CallHandler<ClearCacheRequestV16, ClearCacheResponseV16>
 {
   handle(
-    payload: request.ClearCacheRequest,
+    payload: ClearCacheRequestV16,
     context: HandlerContext,
-  ): response.ClearCacheResponse {
+  ): ClearCacheResponseV16 {
     context.logger.info(
       `Clear cache request received: ${JSON.stringify(payload)}`,
       LogType.OCPP,
@@ -122,16 +116,12 @@ export class ClearCacheHandler
  * flip this to `UnlockFailed` or `NotSupported` to verify CSMS error paths.
  */
 export class UnlockConnectorHandler
-  implements
-    CallHandler<
-      request.UnlockConnectorRequest,
-      response.UnlockConnectorResponse
-    >
+  implements CallHandler<UnlockConnectorRequestV16, UnlockConnectorResponseV16>
 {
   handle(
-    payload: request.UnlockConnectorRequest,
+    payload: UnlockConnectorRequestV16,
     context: HandlerContext,
-  ): response.UnlockConnectorResponse {
+  ): UnlockConnectorResponseV16 {
     const { connectorId } = payload;
     const connector = context.chargePoint.getConnector(connectorId);
     if (!connector) {

--- a/src/cp/infrastructure/transport/handlers/call/RemoteStartTransactionHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/RemoteStartTransactionHandler.ts
@@ -1,6 +1,5 @@
 import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import type {} from "@cshil/ocpp-tools";
 import { LogType } from "../../../../shared/Logger";
 
 /**
@@ -21,14 +20,14 @@ import { LogType } from "../../../../shared/Logger";
 export class RemoteStartTransactionHandler
   implements
     CallHandler<
-      request.RemoteStartTransactionRequest,
-      response.RemoteStartTransactionResponse
+      RemoteStartTransactionRequestV16,
+      RemoteStartTransactionResponseV16
     >
 {
   handle(
-    payload: request.RemoteStartTransactionRequest,
+    payload: RemoteStartTransactionRequestV16,
     context: HandlerContext,
-  ): response.RemoteStartTransactionResponse {
+  ): RemoteStartTransactionResponseV16 {
     const { idTag, connectorId } = payload;
     const resolvedConnectorId = connectorId || 1;
     const connector = context.chargePoint.getConnector(resolvedConnectorId);

--- a/src/cp/infrastructure/transport/handlers/call/RemoteStopTransactionHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/RemoteStopTransactionHandler.ts
@@ -1,19 +1,18 @@
 import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import type {} from "@cshil/ocpp-tools";
 import { OCPPStatus } from "../../../../domain/types/OcppTypes";
 
 export class RemoteStopTransactionHandler
   implements
     CallHandler<
-      request.RemoteStopTransactionRequest,
-      response.RemoteStopTransactionResponse
+      RemoteStopTransactionRequestV16,
+      RemoteStopTransactionResponseV16
     >
 {
   handle(
-    payload: request.RemoteStopTransactionRequest,
+    payload: RemoteStopTransactionRequestV16,
     context: HandlerContext,
-  ): response.RemoteStopTransactionResponse {
+  ): RemoteStopTransactionResponseV16 {
     const { transactionId } = payload;
     const connector = Array.from(context.chargePoint.connectors.values()).find(
       (c) => c.transaction && c.transaction.id === transactionId,

--- a/src/cp/infrastructure/transport/handlers/call/ReservationHandlers.ts
+++ b/src/cp/infrastructure/transport/handlers/call/ReservationHandlers.ts
@@ -1,7 +1,10 @@
 import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
-import { ReservationStatus, CancelReservationStatus, OCPPStatus } from "../../../../domain/types/OcppTypes";
+import type {} from "@cshil/ocpp-tools";
+import {
+  ReservationStatus,
+  CancelReservationStatus,
+  OCPPStatus,
+} from "../../../../domain/types/OcppTypes";
 
 /**
  * Handler for ReserveNow request
@@ -10,13 +13,14 @@ import { ReservationStatus, CancelReservationStatus, OCPPStatus } from "../../..
  * The reservation allows a specific ID tag to use a connector at a future time.
  */
 export class ReserveNowHandler
-  implements CallHandler<request.ReserveNowRequest, response.ReserveNowResponse>
+  implements CallHandler<ReserveNowRequestV16, ReserveNowResponseV16>
 {
   handle(
-    payload: request.ReserveNowRequest,
+    payload: ReserveNowRequestV16,
     context: HandlerContext,
-  ): response.ReserveNowResponse {
-    const { connectorId, expiryDate, idTag, parentIdTag, reservationId } = payload;
+  ): ReserveNowResponseV16 {
+    const { connectorId, expiryDate, idTag, parentIdTag, reservationId } =
+      payload;
     const connector = context.chargePoint.getConnector(connectorId);
     const reservationManager = context.chargePoint.reservationManager;
 
@@ -49,7 +53,7 @@ export class ReserveNowHandler
       expiryDateTime,
       idTag,
       parentIdTag,
-      reservationId
+      reservationId,
     );
 
     // If reservation was accepted, update connector status to Reserved
@@ -68,15 +72,12 @@ export class ReserveNowHandler
  */
 export class CancelReservationHandler
   implements
-    CallHandler<
-      request.CancelReservationRequest,
-      response.CancelReservationResponse
-    >
+    CallHandler<CancelReservationRequestV16, CancelReservationResponseV16>
 {
   handle(
-    payload: request.CancelReservationRequest,
+    payload: CancelReservationRequestV16,
     context: HandlerContext,
-  ): response.CancelReservationResponse {
+  ): CancelReservationResponseV16 {
     const { reservationId } = payload;
     const reservationManager = context.chargePoint.reservationManager;
 
@@ -88,7 +89,9 @@ export class CancelReservationHandler
 
     if (cancelled && reservation) {
       // Update connector status back to Available
-      const connector = context.chargePoint.getConnector(reservation.connectorId);
+      const connector = context.chargePoint.getConnector(
+        reservation.connectorId,
+      );
       if (connector && connector.status === OCPPStatus.Reserved) {
         connector.status = OCPPStatus.Available;
       }

--- a/src/cp/infrastructure/transport/handlers/call/ResetHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/ResetHandler.ts
@@ -1,6 +1,5 @@
 import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import type {} from "@cshil/ocpp-tools";
 import { LogType } from "../../../../shared/Logger";
 
 /**
@@ -13,12 +12,9 @@ import { LogType } from "../../../../shared/Logger";
  * before any StopTransaction.req goes out.
  */
 export class ResetHandler
-  implements CallHandler<request.ResetRequest, response.ResetResponse>
+  implements CallHandler<ResetRequestV16, ResetResponseV16>
 {
-  handle(
-    payload: request.ResetRequest,
-    context: HandlerContext,
-  ): response.ResetResponse {
+  handle(payload: ResetRequestV16, context: HandlerContext): ResetResponseV16 {
     context.logger.info(
       `Reset request received: ${payload.type}`,
       LogType.OCPP,

--- a/src/cp/infrastructure/transport/handlers/call/SmartChargingHandlers.ts
+++ b/src/cp/infrastructure/transport/handlers/call/SmartChargingHandlers.ts
@@ -18,9 +18,8 @@
  */
 
 import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
+import type {} from "@cshil/ocpp-tools";
 import type { Connector } from "../../../../domain/connector/Connector";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
 import {
   OCPPStatus,
   ChargingProfilePurposeType,
@@ -53,8 +52,7 @@ function getIntegerConfigValue(
 // `SetChargingProfileRequest` rather than exporting a named ChargingProfile
 // type. Alias the inline shape so the validator can keep using a tight
 // parameter type.
-type CsChargingProfile =
-  request.SetChargingProfileRequest["csChargingProfiles"];
+type CsChargingProfile = SetChargingProfileRequestV16["csChargingProfiles"];
 
 /**
  * Validate charging profile against OCPP 1.6 spec and configuration.
@@ -200,15 +198,12 @@ function applyProfileStatus(
  */
 export class SetChargingProfileHandler
   implements
-    CallHandler<
-      request.SetChargingProfileRequest,
-      response.SetChargingProfileResponse
-    >
+    CallHandler<SetChargingProfileRequestV16, SetChargingProfileResponseV16>
 {
   handle(
-    payload: request.SetChargingProfileRequest,
+    payload: SetChargingProfileRequestV16,
     context: HandlerContext,
-  ): response.SetChargingProfileResponse {
+  ): SetChargingProfileResponseV16 {
     const { connectorId, csChargingProfiles } = payload;
 
     context.logger.info(
@@ -294,14 +289,14 @@ export class SetChargingProfileHandler
 export class ClearChargingProfileHandler
   implements
     CallHandler<
-      request.ClearChargingProfileRequest,
-      response.ClearChargingProfileResponse
+      ClearChargingProfileRequestV16,
+      ClearChargingProfileResponseV16
     >
 {
   handle(
-    payload: request.ClearChargingProfileRequest,
+    payload: ClearChargingProfileRequestV16,
     context: HandlerContext,
-  ): response.ClearChargingProfileResponse {
+  ): ClearChargingProfileResponseV16 {
     context.logger.info(
       `ClearChargingProfile received: id=${payload.id}, connectorId=${payload.connectorId}, purpose=${payload.chargingProfilePurpose}, stackLevel=${payload.stackLevel}`,
       LogType.OCPP,
@@ -395,14 +390,14 @@ function wattsToUnit(watts: number, unit: ChargingRateUnitType): number {
 export class GetCompositeScheduleHandler
   implements
     CallHandler<
-      request.GetCompositeScheduleRequest,
-      response.GetCompositeScheduleResponse
+      GetCompositeScheduleRequestV16,
+      GetCompositeScheduleResponseV16
     >
 {
   handle(
-    payload: request.GetCompositeScheduleRequest,
+    payload: GetCompositeScheduleRequestV16,
     context: HandlerContext,
-  ): response.GetCompositeScheduleResponse {
+  ): GetCompositeScheduleResponseV16 {
     const { connectorId, duration, chargingRateUnit } = payload;
 
     context.logger.info(

--- a/src/cp/infrastructure/transport/handlers/call/UpdateFirmwareHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/UpdateFirmwareHandler.ts
@@ -1,6 +1,5 @@
 import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import type {} from "@cshil/ocpp-tools";
 import { LogType } from "../../../../shared/Logger";
 
 /**
@@ -14,13 +13,12 @@ import { LogType } from "../../../../shared/Logger";
  * via TriggerMessage(FirmwareStatusNotification).
  */
 export class UpdateFirmwareHandler
-  implements
-    CallHandler<request.UpdateFirmwareRequest, response.UpdateFirmwareResponse>
+  implements CallHandler<UpdateFirmwareRequestV16, UpdateFirmwareResponseV16>
 {
   handle(
-    payload: request.UpdateFirmwareRequest,
+    payload: UpdateFirmwareRequestV16,
     context: HandlerContext,
-  ): response.UpdateFirmwareResponse {
+  ): UpdateFirmwareResponseV16 {
     const retrieveDate = new Date(payload.retrieveDate);
     if (Number.isNaN(retrieveDate.getTime())) {
       context.logger.warn(

--- a/src/cp/infrastructure/transport/handlers/callresult/BootNotificationResultHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/callresult/BootNotificationResultHandler.ts
@@ -1,5 +1,5 @@
 import { CallResultHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import type {} from "@cshil/ocpp-tools";
 import { OCPPStatus } from "../../../../domain/types/OcppTypes";
 import { LogType } from "../../../../shared/Logger";
 
@@ -16,12 +16,9 @@ import { LogType } from "../../../../shared/Logger";
  *   seconds, then auto-retry BootNotification.
  */
 export class BootNotificationResultHandler
-  implements CallResultHandler<response.BootNotificationResponse>
+  implements CallResultHandler<BootNotificationResponseV16>
 {
-  handle(
-    payload: response.BootNotificationResponse,
-    context: HandlerContext,
-  ): void {
+  handle(payload: BootNotificationResponseV16, context: HandlerContext): void {
     const interval =
       typeof payload.interval === "number" && payload.interval > 0
         ? payload.interval

--- a/src/cp/infrastructure/transport/handlers/callresult/OtherResultHandlers.ts
+++ b/src/cp/infrastructure/transport/handlers/callresult/OtherResultHandlers.ts
@@ -1,28 +1,24 @@
 import { CallResultHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
+import type {} from "@cshil/ocpp-tools";
 import { LogType } from "../../../../shared/Logger";
 
 export class HeartbeatResultHandler
-  implements CallResultHandler<response.HeartbeatResponse>
+  implements CallResultHandler<HeartbeatResponseV16>
 {
-  handle(
-    payload: response.HeartbeatResponse,
-    context: HandlerContext,
-  ): void {
-    context.logger.debug(`Received heartbeat response: ${payload.currentTime}`, LogType.HEARTBEAT);
+  handle(payload: HeartbeatResponseV16, context: HandlerContext): void {
+    context.logger.debug(
+      `Received heartbeat response: ${payload.currentTime}`,
+      LogType.HEARTBEAT,
+    );
   }
 }
 
 export class MeterValuesResultHandler
-  implements CallResultHandler<response.MeterValuesResponse>
+  implements CallResultHandler<MeterValuesResponseV16>
 {
-  constructor(private requestPayload?: request.MeterValuesRequest) {}
+  constructor(private requestPayload?: MeterValuesRequestV16) {}
 
-  handle(
-    payload: response.MeterValuesResponse,
-    context: HandlerContext,
-  ): void {
+  handle(payload: MeterValuesResponseV16, context: HandlerContext): void {
     if (this.requestPayload) {
       const connector = context.chargePoint.getConnector(
         this.requestPayload.connectorId,
@@ -39,10 +35,10 @@ export class MeterValuesResultHandler
 }
 
 export class StatusNotificationResultHandler
-  implements CallResultHandler<response.StatusNotificationResponse>
+  implements CallResultHandler<StatusNotificationResponseV16>
 {
   handle(
-    payload: response.StatusNotificationResponse,
+    payload: StatusNotificationResponseV16,
     context: HandlerContext,
   ): void {
     context.logger.debug(
@@ -53,12 +49,9 @@ export class StatusNotificationResultHandler
 }
 
 export class DataTransferResultHandler
-  implements CallResultHandler<response.DataTransferResponse>
+  implements CallResultHandler<DataTransferResponseV16>
 {
-  handle(
-    payload: response.DataTransferResponse,
-    context: HandlerContext,
-  ): void {
+  handle(payload: DataTransferResponseV16, context: HandlerContext): void {
     context.logger.info(
       `Data transfer sent successfully: ${JSON.stringify(payload)}`,
       LogType.OCPP,

--- a/src/cp/infrastructure/transport/handlers/callresult/TransactionResultHandlers.ts
+++ b/src/cp/infrastructure/transport/handlers/callresult/TransactionResultHandlers.ts
@@ -1,17 +1,14 @@
 import { CallResultHandler, HandlerContext } from "../MessageHandlerRegistry";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
+import type {} from "@cshil/ocpp-tools";
 import { OCPPStatus } from "../../../../domain/types/OcppTypes";
 import { LogType } from "../../../../shared/Logger";
 
 export class StartTransactionResultHandler
-  implements CallResultHandler<response.StartTransactionResponse>
+  implements CallResultHandler<StartTransactionResponseV16>
 {
   constructor(private connectorId: number) {}
 
-  handle(
-    payload: response.StartTransactionResponse,
-    context: HandlerContext,
-  ): void {
+  handle(payload: StartTransactionResponseV16, context: HandlerContext): void {
     const { transactionId, idTagInfo } = payload;
     const connector = context.chargePoint.getConnector(this.connectorId);
 
@@ -48,14 +45,11 @@ export class StartTransactionResultHandler
 }
 
 export class StopTransactionResultHandler
-  implements CallResultHandler<response.StopTransactionResponse>
+  implements CallResultHandler<StopTransactionResponseV16>
 {
   constructor(private connectorId: number) {}
 
-  handle(
-    payload: response.StopTransactionResponse,
-    context: HandlerContext,
-  ): void {
+  handle(payload: StopTransactionResponseV16, context: HandlerContext): void {
     context.logger.info(
       `Transaction stopped successfully: ${JSON.stringify(payload)}`,
       LogType.TRANSACTION,
@@ -75,9 +69,9 @@ export class StopTransactionResultHandler
 }
 
 export class AuthorizeResultHandler
-  implements CallResultHandler<response.AuthorizeResponse>
+  implements CallResultHandler<AuthorizeResponseV16>
 {
-  handle(payload: response.AuthorizeResponse, context: HandlerContext): void {
+  handle(payload: AuthorizeResponseV16, context: HandlerContext): void {
     const { idTagInfo } = payload;
     if (idTagInfo.status === "Accepted") {
       context.logger.info("Authorization successful", LogType.TRANSACTION);

--- a/src/cp/infrastructure/transport/wsUrlWithBasic.ts
+++ b/src/cp/infrastructure/transport/wsUrlWithBasic.ts
@@ -5,7 +5,14 @@
  * / Node `ws`) send the credentials as a real HTTP Basic header instead.
  */
 export const OCPP_BROWSER_WS_SECRET_QUERY_PARAM = "ocpp_ws_secret";
-export const OCPP_WEBSOCKET_PROTOCOL = "ocpp1.6";
+export const OCPP_WEBSOCKET_PROTOCOL_16 = "ocpp1.6";
+export const OCPP_WEBSOCKET_PROTOCOL_201 = "ocpp2.0.1";
+
+export function ocppVersionToSubprotocol(ocppVersion: string): string {
+  return ocppVersion === "OCPP-2.0.1"
+    ? OCPP_WEBSOCKET_PROTOCOL_201
+    : OCPP_WEBSOCKET_PROTOCOL_16;
+}
 
 export interface BasicAuthSettings {
   username: string;
@@ -66,12 +73,12 @@ export function openOcppWebSocket(params: {
    *  and ignore the rest, so extras are safe to add and become visible
    *  to upstream routers that match on subprotocol. */
   extraSubprotocols?: ReadonlyArray<string>;
+  /** OCPP version string (e.g. "OCPP-1.6J", "OCPP-2.0.1"). Defaults to 1.6. */
+  ocppVersion?: string;
 }): WebSocket {
   const url = buildOcppWebSocketUrl(params);
-  const protocols = [
-    OCPP_WEBSOCKET_PROTOCOL,
-    ...(params.extraSubprotocols ?? []),
-  ];
+  const versionProtocol = ocppVersionToSubprotocol(params.ocppVersion ?? "");
+  const protocols = [versionProtocol, ...(params.extraSubprotocols ?? [])];
   const extraHeaders = params.extraHeaders ?? {};
   const hasExtraHeaders = Object.keys(extraHeaders).length > 0;
   if (!isBrowserRuntime() && (params.basicAuth?.password || hasExtraHeaders)) {

--- a/src/data/hooks/useChargePoints.ts
+++ b/src/data/hooks/useChargePoints.ts
@@ -87,6 +87,7 @@ export function useChargePoints(
               }
             : null,
           autoMeterValueSetting: config.autoMeterValueSetting ?? null,
+          ocppVersion: config.ocppVersion,
         }));
 
       chargePointService

--- a/src/data/local/LocalChargePointService.ts
+++ b/src/data/local/LocalChargePointService.ts
@@ -84,6 +84,7 @@ export interface LocalChargePointDefinition {
   wsUrl: string;
   basicAuth: { username: string; password: string } | null;
   autoMeterValueSetting: AutoMeterValueSetting | null;
+  ocppVersion?: string;
 }
 
 export class LocalChargePointService implements ChargePointService {
@@ -612,6 +613,9 @@ export class LocalChargePointService implements ChargePointService {
       definition.basicAuth,
       definition.autoMeterValueSetting,
       this.database,
+      {},
+      [],
+      definition.ocppVersion,
     );
 
     // Restore connector-level settings from the SQLite store. Sync reads

--- a/src/v1/cp/OCPPMessageHandler.ts
+++ b/src/v1/cp/OCPPMessageHandler.ts
@@ -12,6 +12,56 @@
  * - Adequate for simulator/testing purposes
  */
 
+import type {
+  AuthorizeRequestV16,
+  AuthorizeResponseV16,
+  BootNotificationRequestV16,
+  BootNotificationResponseV16,
+  CancelReservationRequestV16,
+  ChangeAvailabilityRequestV16,
+  ChangeAvailabilityResponseV16,
+  ChangeConfigurationRequestV16,
+  ChangeConfigurationResponseV16,
+  ClearCacheRequestV16,
+  ClearCacheResponseV16,
+  ClearChargingProfileRequestV16,
+  ClearChargingProfileResponseV16,
+  DataTransferResponseV16,
+  DiagnosticsStatusNotificationResponseV16,
+  FirmwareStatusNotificationResponseV16,
+  GetCompositeScheduleRequestV16,
+  GetCompositeScheduleResponseV16,
+  GetConfigurationRequestV16,
+  GetConfigurationResponseV16,
+  GetDiagnosticsRequestV16,
+  GetDiagnosticsResponseV16,
+  GetLocalListVersionRequestV16,
+  HeartbeatRequestV16,
+  HeartbeatResponseV16,
+  MeterValuesRequestV16,
+  MeterValuesResponseV16,
+  RemoteStartTransactionRequestV16,
+  RemoteStartTransactionResponseV16,
+  RemoteStopTransactionRequestV16,
+  RemoteStopTransactionResponseV16,
+  ReserveNowRequestV16,
+  ResetRequestV16,
+  ResetResponseV16,
+  SendLocalListRequestV16,
+  SetChargingProfileRequestV16,
+  SetChargingProfileResponseV16,
+  StartTransactionRequestV16,
+  StartTransactionResponseV16,
+  StatusNotificationRequestV16,
+  StatusNotificationResponseV16,
+  StopTransactionRequestV16,
+  StopTransactionResponseV16,
+  TriggerMessageRequestV16,
+  TriggerMessageResponseV16,
+  UnlockConnectorRequestV16,
+  UnlockConnectorResponseV16,
+  UpdateFirmwareRequestV16,
+} from "@cshil/ocpp-tools";
 import {
   OcppMessageErrorPayload,
   OcppMessagePayload,
@@ -46,9 +96,6 @@ import {
   StringConfigurationValue,
 } from "./Configuration.ts";
 
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
-
 function applyProfileStatus(
   chargePoint: ChargePoint,
   connector: Connector,
@@ -70,33 +117,33 @@ function applyProfileStatus(
 }
 
 type CoreOcppMessagePayloadCall =
-  | request.ChangeAvailabilityRequest
-  | request.ChangeConfigurationRequest
-  | request.ClearCacheRequest
-  | request.GetConfigurationRequest
-  | request.RemoteStartTransactionRequest
-  | request.RemoteStopTransactionRequest
-  | request.ResetRequest
-  | request.UnlockConnectorRequest;
+  | ChangeAvailabilityRequestV16
+  | ChangeConfigurationRequestV16
+  | ClearCacheRequestV16
+  | GetConfigurationRequestV16
+  | RemoteStartTransactionRequestV16
+  | RemoteStopTransactionRequestV16
+  | ResetRequestV16
+  | UnlockConnectorRequestV16;
 
 type FirmwareManagementOcppMessagePayloadCall =
-  | request.GetDiagnosticsRequest
-  | request.UpdateFirmwareRequest;
+  | GetDiagnosticsRequestV16
+  | UpdateFirmwareRequestV16;
 
 type LocalAuthListManagementOcppMessagePayloadCall =
-  | request.GetLocalListVersionRequest
-  | request.SendLocalListRequest;
+  | GetLocalListVersionRequestV16
+  | SendLocalListRequestV16;
 
 type ReservationOcppMessagePayloadCall =
-  | request.CancelReservationRequest
-  | request.ReserveNowRequest;
+  | CancelReservationRequestV16
+  | ReserveNowRequestV16;
 
 type SmartChargingOcppMessagePayloadCall =
-  | request.ClearChargingProfileRequest
-  | request.GetCompositeScheduleRequest
-  | request.SetChargingProfileRequest;
+  | ClearChargingProfileRequestV16
+  | GetCompositeScheduleRequestV16
+  | SetChargingProfileRequestV16;
 
-type RemoteTriggerOcppMessagePayloadCall = request.TriggerMessageRequest;
+type RemoteTriggerOcppMessagePayloadCall = TriggerMessageRequestV16;
 
 type OcppMessagePayloadCall =
   | CoreOcppMessagePayloadCall
@@ -107,19 +154,19 @@ type OcppMessagePayloadCall =
   | RemoteTriggerOcppMessagePayloadCall;
 
 type CoreOcppMessagePayloadCallResult =
-  | response.AuthorizeResponse
-  | response.BootNotificationResponse
-  | response.ChangeConfigurationResponse
-  | response.DataTransferResponse
-  | response.HeartbeatResponse
-  | response.MeterValuesResponse
-  | response.StartTransactionResponse
-  | response.StatusNotificationResponse
-  | response.StopTransactionResponse;
+  | AuthorizeResponseV16
+  | BootNotificationResponseV16
+  | ChangeConfigurationResponseV16
+  | DataTransferResponseV16
+  | HeartbeatResponseV16
+  | MeterValuesResponseV16
+  | StartTransactionResponseV16
+  | StatusNotificationResponseV16
+  | StopTransactionResponseV16;
 
 type FirmwareManagementOcppMessagePayloadCallResult =
-  | response.DiagnosticsStatusNotificationResponse
-  | response.FirmwareStatusNotificationResponse;
+  | DiagnosticsStatusNotificationResponseV16
+  | FirmwareStatusNotificationResponseV16;
 
 type OcppMessagePayloadCallResult =
   | CoreOcppMessagePayloadCallResult
@@ -175,13 +222,13 @@ export class OCPPMessageHandler {
 
   public authorize(tagId: string): void {
     const messageId = this.generateMessageId();
-    const payload: request.AuthorizeRequest = { idTag: tagId };
+    const payload: AuthorizeRequestV16 = { idTag: tagId };
     this.sendRequest(OCPPAction.Authorize, messageId, payload);
   }
 
   public startTransaction(transaction: Transaction, connectorId: number): void {
     const messageId = this.generateMessageId();
-    const payload: request.StartTransactionRequest = {
+    const payload: StartTransactionRequestV16 = {
       connectorId: connectorId,
       idTag: transaction.tagId,
       meterStart: transaction.meterStart,
@@ -197,7 +244,7 @@ export class OCPPMessageHandler {
 
   public stopTransaction(transaction: Transaction, connectorId: number): void {
     const messageId = this.generateMessageId();
-    const payload: request.StopTransactionRequest = {
+    const payload: StopTransactionRequestV16 = {
       transactionId: transaction.id!,
       idTag: transaction.tagId,
       meterStop: transaction.meterStop!,
@@ -213,7 +260,7 @@ export class OCPPMessageHandler {
 
   public sendBootNotification(bootPayload: BootNotification): void {
     const messageId = this.generateMessageId();
-    const payload: request.BootNotificationRequest = {
+    const payload: BootNotificationRequestV16 = {
       chargePointVendor: bootPayload.ChargePointVendor,
       chargePointModel: bootPayload.ChargePointModel,
       chargePointSerialNumber: bootPayload.ChargePointSerialNumber,
@@ -229,7 +276,7 @@ export class OCPPMessageHandler {
 
   public sendHeartbeat(): void {
     const messageId = this.generateMessageId();
-    const payload: request.HeartbeatRequest = {};
+    const payload: HeartbeatRequestV16 = {};
     this.sendRequest(OCPPAction.Heartbeat, messageId, payload);
   }
 
@@ -239,7 +286,7 @@ export class OCPPMessageHandler {
     meterValue: number,
   ): void {
     const messageId = this.generateMessageId();
-    const payload: request.MeterValuesRequest = {
+    const payload: MeterValuesRequestV16 = {
       transactionId: transactionId,
       connectorId: connectorId,
       meterValue: [
@@ -254,7 +301,7 @@ export class OCPPMessageHandler {
 
   public sendStatusNotification(connectorId: number, status: OCPPStatus): void {
     const messageId = this.generateMessageId();
-    const payload: request.StatusNotificationRequest = {
+    const payload: StatusNotificationRequestV16 = {
       connectorId: connectorId,
       errorCode: "NoError",
       status: status,
@@ -314,58 +361,58 @@ export class OCPPMessageHandler {
     switch (action) {
       case OCPPAction.RemoteStartTransaction:
         response = this.handleRemoteStartTransaction(
-          payload as request.RemoteStartTransactionRequest,
+          payload as RemoteStartTransactionRequestV16,
         );
         break;
       case OCPPAction.RemoteStopTransaction:
         response = this.handleRemoteStopTransaction(
-          payload as request.RemoteStopTransactionRequest,
+          payload as RemoteStopTransactionRequestV16,
         );
         break;
       case OCPPAction.Reset:
-        response = this.handleReset(payload as request.ResetRequest);
+        response = this.handleReset(payload as ResetRequestV16);
         break;
       case OCPPAction.GetDiagnostics:
         response = this.handleGetDiagnostics(
-          payload as request.GetDiagnosticsRequest,
+          payload as GetDiagnosticsRequestV16,
         );
         break;
       case OCPPAction.TriggerMessage:
         response = this.handleTriggerMessage(
-          payload as request.TriggerMessageRequest,
+          payload as TriggerMessageRequestV16,
         );
         break;
       case OCPPAction.GetConfiguration:
         response = this.handleGetConfiguration(
-          payload as request.GetConfigurationRequest,
+          payload as GetConfigurationRequestV16,
         );
         break;
       case OCPPAction.ChangeConfiguration:
         response = this.handleChangeConfiguration(
-          payload as request.ChangeConfigurationRequest,
+          payload as ChangeConfigurationRequestV16,
         );
         break;
       case OCPPAction.ClearCache:
-        response = this.handleClearCache(payload as request.ClearCacheRequest);
+        response = this.handleClearCache(payload as ClearCacheRequestV16);
         break;
       case OCPPAction.UnlockConnector:
         response = this.handleUnlockConnector(
-          payload as request.UnlockConnectorRequest,
+          payload as UnlockConnectorRequestV16,
         );
         break;
       case OCPPAction.SetChargingProfile:
         response = this.handleSetChargingProfile(
-          payload as request.SetChargingProfileRequest,
+          payload as SetChargingProfileRequestV16,
         );
         break;
       case OCPPAction.ClearChargingProfile:
         response = this.handleClearChargingProfile(
-          payload as request.ClearChargingProfileRequest,
+          payload as ClearChargingProfileRequestV16,
         );
         break;
       case OCPPAction.GetCompositeSchedule:
         response = this.handleGetCompositeSchedule(
-          payload as request.GetCompositeScheduleRequest,
+          payload as GetCompositeScheduleRequestV16,
         );
         break;
       default:
@@ -392,48 +439,44 @@ export class OCPPMessageHandler {
     const action = request?.action;
     switch (action) {
       case OCPPAction.ChangeAvailability:
-        this.handleChangeAvailability(
-          payload as request.ChangeAvailabilityRequest,
-        );
+        this.handleChangeAvailability(payload as ChangeAvailabilityRequestV16);
         break;
       case OCPPAction.BootNotification:
         this.handleBootNotificationResponse(
-          payload as response.BootNotificationResponse,
+          payload as BootNotificationResponseV16,
         );
         break;
       case OCPPAction.Authorize:
-        this.handleAuthorizeResponse(payload as response.AuthorizeResponse);
+        this.handleAuthorizeResponse(payload as AuthorizeResponseV16);
         break;
       case OCPPAction.StartTransaction:
         this.handleStartTransactionResponse(
           request?.connectorId || 1,
-          payload as response.StartTransactionResponse,
+          payload as StartTransactionResponseV16,
         );
         break;
       case OCPPAction.StopTransaction:
         this.handleStopTransactionResponse(
           request?.connectorId || 1,
-          payload as response.StopTransactionResponse,
+          payload as StopTransactionResponseV16,
         );
         break;
       case OCPPAction.Heartbeat:
-        this.handleHeartbeatResponse(payload as response.HeartbeatResponse);
+        this.handleHeartbeatResponse(payload as HeartbeatResponseV16);
         break;
       case OCPPAction.MeterValues:
         this.handleMeterValuesResponse(
-          payload as response.MeterValuesResponse,
-          request?.payload as request.MeterValuesRequest,
+          payload as MeterValuesResponseV16,
+          request?.payload as MeterValuesRequestV16,
         );
         break;
       case OCPPAction.StatusNotification:
         this.handleStatusNotificationResponse(
-          payload as response.StatusNotificationResponse,
+          payload as StatusNotificationResponseV16,
         );
         break;
       case OCPPAction.DataTransfer:
-        this.handleDataTransferResponse(
-          payload as response.DataTransferResponse,
-        );
+        this.handleDataTransferResponse(payload as DataTransferResponseV16);
         break;
       default:
         this._logger.log(`Unsupported action result: ${action}`);
@@ -454,8 +497,8 @@ export class OCPPMessageHandler {
   }
 
   private handleRemoteStartTransaction(
-    payload: request.RemoteStartTransactionRequest,
-  ): response.RemoteStartTransactionResponse {
+    payload: RemoteStartTransactionRequestV16,
+  ): RemoteStartTransactionResponseV16 {
     const { idTag, connectorId } = payload;
     const connector = this._chargePoint.getConnector(connectorId || 1);
 
@@ -468,8 +511,8 @@ export class OCPPMessageHandler {
   }
 
   private handleRemoteStopTransaction(
-    payload: request.RemoteStopTransactionRequest,
-  ): response.RemoteStopTransactionResponse {
+    payload: RemoteStopTransactionRequestV16,
+  ): RemoteStopTransactionResponseV16 {
     const { transactionId } = payload;
     const connector = Array.from(this._chargePoint.connectors.values()).find(
       (c) => c.transaction && c.transaction.id === transactionId,
@@ -487,7 +530,7 @@ export class OCPPMessageHandler {
     }
   }
 
-  private handleReset(payload: request.ResetRequest): response.ResetResponse {
+  private handleReset(payload: ResetRequestV16): ResetResponseV16 {
     this._logger.log(`Reset request received: ${payload.type}`);
     setTimeout(() => {
       this._logger.log(`Reset chargePoint: ${this._chargePoint.id}`);
@@ -501,8 +544,8 @@ export class OCPPMessageHandler {
   }
 
   private handleGetDiagnostics(
-    payload: request.GetDiagnosticsRequest,
-  ): response.GetDiagnosticsResponse {
+    payload: GetDiagnosticsRequestV16,
+  ): GetDiagnosticsResponseV16 {
     this._logger.log(`Get diagnostics request received: ${payload.location}`); // e.g. `FTP
     const logs = this._logger.getLogs().join("\n");
     const blob = new Blob([logs], { type: "text/plain" });
@@ -512,8 +555,8 @@ export class OCPPMessageHandler {
   }
 
   private handleGetConfiguration(
-    payload: request.GetConfigurationRequest,
-  ): response.GetConfigurationResponse {
+    payload: GetConfigurationRequestV16,
+  ): GetConfigurationResponseV16 {
     this._logger.log(
       `Get configuration request received: ${JSON.stringify(payload.key)}`,
     );
@@ -562,8 +605,8 @@ export class OCPPMessageHandler {
   }
 
   private handleChangeConfiguration(
-    payload: request.ChangeConfigurationRequest,
-  ): response.ChangeConfigurationResponse {
+    payload: ChangeConfigurationRequestV16,
+  ): ChangeConfigurationResponseV16 {
     this._logger.log(
       `Change configuration request received: ${JSON.stringify(payload.key)}: ${JSON.stringify(payload.value)}`,
     );
@@ -576,8 +619,8 @@ export class OCPPMessageHandler {
   }
 
   private handleTriggerMessage(
-    payload: request.TriggerMessageRequest,
-  ): response.TriggerMessageResponse {
+    payload: TriggerMessageRequestV16,
+  ): TriggerMessageResponseV16 {
     this._logger.log(
       `Trigger message request received: ${payload.requestedMessage}`,
     ); // e.g. `DiagnosticsStatusNotification`
@@ -585,8 +628,8 @@ export class OCPPMessageHandler {
   }
 
   private handleChangeAvailability(
-    payload: request.ChangeAvailabilityRequest,
-  ): response.ChangeAvailabilityResponse {
+    payload: ChangeAvailabilityRequestV16,
+  ): ChangeAvailabilityResponseV16 {
     this._logger.log(
       `Change availability request received: ${JSON.stringify(payload)}`,
     );
@@ -602,8 +645,8 @@ export class OCPPMessageHandler {
   }
 
   private handleClearCache(
-    payload: request.ClearCacheRequest,
-  ): response.ClearCacheResponse {
+    payload: ClearCacheRequestV16,
+  ): ClearCacheResponseV16 {
     this._logger.log(
       `Clear cache request received: ${JSON.stringify(payload)}`,
     );
@@ -611,8 +654,8 @@ export class OCPPMessageHandler {
   }
 
   private handleUnlockConnector(
-    payload: request.UnlockConnectorRequest,
-  ): response.UnlockConnectorResponse {
+    payload: UnlockConnectorRequestV16,
+  ): UnlockConnectorResponseV16 {
     this._logger.log(
       `Unlock connector request received: ${JSON.stringify(payload)}`,
     );
@@ -620,8 +663,8 @@ export class OCPPMessageHandler {
   }
 
   private handleSetChargingProfile(
-    payload: request.SetChargingProfileRequest,
-  ): response.SetChargingProfileResponse {
+    payload: SetChargingProfileRequestV16,
+  ): SetChargingProfileResponseV16 {
     const { connectorId, csChargingProfiles } = payload;
     this._logger.log(
       `SetChargingProfile received for connector ${connectorId}: profileId=${csChargingProfiles.chargingProfileId}, purpose=${csChargingProfiles.chargingProfilePurpose}`,
@@ -689,8 +732,8 @@ export class OCPPMessageHandler {
   }
 
   private handleClearChargingProfile(
-    payload: request.ClearChargingProfileRequest,
-  ): response.ClearChargingProfileResponse {
+    payload: ClearChargingProfileRequestV16,
+  ): ClearChargingProfileResponseV16 {
     this._logger.log(
       `ClearChargingProfile received: id=${payload.id}, connectorId=${payload.connectorId}`,
     );
@@ -720,8 +763,8 @@ export class OCPPMessageHandler {
   }
 
   private handleGetCompositeSchedule(
-    payload: request.GetCompositeScheduleRequest,
-  ): response.GetCompositeScheduleResponse {
+    payload: GetCompositeScheduleRequestV16,
+  ): GetCompositeScheduleResponseV16 {
     this._logger.log(
       `GetCompositeSchedule received: connectorId=${payload.connectorId}, duration=${payload.duration}`,
     );
@@ -759,7 +802,7 @@ export class OCPPMessageHandler {
   }
 
   private handleBootNotificationResponse(
-    payload: response.BootNotificationResponse,
+    payload: BootNotificationResponseV16,
   ): void {
     this._logger.log("Boot notification successful");
     if (payload.status === "Accepted") {
@@ -770,7 +813,7 @@ export class OCPPMessageHandler {
     }
   }
 
-  private handleAuthorizeResponse(payload: response.AuthorizeResponse): void {
+  private handleAuthorizeResponse(payload: AuthorizeResponseV16): void {
     const { idTagInfo } = payload;
     if (idTagInfo.status === "Accepted") {
       this._logger.log("Authorization successful");
@@ -781,7 +824,7 @@ export class OCPPMessageHandler {
 
   private handleStartTransactionResponse(
     connectorId: number,
-    payload: response.StartTransactionResponse,
+    payload: StartTransactionResponseV16,
   ): void {
     const { transactionId, idTagInfo } = payload;
     const connector = this._chargePoint.getConnector(connectorId);
@@ -814,7 +857,7 @@ export class OCPPMessageHandler {
 
   private handleStopTransactionResponse(
     connectorId: number,
-    payload: response.StopTransactionResponse,
+    payload: StopTransactionResponseV16,
   ): void {
     this._logger.log(
       `Transaction stopped successfully: ${JSON.stringify(payload)}`,
@@ -827,13 +870,13 @@ export class OCPPMessageHandler {
     }
   }
 
-  private handleHeartbeatResponse(payload: response.HeartbeatResponse): void {
+  private handleHeartbeatResponse(payload: HeartbeatResponseV16): void {
     this._logger.log(`Received heartbeat response: ${payload.currentTime}`);
   }
 
   private handleMeterValuesResponse(
-    payload: response.MeterValuesResponse,
-    request?: request.MeterValuesRequest,
+    payload: MeterValuesResponseV16,
+    request?: MeterValuesRequestV16,
   ): void {
     if (request) {
       const connector = this._chargePoint.getConnector(request.connectorId);
@@ -847,16 +890,14 @@ export class OCPPMessageHandler {
   }
 
   private handleStatusNotificationResponse(
-    payload: response.StatusNotificationResponse,
+    payload: StatusNotificationResponseV16,
   ): void {
     this._logger.log(
       `Status notification sent successfully: ${JSON.stringify(payload)}`,
     );
   }
 
-  private handleDataTransferResponse(
-    payload: response.DataTransferResponse,
-  ): void {
+  private handleDataTransferResponse(payload: DataTransferResponseV16): void {
     this._logger.log(
       `Data transfer sent successfully: ${JSON.stringify(payload)}`,
     );

--- a/src/v1/cp/OCPPWebSocket.ts
+++ b/src/v1/cp/OCPPWebSocket.ts
@@ -1,8 +1,24 @@
+import type {
+  AuthorizeRequestV16,
+  BootNotificationRequestV16,
+  ChangeConfigurationResponseV16,
+  ClearChargingProfileResponseV16,
+  GetConfigurationResponseV16,
+  GetDiagnosticsResponseV16,
+  HeartbeatRequestV16,
+  MeterValuesRequestV16,
+  RemoteStartTransactionResponseV16,
+  RemoteStopTransactionResponseV16,
+  ResetResponseV16,
+  StartTransactionRequestV16,
+  StatusNotificationRequestV16,
+  StopTransactionRequestV16,
+  TriggerMessageResponseV16,
+  UnlockConnectorResponseV16,
+} from "@cshil/ocpp-tools";
 import { openOcppWebSocket } from "../../cp/infrastructure/transport/wsUrlWithBasic";
 import { Logger } from "./Logger";
 import { OCPPAction, OCPPErrorCode, OCPPMessageType } from "./OcppTypes";
-import * as request from "@voltbras/ts-ocpp/dist/messages/json/request";
-import * as response from "@voltbras/ts-ocpp/dist/messages/json/response";
 
 export type OcppMessagePayload =
   | OcppMessageRequestPayload
@@ -10,24 +26,24 @@ export type OcppMessagePayload =
   | OcppMessageErrorPayload;
 
 export type OcppMessageRequestPayload =
-  | request.AuthorizeRequest
-  | request.BootNotificationRequest
-  | request.HeartbeatRequest
-  | request.MeterValuesRequest
-  | request.StartTransactionRequest
-  | request.StatusNotificationRequest
-  | request.StopTransactionRequest;
+  | AuthorizeRequestV16
+  | BootNotificationRequestV16
+  | HeartbeatRequestV16
+  | MeterValuesRequestV16
+  | StartTransactionRequestV16
+  | StatusNotificationRequestV16
+  | StopTransactionRequestV16;
 
 export type OcppMessageResponsePayload =
-  | response.ChangeConfigurationResponse
-  | response.GetConfigurationResponse
-  | response.GetDiagnosticsResponse
-  | response.RemoteStartTransactionResponse
-  | response.RemoteStopTransactionResponse
-  | response.ResetResponse
-  | response.TriggerMessageResponse
-  | response.UnlockConnectorResponse
-  | response.ClearChargingProfileResponse;
+  | ChangeConfigurationResponseV16
+  | GetConfigurationResponseV16
+  | GetDiagnosticsResponseV16
+  | RemoteStartTransactionResponseV16
+  | RemoteStopTransactionResponseV16
+  | ResetResponseV16
+  | TriggerMessageResponseV16
+  | UnlockConnectorResponseV16
+  | ClearChargingProfileResponseV16;
 
 export type OcppMessageErrorPayload = {
   readonly errorCode: OCPPErrorCode;

--- a/src/v1/cp/OcppTypes.ts
+++ b/src/v1/cp/OcppTypes.ts
@@ -1,4 +1,4 @@
-import { ErrorCode } from "@voltbras/ts-ocpp/dist/ws";
+import { OCPPErrorCodeV16 } from "@cshil/ocpp-tools";
 
 export enum OCPPStatus {
   Available = "Available",
@@ -126,7 +126,7 @@ export type OcppConfigurationKey = {
   value?: string;
 };
 
-export type OCPPErrorCode = ErrorCode;
+export type OCPPErrorCode = OCPPErrorCodeV16;
 
 export interface BootNotification {
   ChargeBoxSerialNumber: string;


### PR DESCRIPTION
## Summary

- Replace the unmaintained `@voltbras/ts-ocpp` with `@cshil/ocpp-tools`, which supports both OCPP 1.6 and 2.0.1
- Add initial OCPP 2.0.1 protocol support; the version is selectable per charge point in the UI

## Changes

### Library migration (`@voltbras/ts-ocpp` → `@cshil/ocpp-tools`)
- Update ~20 files to use `XxxRequestV16` / `XxxResponseV16` naming convention
- Define `OCPPMessageType` enum locally to preserve `CALLRESULT`/`CALLERROR` names site-wide
- `@voltbras/ts-ocpp` is fully removed from `package.json`

### OCPP 2.0.1 support
- `IChargePointMessageHandler` — new interface that decouples `ChargePoint` from the concrete 1.6 handler
- `OCPPMessageHandlerV201` — implements the following OCPP 2.0.1 messages:
  - `BootNotification` (maps 1.6 boot payload → `ChargingStation` object)
  - `Heartbeat`
  - `StatusNotification` (maps `OCPPStatus` → `ConnectorStatusEnumType`, skips `connectorId=0`)
  - `TransactionEvent` Started / Ended (replaces `StartTransaction` / `StopTransaction`)
  - `MeterValues`
  - `Authorize` (maps tag ID → `IdToken`)
- `ocppVersionToSubprotocol()` maps `"OCPP-2.0.1"` → `"ocpp2.0.1"` WebSocket subprotocol
- `ocppVersion` is now threaded through `ChargePoint` → `OCPPWebSocket` → `openOcppWebSocket`
- "OCPP 2.0.1" option added to the charge point config modal

## Test plan

- [ ] Configure a charge point with **OCPP 1.6J** and connect to a CSMS — verify existing behaviour is unchanged
- [ ] Configure a charge point with **OCPP 2.0.1** and connect to an OCPP 2.0.1-capable CSMS
  - [ ] Confirm WebSocket subprotocol negotiated as `ocpp2.0.1`
  - [ ] `BootNotification` accepted
  - [ ] `Heartbeat` sent periodically
  - [ ] `StatusNotification` sent on connector state change
  - [ ] `TransactionEvent` (Started) sent when a transaction starts
  - [ ] `TransactionEvent` (Ended) sent when a transaction stops
  - [ ] `MeterValues` sent periodically during charging

Relates to #68