### PR TITLE
fix(meter): round meter values to integer watt-hours

### DIFF
--- a/src/cp/domain/charge-point/Configuration.ts
+++ b/src/cp/domain/charge-point/Configuration.ts
@@ -444,6 +444,10 @@ export const defaultConfiguration: (cp: ChargePoint) => Configuration = (
     intVal(ConfigurationKeys.Core.MeterValuesAlignedDataMaxLength, 8),
     arrVal(ConfigurationKeys.Core.MeterValuesSampledData, [
       "Energy.Active.Import.Register",
+      // Real charge points also sample instantaneous power; the CSMS uses
+      // Power.Active.Import (e.g. low-power / 3kW tariff detection), so emit it
+      // by default for realistic CSMS-side testing.
+      "Power.Active.Import",
     ]),
     intVal(ConfigurationKeys.Core.MeterValuesSampledDataMaxLength, 8),
     intVal(ConfigurationKeys.Core.MeterValueSampleInterval, 60),

--- a/src/cp/domain/connector/Connector.ts
+++ b/src/cp/domain/connector/Connector.ts
@@ -770,8 +770,16 @@ export class Connector {
   }
 
   private applyMeterValue(value: number): void {
-    this.meterValueWh = value;
-    this.eventsEmitter.emit("meterValueChange", { meterValue: value });
+    // OCPP 1.6 register meter values — StartTransaction.meterStart,
+    // StopTransaction.meterStop and MeterValues sampled values for
+    // Energy.Active.Import.Register — are integer watt-hours. The auto-meter
+    // curve interpolates in kWh and can yield a fractional Wh, so round to an
+    // integer here. A fractional meterStop is rejected by a strict CSMS with a
+    // FormationViolation ("cannot unmarshal number … into … of type int"),
+    // which silently strands the transaction in "Charging".
+    const meterValueWh = Math.round(value);
+    this.meterValueWh = meterValueWh;
+    this.eventsEmitter.emit("meterValueChange", { meterValue: meterValueWh });
     // Mirror the new meter value into SoC when the UI has flipped Sync on.
     // We do it here (not just in UI handlers) so the scenario's auto-meter
     // scheduler and any other domain caller also drive SoC. capacity=0 means
@@ -780,7 +788,7 @@ export class Connector {
       const capacity = this._evSettings.batteryCapacityKwh;
       if (capacity > 0) {
         const initial = this._evSettings.initialSoc ?? 0;
-        const derived = initial + (value / 1000 / capacity) * 100;
+        const derived = initial + (meterValueWh / 1000 / capacity) * 100;
         const clamped = Math.min(100, Math.max(0, derived));
         if (this.socPercent !== clamped) {
           this.socPercent = clamped;

--- a/src/cp/domain/connector/__tests__/Connector.meterValue.test.ts
+++ b/src/cp/domain/connector/__tests__/Connector.meterValue.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { Connector } from "../Connector";
+import { Logger, LogLevel } from "../../../shared/Logger";
+
+function makeConnector(): Connector {
+  return new Connector(1, new Logger(LogLevel.ERROR));
+}
+
+describe("Connector meterValue rounding", () => {
+  it("rounds a fractional meter value to an integer watt-hour", () => {
+    // OCPP 1.6 register meter values (StopTransaction.meterStop, MeterValues
+    // Energy.*.Register) are integer Wh. The auto-meter curve interpolates in
+    // kWh and can produce a fractional Wh (e.g. 26.008333 kWh -> 26008.333 Wh).
+    // A fractional meterStop is rejected by a strict CSMS with a
+    // FormationViolation and silently strands the transaction in "Charging".
+    const connector = makeConnector();
+
+    connector.meterValue = 26008.333333333343;
+    expect(connector.meterValue).toBe(26008);
+    expect(Number.isInteger(connector.meterValue)).toBe(true);
+
+    connector.meterValue = 73.33333333333331;
+    expect(connector.meterValue).toBe(73);
+    expect(Number.isInteger(connector.meterValue)).toBe(true);
+  });
+
+  it("leaves integer meter values unchanged", () => {
+    const connector = makeConnector();
+    connector.meterValue = 5000;
+    expect(connector.meterValue).toBe(5000);
+  });
+});


### PR DESCRIPTION
## Summary
OCPP 1.6 register-type meter values (`StartTransaction.meterStart`, `StopTransaction.meterStop`, and `MeterValues` for `Energy.*.Register`) are **integer watt-hours**. The auto-meter curve interpolates in kWh and could emit a **fractional Wh** (e.g. `26008.333` Wh).

A strict CSMS (e.g. an ocpp-go based one) rejects that with a `FormationViolation` (`cannot unmarshal number … into … of type int`), so the `StopTransaction` is never processed and the **transaction is stranded in "Charging"**.

## Changes
- Round `meterValueWh` to an integer Wh in `Connector.applyMeterValue`, so every downstream OCPP message (`meterStop`, `MeterValues`) carries a valid integer.
- Add **`Power.Active.Import`** to the default `MeterValuesSampledData`, so the simulator reports instantaneous power like a real charge point (a CSMS uses it e.g. for low-power / 3 kW tariff detection).
- Add a `Connector` unit test covering the rounding.

## Testing
- `vitest` connector suite: 25 passing (incl. the new test).
- `eslint --max-warnings 0`: clean.

## Background (issue reproduced on a real environment)
During a 10-connector concurrent-charging test on staging, the 8 sessions that charged for ~2+ minutes sent a fractional `meterStop` → the CSMS returned `CALLERROR (FormationViolation)` → `StopTransaction` was dropped → the transactions were stranded in "Charging".

With this fix, a 35-second charge produced `meterStop:483` (integer) and stopped cleanly, confirmed end-to-end on staging. The bug no longer reproduces.