### PR TITLE
docs: use the ocpp-cp-sim command in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install
 npm run dev
 
 # CLI / Server mode (requires Bun)
-bun src/cli/main.ts --ws-url ws://localhost:9000/ocpp --cp-id CP001
+ocpp-cp-sim --ws-url ws://localhost:9000/ocpp --cp-id CP001
 ```
 
 ### Install as a global command (`ocpp-cp-sim`)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,10 +10,10 @@ Headless charge point simulator for scripting, CI pipelines, and AI/automation i
 
 ```bash
 # Interactive REPL
-bun src/cli/main.ts --ws-url ws://localhost:9000/ocpp --cp-id CP001
+ocpp-cp-sim --ws-url ws://localhost:9000/ocpp --cp-id CP001
 
 # JSON Lines mode (for automation)
-bun src/cli/main.ts --ws-url ws://localhost:9000/ocpp --cp-id CP001 --json
+ocpp-cp-sim --ws-url ws://localhost:9000/ocpp --cp-id CP001 --json
 
 # npm script shorthand
 npm run cli -- --ws-url ws://localhost:9000/ocpp --cp-id CP001
@@ -41,7 +41,7 @@ ocpp-cp-sim --daemon --http-port 9700
 
 > A plain `bun install -g github:shiv3/ocpp-cp-simulator` is **not** supported: the web-console `dist/` is built at release time (not committed to git), and bun doesn't install devDependencies for global packages so it can't run `vite build` on install. Use the prebuilt tarball URL above.
 
-All flags described below apply to both `ocpp-cp-sim ...` and `bun src/cli/main.ts ...`.
+All flags described below apply whether you run the installed `ocpp-cp-sim` command or, from a source checkout, `bun src/cli/main.ts …`.
 
 ## Operation Modes
 
@@ -50,7 +50,7 @@ All flags described below apply to both `ocpp-cp-sim ...` and `bun src/cli/main.
 Default mode. Connects to a CSMS and provides a `ocpp>` prompt.
 
 ```bash
-bun src/cli/main.ts --ws-url ws://localhost:9000/ocpp --cp-id CP001
+ocpp-cp-sim --ws-url ws://localhost:9000/ocpp --cp-id CP001
 ```
 
 ```
@@ -93,7 +93,7 @@ ChargePoint: CP001  Status: ...
 Machine-readable mode for automation and AI agent integration. Each line of stdin is a JSON command; each line of stdout is a JSON response or event.
 
 ```bash
-bun src/cli/main.ts --ws-url ws://localhost:9000/ocpp --cp-id CP001 --json
+ocpp-cp-sim --ws-url ws://localhost:9000/ocpp --cp-id CP001 --json
 ```
 
 #### Request Format
@@ -160,28 +160,28 @@ Long-running process that exposes an **HTTP + WebSocket** API over a Unix domain
 
 ```bash
 # Start daemon (Unix socket only, default /tmp/ocpp-server.sock)
-bun src/cli/main.ts --ws-url ws://localhost:9000/ocpp --cp-id CP001 --daemon &
+ocpp-cp-sim --ws-url ws://localhost:9000/ocpp --cp-id CP001 --daemon &
 
 # Start daemon with both Unix socket and TCP
-bun src/cli/main.ts --ws-url ws://localhost:9000/ocpp --cp-id CP001 --daemon --http-port 9700 &
+ocpp-cp-sim --ws-url ws://localhost:9000/ocpp --cp-id CP001 --daemon --http-port 9700 &
 
 # Start foreground HTTP server (no Unix socket by default)
-bun src/cli/main.ts --http-port 9700
+ocpp-cp-sim --http-port 9700
 
 # Send command to running server (Unix socket by default)
-bun src/cli/main.ts --cp-id CP001 --send '{"command": "status"}'
+ocpp-cp-sim --cp-id CP001 --send '{"command": "status"}'
 
 # Send command via TCP HTTP
-bun src/cli/main.ts --cp-id CP001 --http-url http://127.0.0.1:9700 --send '{"command": "status"}'
+ocpp-cp-sim --cp-id CP001 --http-url http://127.0.0.1:9700 --send '{"command": "status"}'
 
 # Subscribe to real-time events (TCP only)
-bun src/cli/main.ts --cp-id CP001 --http-url http://127.0.0.1:9700 --events
+ocpp-cp-sim --cp-id CP001 --http-url http://127.0.0.1:9700 --events
 
 # Subscribe to all CPs' events
-bun src/cli/main.ts --http-url http://127.0.0.1:9700 --events --all
+ocpp-cp-sim --http-url http://127.0.0.1:9700 --events --all
 
 # Shut down the server
-bun src/cli/main.ts --stop
+ocpp-cp-sim --stop
 ```
 
 #### Server Files
