### PR TITLE
ci: keep tauri-action on Node 20 to fix the desktop release

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -8,6 +8,12 @@ on:
         required: true
         type: string
 
+# See release.yml: tauri-action@v0's Node 20 bundle crashes under the Node 24
+# GitHub now forces on Actions, so opt back into Node 20 until it ships a
+# Node 24-compatible release.
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+
 jobs:
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,14 @@ on:
       - "v*"
   workflow_dispatch:
 
+# tauri-action@v0 (incl. the latest v0.6.2) ships a Node 20 bundle whose
+# top-level await is left "unsettled" under the Node 24 that GitHub now forces
+# on Actions runners (Node 20 deprecated 2026-06-16). That kills the step right
+# after "running pnpm [tauri build]", before any build runs. Opt back into
+# Node 20 until tauri-action publishes a Node 24-compatible release.
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+
 jobs:
   release:
     permissions:


### PR DESCRIPTION
## Summary
- The first real `v*` release (`v0.3.2`) failed: the **Release Desktop App** workflow died in *Build Tauri app* right after `running pnpm [tauri build]`, with `Detected unsettled top-level await at .../tauri-action/v0/dist/index.js`.
- Root cause: GitHub deprecated Node 20 on 2026-06-16 and now forces Actions onto **Node 24**. `tauri-action@v0` (latest `v0.6.2`) ships a Node 20 webpack bundle whose top-level await is left "unsettled" under Node 24, crashing the action before any build runs. A version bump doesn't help (no Node 24-compatible release yet).
- Fix: set `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` (GitHub's documented opt-out) on `release.yml` and `manual-release.yml` so they run on Node 20.
- **No lockfile changes.** The stale `pnpm-lock.yaml` is *not* involved — tauri-action runs `pnpm tauri build` directly (no `pnpm install`), so the lockfile is never consulted.

## Caveats
- This is GitHub's **temporary** opt-out; Node 20 is removed from runners on 2026-09-16. Revisit when tauri-action publishes a Node 24-compatible release.
- Only verifiable by cutting a real `v*` release (CI-only repro) — the Rust build / signing steps downstream have never run before, so a later failure there is possible.

## Test plan
- [ ] Re-run the release (publish a draft → `v*` tag) and confirm *Build Tauri app* gets past the action startup and into the actual build.