### PR TITLE
feat(server): emit semantic Cache-Control headers in daemon mode

### DIFF
--- a/src/cli/server/__tests__/httpServer.staticCache.bun.test.ts
+++ b/src/cli/server/__tests__/httpServer.staticCache.bun.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { createHttpHandlers } from "../httpServer";
+import { CPRegistry } from "../CPRegistry";
+import { EventBus } from "../eventBus";
+import { createLifecycle } from "../lifecycle";
+
+// serveStatic uses Bun.file, so this lives in a `.bun.test.ts` file that runs
+// under `bun test` rather than vitest.
+//
+// Covers issue #79: the daemon must emit semantically-correct Cache-Control
+// headers so a CDN behind forward-auth doesn't edge-cache auth-gated assets by
+// file extension, while still letting content-hashed build assets cache long.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const stubServer = null as any;
+
+let staticDir: string;
+
+function makeHandlers(): ReturnType<typeof createHttpHandlers> {
+  const bus = new EventBus();
+  const registry = new CPRegistry(bus, null);
+  const lifecycle = createLifecycle({ pidPath: null, registry });
+  return createHttpHandlers({
+    registry,
+    bus,
+    lifecycle,
+    database: null,
+    healthPath: "/v1/healthz",
+    cors: { kind: "any" },
+    staticDir,
+  });
+}
+
+async function run(req: Request): Promise<Response> {
+  const handlers = makeHandlers();
+  return (await Promise.resolve(handlers.fetch(req, stubServer))) as Response;
+}
+
+beforeAll(() => {
+  staticDir = fs.mkdtempSync(path.join(os.tmpdir(), "ocpp-static-"));
+  fs.mkdirSync(path.join(staticDir, "assets"), { recursive: true });
+  fs.writeFileSync(
+    path.join(staticDir, "index.html"),
+    "<!doctype html><html><body>hi</body></html>",
+  );
+  fs.writeFileSync(
+    path.join(staticDir, "assets", "index-abc123.js"),
+    "console.log('hi');",
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(staticDir, { recursive: true, force: true });
+});
+
+describe("httpServer static Cache-Control (issue #79)", () => {
+  it("marks content-hashed /assets/* as immutable, long-lived", async () => {
+    const res = await run(
+      new Request("http://127.0.0.1:9700/assets/index-abc123.js"),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable",
+    );
+  });
+
+  it("marks the HTML entry point (/) as no-store", async () => {
+    const res = await run(new Request("http://127.0.0.1:9700/"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("marks an explicit index.html request as no-store", async () => {
+    const res = await run(new Request("http://127.0.0.1:9700/index.html"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("marks the SPA fallback (deep link) as no-store", async () => {
+    const res = await run(new Request("http://127.0.0.1:9700/settings"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toContain("text/html");
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("marks control-API (/v1/*) responses as no-store", async () => {
+    const res = await run(new Request("http://127.0.0.1:9700/v1/cp"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+});

--- a/src/cli/server/httpServer.ts
+++ b/src/cli/server/httpServer.ts
@@ -43,6 +43,7 @@ async function serveStatic(
   }
 
   let file = Bun.file(resolved);
+  let servedFallback = false;
   if (!(await file.exists())) {
     // SPA fallback: only for "looks like a page" requests (no extension on
     // the last path segment). Asset requests for missing files should
@@ -51,8 +52,30 @@ async function serveStatic(
     if (last.includes(".")) return null;
     file = Bun.file(path.join(absoluteRoot, "index.html"));
     if (!(await file.exists())) return null;
+    servedFallback = true;
   }
-  return new Response(file);
+  const res = new Response(file);
+  res.headers.set("cache-control", cacheControlFor(pathname, servedFallback));
+  return res;
+}
+
+/**
+ * Cache-Control for a statically served file (issue #79).
+ *
+ * - Vite emits content hashes into `/assets/*` filenames, so the bytes for a
+ *   given URL never change: cache them forever and skip revalidation.
+ * - The HTML entry point and any SPA fallback (a deep link rewritten to
+ *   index.html) are the bootstrap document that references the current hashed
+ *   bundles; it must always be re-fetched or a stale shell pins old assets.
+ *   Everything else served from the static root (favicon, manifest, …) is
+ *   un-hashed too, so default it to no-store as well — conservative, and it
+ *   keeps a CDN from edge-caching auth-gated files by extension.
+ */
+function cacheControlFor(pathname: string, servedFallback: boolean): string {
+  if (!servedFallback && pathname.startsWith("assets/")) {
+    return "public, max-age=31536000, immutable";
+  }
+  return "no-store";
 }
 
 interface SocketData {
@@ -193,6 +216,20 @@ function forbidden(): Response {
 }
 
 /**
+ * Default every response to `Cache-Control: no-store` unless the handler set
+ * one explicitly (issue #79). serveStatic already stamps build assets as
+ * immutable and HTML as no-store; this catches the dynamic / auth-sensitive
+ * rest — the /v1 control API, health, CORS rejections — which must never be
+ * cached at a reverse-proxy edge.
+ */
+function applyCacheControl(res: Response): Response {
+  if (!res.headers.has("cache-control")) {
+    res.headers.set("cache-control", "no-store");
+  }
+  return res;
+}
+
+/**
  * Parse a `Authorization: Basic <base64>` header into username + password.
  * Returns null when the header is missing, not Basic, or doesn't decode.
  * Tolerates the rare `Basic` scheme written in any case.
@@ -328,9 +365,11 @@ export function createHttpHandlers(deps: {
 
       const result = dispatch(req, server);
       if (result === undefined) return undefined; // WS upgrade already handled
-      if (result instanceof Response) return applyCors(result, req, cors);
+      if (result instanceof Response) {
+        return applyCacheControl(applyCors(result, req, cors));
+      }
       return result.then((r) =>
-        r instanceof Response ? applyCors(r, req, cors) : r,
+        r instanceof Response ? applyCacheControl(applyCors(r, req, cors)) : r,
       );
     },
 


### PR DESCRIPTION
## Summary

Closes #79. In server/daemon mode the simulator previously emitted **no `Cache-Control` header** on any response. With no caching directive, a CDN falls back to its own heuristics (Cloudflare, for example, edge-caches `.js`/`.css` by file extension regardless of headers), which behind forward-auth can cache auth-gated assets at the edge — forcing operators to blanket-disable caching at the proxy.

This sets `Cache-Control` itself, per route class, following the standard Vite/SPA convention:

- **Content-hashed build assets** (`/assets/*`): `public, max-age=31536000, immutable` — the filename changes when the content changes, so they're safe to cache forever.
- **HTML entry point / SPA fallback** (`/`, `index.html`, deep links rewritten to index.html): `no-store` — the bootstrap document references the current hashed bundles and must always revalidate.
- **Control API (`/v1/*`), health, errors, and other un-hashed static files** (favicon, manifest, …): `no-store` — dynamic / auth-sensitive, conservative default.

Pairs naturally with the existing reverse-proxy support (`--cors-origin` / `--trust-forwarded-headers`).

## Implementation

- `serveStatic` stamps each served file via a new `cacheControlFor(pathname, servedFallback)` helper. The `servedFallback` flag distinguishes a real `/assets/*` file from an extension-less path rewritten to `index.html`, so the SPA fallback never gets the immutable header.
- A new `applyCacheControl` step in the `fetch` wrapper defaults every response to `no-store` *unless the handler already set one*, so the immutable asset header is preserved while the dynamic `/v1/*` API and errors stay uncached.

## Test plan

- New `src/cli/server/__tests__/httpServer.staticCache.bun.test.ts` (runs under `bun test`, since `serveStatic` uses `Bun.file`):
  - `/assets/index-abc123.js` → `public, max-age=31536000, immutable`
  - `/`, `/index.html`, `/settings` (SPA fallback) → `no-store`
  - `/v1/cp` → `no-store`
- Full suite green: vitest 102 passed, bun 18 passed. Lint clean for touched files.