@@ -199,7 +199,7 @@ Use `--unix-socket /custom/path` to change the path. Use `--unix-socket none` to
 
 ```bash
 # Start with no initial CP
-bun src/cli/main.ts --daemon --http-port 9700 &
+ocpp-cp-sim --daemon --http-port 9700 &
 
 # Create CPs dynamically
 curl -X POST http://127.0.0.1:9700/v1/cp \

--- a/docs/server.md
+++ b/docs/server.md
@@ -4,28 +4,28 @@ The simulator can run as a long-lived process exposing an HTTP/WebSocket API. A 
 
 The same HTTP/WS handlers are exposed over both a TCP port and a Unix domain socket, so local tools can use the Unix socket for lower-overhead IPC while remote clients use TCP.
 
-> All examples below show `bun src/cli/main.ts` for clarity when working from a checkout. If you've installed the package (`bun link` or `bun install -g`), `ocpp-cp-sim` is interchangeable everywhere.
+> All examples below use the installed `ocpp-cp-sim` command. From a source checkout (no install), `bun src/cli/main.ts …` is interchangeable everywhere.
 
 ## Starting the Server
 
 ```bash
 # Background daemon, Unix socket only (default /tmp/ocpp-server.sock)
-bun src/cli/main.ts --daemon &
+ocpp-cp-sim --daemon &
 
 # Background daemon, Unix + TCP
-bun src/cli/main.ts --daemon --http-port 9700 &
+ocpp-cp-sim --daemon --http-port 9700 &
 
 # Foreground HTTP server (no Unix socket by default)
-bun src/cli/main.ts --http-port 9700
+ocpp-cp-sim --http-port 9700
 
 # Foreground HTTP + custom Unix socket
-bun src/cli/main.ts --http-port 9700 --unix-socket /var/run/ocpp.sock
+ocpp-cp-sim --http-port 9700 --unix-socket /var/run/ocpp.sock
 
 # TCP-only daemon
-bun src/cli/main.ts --daemon --unix-socket none --http-port 9700 &
+ocpp-cp-sim --daemon --unix-socket none --http-port 9700 &
 
 # Bootstrap a CP at startup
-bun src/cli/main.ts --daemon --http-port 9700 \
+ocpp-cp-sim --daemon --http-port 9700 \
   --cp-id CP001 --ws-url ws://localhost:9000/ocpp &
 ```
 
@@ -259,7 +259,7 @@ Inbound messages are ignored in this version (push-only). For events, only TCP i
 
 ```bash
 # Start the server (foreground)
-bun src/cli/main.ts --http-port 9700
+ocpp-cp-sim --http-port 9700
 
 # In another shell, register a CP and connect it
 curl -X POST http://127.0.0.1:9700/v1/cp \


### PR DESCRIPTION
## Summary
- Replace `bun src/cli/main.ts …` with the installed `ocpp-cp-sim` command in all runnable examples across `README.md`, `docs/cli.md`, and `docs/server.md` (23 spots).
- Flip the two "from a source checkout" notes so they now present `bun src/cli/main.ts …` as the equivalent for checkout users.
- Left `docs/browser.md` unchanged: there `bun src/cli/main.ts` factually describes what the Tauri dev shell spawns (the source), not a command users type.

## Test plan
- [ ] Skim the rendered docs — example commands read as `ocpp-cp-sim …`; the checkout notes still make sense.

> Note: overlaps with #75 and #76 (both also edit `README.md` / `docs/server.md` / `docs/cli.md`) — expect a trivial conflict depending on merge order.