### PR TITLE
ci: fix Windows sidecar detection & Linux AppImage bundling

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -115,6 +115,15 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Tauri's beforeBuildCommand re-runs build-tauri-sidecar.sh; hand it
+          # the matrix triple so it doesn't have to auto-detect the host (which
+          # fails on the Windows MINGW runner, and would pick the wrong arch
+          # for the cross-compiled x86_64 macOS build).
+          TAURI_TARGET: ${{ matrix.target }}
+          # linuxdeploy and its plugins are AppImages; GitHub runners lack FUSE,
+          # so extract-and-run instead of mounting. Fixes the Linux AppImage
+          # bundle dying with "failed to run linuxdeploy". No-op off Linux.
+          APPIMAGE_EXTRACT_AND_RUN: "1"
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           args: ${{ matrix.args }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,15 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Tauri's beforeBuildCommand re-runs build-tauri-sidecar.sh; hand it
+          # the matrix triple so it doesn't have to auto-detect the host (which
+          # fails on the Windows MINGW runner, and would pick the wrong arch
+          # for the cross-compiled x86_64 macOS build).
+          TAURI_TARGET: ${{ matrix.target }}
+          # linuxdeploy and its plugins are AppImages; GitHub runners lack FUSE,
+          # so extract-and-run instead of mounting. Fixes the Linux AppImage
+          # bundle dying with "failed to run linuxdeploy". No-op off Linux.
+          APPIMAGE_EXTRACT_AND_RUN: "1"
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "OCPP CP Simulator ${{ github.ref_name }}"

--- a/scripts/build-tauri-sidecar.sh
+++ b/scripts/build-tauri-sidecar.sh
@@ -24,6 +24,9 @@ if [ -z "$TARGET" ]; then
     "Darwin x86_64") TARGET="x86_64-apple-darwin" ;;
     "Linux aarch64") TARGET="aarch64-unknown-linux-gnu" ;;
     "Linux x86_64")  TARGET="x86_64-unknown-linux-gnu" ;;
+    # Git Bash / MSYS2 / Cygwin report e.g. "MINGW64_NT-10.0-26100 x86_64".
+    MINGW*" x86_64" | MSYS*" x86_64" | CYGWIN*" x86_64") TARGET="x86_64-pc-windows-msvc" ;;
+    MINGW*" arm64" | MSYS*" arm64" | CYGWIN*" arm64")    TARGET="aarch64-pc-windows-msvc" ;;
     *) echo "Unable to auto-detect rust target triple from $(uname -sm); pass it as an arg." >&2; exit 1 ;;
   esac
 fi


### PR DESCRIPTION
## Context

After #81 fixed the `pnpm` spawn failure, the v0.3.4 release got all the way to the **actual Tauri build** — macOS (both arches) now build and publish successfully ✅. That exposed two platform-specific bundling bugs that were previously masked by the early `pnpm` crash.

## Windows — `Unable to auto-detect rust target triple`

`npm run build` (vite) succeeds, then Tauri's `beforeBuildCommand` re-runs `build-tauri-sidecar.sh`. That second invocation has **no `TAURI_TARGET`** (it's set only on our explicit sidecar step, not inherited by the tauri-action step), so the script falls back to host auto-detect — and its `uname -sm` cases didn't cover the MINGW string the Windows runner reports (`MINGW64_NT-10.0-26100 x86_64`). It bailed:

```
✓ built in 7.33s
Unable to auto-detect rust target triple from MINGW64_NT-10.0-26100 x86_64; pass it as an arg.
beforeBuildCommand `npm run build && bash scripts/build-tauri-sidecar.sh` failed with exit code 1
```

Fix:
- Pass `TAURI_TARGET: ${{ matrix.target }}` to the **`Build Tauri app`** step so `beforeBuildCommand` gets the right triple. This also corrects the macOS x86_64 cross-build, which was auto-detecting the arm64 host triple instead of the target.
- Add `MINGW*`/`MSYS*`/`CYGWIN*` cases to `build-tauri-sidecar.sh` as a fallback for local Windows dev builds. Verified: `MINGW64_NT-10.0-26100 x86_64` → `x86_64-pc-windows-msvc`.

## Linux — `failed to run linuxdeploy`

The `.deb` and `.rpm` bundles succeed; the **AppImage** step fails:

```
Bundling OCPP CP Simulator_0.1.0_amd64.AppImage ...
failed to bundle project: `failed to run linuxdeploy`
```

`linuxdeploy` (and its GTK/gstreamer plugins) are themselves AppImages, and GitHub's `ubuntu-22.04` runners have no FUSE to mount them. Fix: set `APPIMAGE_EXTRACT_AND_RUN: "1"` on the build step so they extract-and-run instead of mounting (no-op on macOS/Windows).

## Changes

- `scripts/build-tauri-sidecar.sh`: handle MINGW/MSYS/Cygwin hosts in the auto-detect fallback.
- `release.yml` / `manual-release.yml`: add `TAURI_TARGET` + `APPIMAGE_EXTRACT_AND_RUN` to the tauri-action step env.

## Verification

- `bash -n` on the script passes; simulated the `uname -sm` case for the real Windows string and the existing macOS/Linux strings — all resolve correctly.
- Both workflow YAMLs validated.
- macOS already verified green on the v0.3.4 run; this targets the two remaining platforms. Full confirmation needs a tag push.