### PR TITLE
fix(scenario): cancel auto-meter and abort flow on stop

### DIFF
--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -61,6 +61,14 @@ export class ScenarioExecutor {
   private previousState: ScenarioExecutionState = "idle";
   private eventEmitter?: EventEmitter<ScenarioEvents>;
   private forceSkipResolve: (() => void) | null = null;
+  // Abort plumbing: stop() flips `aborted` and resolves `abortPromise` so any
+  // in-flight wait (auto-meter maxTime, delay, status/meter waits) unblocks
+  // immediately and the flow walker bails before running the next node.
+  // Without this a stopped scenario's maxTime timer fires later and a stale
+  // "Stop Transaction" node ends an unrelated charge on the same connector.
+  private aborted = false;
+  private abortResolve: (() => void) | null = null;
+  private abortPromise: Promise<void> = Promise.resolve();
   private remoteStartTagId: string | null = null;
   // Reason captured from the most recent RemoteStopTrigger node, forwarded
   // to the next Transaction Stop's StopTransaction.req so the CSMS sees
@@ -124,6 +132,11 @@ export class ScenarioExecutor {
    */
   public async start(opts?: ScenarioStartOptions): Promise<void> {
     const mode: ScenarioExecutionMode = "oneshot";
+    // Fresh abort gate for this run.
+    this.aborted = false;
+    this.abortPromise = new Promise<void>((resolve) => {
+      this.abortResolve = resolve;
+    });
     // Dispatch START event to transition to running state
     this.service.send({ type: "START", mode });
     this.notifyStateChange();
@@ -334,6 +347,7 @@ export class ScenarioExecutor {
 
     while (
       currentNode &&
+      !this.aborted &&
       getScenarioStateName(this.service.machine) !== "idle"
     ) {
       // Execute the current node
@@ -380,6 +394,11 @@ export class ScenarioExecutor {
    * Execute a single node
    */
   private async executeSingleNode(node: ScenarioNode): Promise<void> {
+    // A stop() may have landed while the previous node was awaiting; never
+    // start another node once aborted.
+    if (this.aborted) {
+      return;
+    }
     // Update context with current node
     const context = getScenarioContext(this.service.machine);
     context.currentNodeId = node.id;
@@ -1149,6 +1168,15 @@ export class ScenarioExecutor {
    * Stop execution
    */
   public stop(): void {
+    // Flip the abort gate first so in-flight waits unblock and the flow
+    // walker bails before executing the next node.
+    this.aborted = true;
+    this.abortResolve?.();
+    // Stop the connector's auto-meter now; otherwise a pending maxTime/maxValue
+    // could later resume the flow and fire a downstream Stop Transaction on a
+    // charge that started after this scenario was stopped.
+    this.callbacks.onStopAutoMeterValue?.();
+
     this.service.send({ type: "STOP" });
     this.notifyStateChange();
 
@@ -1233,7 +1261,7 @@ export class ScenarioExecutor {
   ): Promise<void> {
     const stateName = getScenarioStateName(this.service.machine);
     if (stateName !== "stepping") {
-      await waitPromise;
+      await Promise.race([waitPromise, this.abortPromise]);
       return;
     }
 
@@ -1244,7 +1272,7 @@ export class ScenarioExecutor {
     this.forceSkipResolve = localResolve;
 
     try {
-      await Promise.race([waitPromise, forcePromise]);
+      await Promise.race([waitPromise, forcePromise, this.abortPromise]);
     } finally {
       if (this.forceSkipResolve === localResolve) {
         this.forceSkipResolve = null;
@@ -1263,6 +1291,12 @@ export class ScenarioExecutor {
    * Sleep utility
    */
   private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    if (this.aborted) {
+      return Promise.resolve();
+    }
+    return Promise.race([
+      new Promise<void>((resolve) => setTimeout(resolve, ms)),
+      this.abortPromise,
+    ]);
   }
 }

--- a/src/cp/application/scenario/__tests__/ScenarioExecutor.stop.test.ts
+++ b/src/cp/application/scenario/__tests__/ScenarioExecutor.stop.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from "vitest";
+import { ScenarioExecutor } from "../ScenarioExecutor";
+import { ScenarioDefinition, ScenarioNodeType } from "../ScenarioTypes";
+
+// Regression: stopping a scenario while its auto-meter node is waiting out
+// `maxTime` must (a) stop the auto-meter immediately and (b) never let the
+// flow advance to the downstream node. Before the fix, stop() neither aborted
+// the maxTime wait nor stopped the scheduler, so `maxTime` seconds later the
+// node "completed" and a stale "Stop Transaction" fired — ending an unrelated
+// charge that had since started on the same connector.
+function autoMeterThenStopScenario(): ScenarioDefinition {
+  return {
+    id: "stop-during-auto-meter",
+    name: "Stop during auto-meter",
+    targetType: "connector",
+    targetId: 1,
+    nodes: [
+      {
+        id: "start",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "auto-meter",
+        type: ScenarioNodeType.METER_VALUE,
+        position: { x: 0, y: 100 },
+        data: {
+          label: "Auto MeterValue",
+          value: 0,
+          sendMessage: false,
+          autoIncrement: true,
+          incrementInterval: 1,
+          incrementAmount: 10,
+          maxValue: 999999,
+          maxTime: 1,
+        },
+      },
+      {
+        id: "stop-tx",
+        type: ScenarioNodeType.TRANSACTION,
+        position: { x: 0, y: 200 },
+        data: { label: "Stop Transaction", action: "stop" },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "start", target: "auto-meter" },
+      { id: "e2", source: "auto-meter", target: "stop-tx" },
+    ],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    defaultExecutionMode: "oneshot",
+    enabled: true,
+    trigger: { type: "manual" },
+  };
+}
+
+describe("ScenarioExecutor stop during auto-meter", () => {
+  it("stops the auto-meter promptly and does not advance to the downstream node", async () => {
+    const onStartAutoMeterValue = vi.fn();
+    const onStopAutoMeterValue = vi.fn();
+    const onStopTransaction = vi.fn(async () => {});
+
+    const executor = new ScenarioExecutor(autoMeterThenStopScenario(), {
+      onStartAutoMeterValue,
+      onStopAutoMeterValue,
+      onStopTransaction,
+    });
+
+    const execution = executor.start();
+
+    // Let the flow reach the auto-meter node and begin its maxTime wait.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(onStartAutoMeterValue).toHaveBeenCalledTimes(1);
+    expect(onStopTransaction).not.toHaveBeenCalled();
+
+    // Stop mid-wait: the auto-meter must be cancelled now, not after maxTime.
+    executor.stop();
+    expect(onStopAutoMeterValue).toHaveBeenCalled();
+
+    // Wait well past maxTime (1s) to prove the stale timer never advances.
+    await new Promise((r) => setTimeout(r, 1200));
+    await execution.catch(() => {});
+
+    expect(onStopTransaction).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem
Stopping a scenario while its **auto-meter node** is waiting out `maxTime` did not actually cancel anything:

- `stop()` only sent `STOP` to the state machine and emitted events.
- The meterValue node was blocked on `await waitWithProgress(maxTime)` → a **non-abortable `setTimeout`**, and the connector's `MeterValueScheduler` kept running.
- So `maxTime` seconds *later* the wait resolved, the node "completed", and the sequential walker advanced to the **next node — usually a Stop Transaction**.

In a multi-charge test this fired a stale `StopTransaction` that **ended an unrelated charge** which had since started on the same connector (observed: a 12-min charge cut to ~3 min → wrong billing-block count). Because `stop_all_scenarios` / `removeScenario` both go through `executor.stop()`, they couldn't reliably clear a running scenario either — the only workaround was resetting state + restarting the process.

## Fix
`stop()` now flips an **abort gate**:
- resolves an `abortPromise` that every wait (`sleep`/`maxTime`, status/meter waits via `waitWithOptionalForceSkip`) races against, so in-flight waits unblock immediately;
- calls `onStopAutoMeterValue()` to halt the scheduler right away;
- the flow walker (`executeSequentialFlow`) and `executeSingleNode` both bail once `aborted`, so no further node runs.

The abort gate is reset per run in `start()`.

## Test
New `ScenarioExecutor.stop.test.ts`: `start → auto-meter(maxTime=1s) → Stop Transaction`; stop mid-wait; assert the auto-meter is stopped **immediately** (not after `maxTime`) and the downstream Stop Transaction **never** runs even after `maxTime` elapses. Fails before the change, passes after.

`tsc --noEmit` clean; full suite 105/105 green.