### PR TITLE
ci: semver Docker image tags + auto-drafted releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,59 @@
+# Config for release-drafter (.github/workflows/release-drafter.yml).
+# Maintains a rolling DRAFT GitHub Release that accumulates merged PRs on
+# `main`. Publishing the draft assigns the `vX.Y.Z` tag, which then triggers
+# the desktop-app build (release.yml) and the semver Docker image
+# (docker-publish.yml). The draft is just notes until you publish it.
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "Features"
+    labels: ["feature", "enhancement", "feat"]
+  - title: "Bug Fixes"
+    labels: ["fix", "bugfix", "bug"]
+  - title: "Maintenance"
+    labels: ["chore", "ci", "docs", "documentation", "dependencies", "refactor", "test"]
+
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: '\<*_&'
+
+# Next version is inferred from the labels on the PRs since the last release.
+# Defaults to a patch bump when nothing more specific applies.
+version-resolver:
+  major:
+    labels: ["major", "breaking"]
+  minor:
+    labels: ["minor", "feature", "enhancement", "feat"]
+  patch:
+    labels:
+      ["patch", "fix", "bugfix", "bug", "chore", "ci", "docs", "documentation", "dependencies", "refactor", "test"]
+  default: patch
+
+# Auto-label PRs so the categories/version above work without manual labeling.
+# Matches this repo's branch + conventional-commit title conventions.
+autolabeler:
+  - label: "feature"
+    branch: ['/^feat(ure)?\//']
+    title: ["/^feat(\\(.+\\))?:/"]
+  - label: "fix"
+    branch: ['/^fix\//']
+    title: ["/^fix(\\(.+\\))?:/"]
+  - label: "docs"
+    branch: ['/^docs\//']
+    title: ["/^docs(\\(.+\\))?:/"]
+  - label: "ci"
+    branch: ['/^ci\//']
+    title: ["/^ci(\\(.+\\))?:/"]
+  - label: "chore"
+    branch: ['/^chore\//']
+    title: ["/^chore(\\(.+\\))?:/"]
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPO/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+  ---
+  Container image: `ghcr.io/$OWNER/$REPO:$RESOLVED_VERSION` (published when this release is tagged).

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,24 +29,9 @@ version-resolver:
       ["patch", "fix", "bugfix", "bug", "chore", "ci", "docs", "documentation", "dependencies", "refactor", "test"]
   default: patch
 
-# Auto-label PRs so the categories/version above work without manual labeling.
-# Matches this repo's branch + conventional-commit title conventions.
-autolabeler:
-  - label: "feature"
-    branch: ['/^feat(ure)?\//']
-    title: ["/^feat(\\(.+\\))?:/"]
-  - label: "fix"
-    branch: ['/^fix\//']
-    title: ["/^fix(\\(.+\\))?:/"]
-  - label: "docs"
-    branch: ['/^docs\//']
-    title: ["/^docs(\\(.+\\))?:/"]
-  - label: "ci"
-    branch: ['/^ci\//']
-    title: ["/^ci(\\(.+\\))?:/"]
-  - label: "chore"
-    branch: ['/^chore\//']
-    title: ["/^chore(\\(.+\\))?:/"]
+# Note: categories/version above key off PR labels. This drafter runs only on
+# push to `main` (no PR autolabeling), so label PRs manually to group them —
+# otherwise changes land uncategorized and the version defaults to a patch bump.
 
 template: |
   ## What's Changed

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,12 +5,15 @@ name: Build & publish Docker image
 # ghcr.io/<owner>/<repo>. Triggers:
 #   - push to `main`                       → `main` + `sha-<short>` + `latest`
 #   - push to `feat/browser-remote-mode`   → branch-slug + `sha-<short>` (no `latest`)
+#   - push of a `vX.Y.Z` tag               → `X.Y.Z` + `X.Y` + `X` (semver pins)
 #   - manual via workflow_dispatch         → same as the triggering branch
 #
 # We deliberately do NOT build on every PR or every feature branch:
 # Docker layers take time + cache space, and the active branch already
-# rebuilds on every push. Tag-based releases can be re-added if/when
-# we cut versioned images.
+# rebuilds on every push. Versioned releases come from `vX.Y.Z` tags
+# (same tags that `release.yml` cuts for the desktop app), giving
+# reproducible image pins like `ghcr.io/<owner>/<repo>:1.2.3`. `latest`
+# stays pinned to `main` (bleeding edge), not to the newest release.
 
 on:
   push:
@@ -20,6 +23,10 @@ on:
       # Active feature branch — pushes here get an image tagged with the
       # branch slug + commit sha so we can test changes without merging.
       - feat/browser-remote-mode
