### PR TITLE
feat(cli): expose diagnostics & firmware status notifications in JSON mode

### DIFF
--- a/src/cli/jsonMode.ts
+++ b/src/cli/jsonMode.ts
@@ -126,6 +126,18 @@ export async function handleJsonCommand(
       return undefined;
     }
 
+    case "diagnostics_status_notification": {
+      const status = requireString(params, "status");
+      service.sendDiagnosticsStatusNotification(status);
+      return undefined;
+    }
+
+    case "firmware_status_notification": {
+      const status = requireString(params, "status");
+      service.sendFirmwareStatusNotification(status);
+      return undefined;
+    }
+
     case "start_heartbeat": {
       const interval = requireNumber(params, "interval");
       if (interval <= 0) {

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -413,6 +413,25 @@ export class CLIChargePointService {
     this._chargePoint.sendHeartbeat();
   }
 
+  sendDiagnosticsStatusNotification(status: string): void {
+    this._chargePoint.sendDiagnosticsStatusNotification(
+      status as "Idle" | "Uploaded" | "UploadFailed" | "Uploading",
+    );
+  }
+
+  sendFirmwareStatusNotification(status: string): void {
+    this._chargePoint.sendFirmwareStatusNotification(
+      status as
+        | "Downloaded"
+        | "DownloadFailed"
+        | "Downloading"
+        | "Idle"
+        | "InstallationFailed"
+        | "Installing"
+        | "Installed",
+    );
+  }
+
   startHeartbeat(intervalSeconds: number): void {
     this._chargePoint.startHeartbeat(intervalSeconds);
   }


### PR DESCRIPTION
## Summary
- Add `diagnostics_status_notification` and `firmware_status_notification` commands to JSON mode.
- Each takes a `status` string and delegates to `ChargePoint.sendDiagnosticsStatusNotification` / `sendFirmwareStatusNotification`, sending `DiagnosticsStatusNotification.req` / `FirmwareStatusNotification.req`.
- Thin wrappers, consistent with the existing `heartbeat` and similar commands.

## Test plan
- [x] `bunx tsc --noEmit -p tsconfig.cli.json` — no new errors in the changed files (`jsonMode.ts` / `service.ts`); total error count is identical before and after the change.
- [x] Smoke test: fed each command into JSON mode and got `{"ok":true}`; a missing `status` returns `Missing or invalid parameter: status`.
- [ ] Verify the `.req` is actually transmitted with a connected CSMS (locally it is held back by the boot gate; once connected it sends like every other notification).