+    tags:
+      # Semver release tags — publish immutable `X.Y.Z` / `X.Y` / `X`
+      # image pins for reproducible deployments (issue #72).
+      - "v*"
   workflow_dispatch:
 
 permissions:
@@ -50,11 +57,20 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
+          # `latest` deliberately tracks the default branch (bleeding edge),
+          # NOT the newest semver tag — so disable metadata-action's built-in
+          # "latest on semver" behaviour and set `latest` ourselves below.
+          flavor: |
+            latest=false
           tags: |
-            # main      → `main` + `sha-<short>` + `latest`
-            # feat/...  → branch-slug + `sha-<short>` (no `latest`)
+            # main       → `main` + `sha-<short>` + `latest`
+            # feat/...   → branch-slug + `sha-<short>` (no `latest`)
+            # v1.2.3 tag → `1.2.3` + `1.2` + `1` (semver release pins)
             type=ref,event=branch
             type=sha,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build & push

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,33 @@
+name: Release Drafter
+
+# Keeps a DRAFT GitHub Release up to date as PRs merge to `main`, so a release
+# is always one click away: review the auto-generated notes, then Publish. On
+# publish the release's `vX.Y.Z` tag is created, which triggers release.yml
+# (desktop builds) and docker-publish.yml (semver image tags). See config in
+# .github/release-drafter.yml.
+#
+# The `pull_request` trigger only runs the autolabeler (categorize PRs by
+# branch/title); the draft itself is (re)written on push to `main`.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write # create / update the draft release
+      pull-requests: write # apply autolabels to PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,15 +6,14 @@ name: Release Drafter
 # (desktop builds) and docker-publish.yml (semver image tags). See config in
 # .github/release-drafter.yml.
 #
-# The `pull_request` trigger only runs the autolabeler (categorize PRs by
-# branch/title); the draft itself is (re)written on push to `main`.
+# Runs ONLY on push to `main` — not on pull requests. Categorization / version
+# bumps therefore use whatever labels a PR already carries (label PRs manually,
+# or the change lands uncategorized and the version defaults to a patch bump).
 
 on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
@@ -23,7 +22,6 @@ jobs:
   update_release_draft:
     permissions:
       contents: write # create / update the draft release
-      pull-requests: write # apply autolabels to PRs
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,6 +4,22 @@ The image bundles **both** the daemon and the React browser UI in a single Bun-b
 
 Hosted images live at **`ghcr.io/shiv3/ocpp-cp-simulator`** (built by [`.github/workflows/docker-publish.yml`](../.github/workflows/docker-publish.yml) on push to `main` and on `v*` / `cli-v*` tags).
 
+### Image tags
+
+| Tag                      | Moves?    | Use it for                                                       |
+| ------------------------ | --------- | ---------------------------------------------------------------- |
+| `latest`                 | mutable   | Bleeding edge — tracks the newest `main` build.                  |
+| `main`                   | mutable   | Same as `latest`; explicit about the source branch.              |
+| `sha-<short>`            | immutable | Pin to one exact `main` commit.                                  |
+| `X.Y.Z` (e.g. `1.2.3`)   | immutable | **Reproducible release pin** — recommended for IaC / production. |
+| `X.Y` (e.g. `1.2`) / `X` | mutable   | Auto-track patch / minor releases within a version line.         |
+
+Semver tags are published when a `vX.Y.Z` git tag is pushed (the same tag that cuts the desktop-app [release](../.github/workflows/release.yml)). For production, pin to a full `X.Y.Z` (or a digest) rather than `latest`/`main`:
+
+```sh
+docker pull ghcr.io/shiv3/ocpp-cp-simulator:1.2.3
+```
+
 ## Quick start
 
 ```sh


### PR DESCRIPTION
## Summary
- Publish immutable `X.Y.Z` / `X.Y` / `X` image pins on `vX.Y.Z` tag pushes so deployments can pin reproducibly (`ghcr.io/shiv3/ocpp-cp-simulator:1.2.3`) instead of mutable `latest`/`main`/digest-only.
- Keep `latest` pinned to `main` (bleeding edge) via `flavor: latest=false` + an explicit default-branch rule.
- Add release-drafter so every merge to `main` maintains a rolling **draft** GitHub Release with auto-categorized notes (PRs labeled by branch/title). Publishing the draft cuts the `vX.Y.Z` tag, which then drives both `release.yml` (desktop builds) and the semver image tags above — cutting a release becomes review-and-publish.
- Document the tag scheme in `docs/docker.md`.

Closes #72

## Test plan
- [ ] Merge a PR to `main` → the draft release updates with categorized notes.
- [ ] Publish the draft → `vX.Y.Z` tag created → `ghcr.io/...:X.Y.Z` / `:X.Y` / `:X` published and `latest` left unchanged.