### PR TITLE
feat(cli): friendlier client target + per-connector EV override on templates

### DIFF
--- a/src/cli/__tests__/clientLocation.test.ts
+++ b/src/cli/__tests__/clientLocation.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { resolveClientLocation } from "../clientLocation";
+
+const base = {
+  httpUrl: null as string | null,
+  unixSocket: null as string | null,
+  httpBasicAuth: null as { username: string; password: string } | null,
+  httpHost: "",
+  httpPort: null as number | null,
+  basicAuth: null as { username: string; password: string } | null,
+};
+
+describe("resolveClientLocation", () => {
+  it("uses explicit --http-url + --http-basic-auth with no warnings", () => {
+    const { location, warnings } = resolveClientLocation({
+      ...base,
+      httpUrl: "http://h:1",
+      httpBasicAuth: { username: "u", password: "p" },
+    });
+    expect(location).toEqual({
+      httpUrl: "http://h:1",
+      unixSocket: null,
+      basicAuth: { username: "u", password: "p" },
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  it("derives client target from --http-port/--http-host with a deprecation warning", () => {
+    const { location, warnings } = resolveClientLocation({
+      ...base,
+      httpHost: "localhost",
+      httpPort: 9700,
+    });
+    expect(location.httpUrl).toBe("http://localhost:9700");
+    expect(
+      warnings.some(
+        (w) => w.includes("deprecated") && w.includes("--http-url"),
+      ),
+    ).toBe(true);
+  });
+
+  it("defaults the derived host to 127.0.0.1", () => {
+    const { location } = resolveClientLocation({ ...base, httpPort: 9700 });
+    expect(location.httpUrl).toBe("http://127.0.0.1:9700");
+  });
+
+  it("falls back to --basic-auth-* for client credentials with a deprecation warning", () => {
+    const { location, warnings } = resolveClientLocation({
+      ...base,
+      httpUrl: "http://h:1",
+      basicAuth: { username: "a", password: "b" },
+    });
+    expect(location.basicAuth).toEqual({ username: "a", password: "b" });
+    expect(
+      warnings.some(
+        (w) => w.includes("deprecated") && w.includes("--http-basic-auth"),
+      ),
+    ).toBe(true);
+  });
+
+  it("prefers --http-basic-auth over --basic-auth (no warning)", () => {
+    const { location, warnings } = resolveClientLocation({
+      ...base,
+      httpUrl: "http://h:1",
+      httpBasicAuth: { username: "x", password: "y" },
+      basicAuth: { username: "a", password: "b" },
+    });
+    expect(location.basicAuth).toEqual({ username: "x", password: "y" });
+    expect(warnings).toEqual([]);
+  });
+
+  it("an explicit unix socket suppresses the --http-port derivation", () => {
+    const { location, warnings } = resolveClientLocation({
+      ...base,
+      unixSocket: "/tmp/s.sock",
+      httpPort: 9700,
+    });
+    expect(location.httpUrl).toBeNull();
+    expect(location.unixSocket).toBe("/tmp/s.sock");
+    expect(warnings).toEqual([]);
+  });
+});

--- a/src/cli/__tests__/jsonMode.template.test.ts
+++ b/src/cli/__tests__/jsonMode.template.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleJsonCommand } from "../jsonMode";
+import type { CLIChargePointService } from "../service";
+
+// run_scenario_template / load_scenario_template should accept an optional
+// `evSettings` override so a connector's charging power (=> low-power
+// eligibility) can be set without authoring a whole custom scenario — the
+// template's own evSettings would otherwise clobber a prior set_ev_settings.
+describe("(load|run)_scenario_template evSettings override", () => {
+  it("forwards evSettings to loadScenarioTemplate and runs the scenario", async () => {
+    const loadScenarioTemplate = vi.fn().mockReturnValue("sid-1");
+    const runScenario = vi.fn();
+    const service = {
+      loadScenarioTemplate,
+      runScenario,
+    } as unknown as CLIChargePointService;
+
+    const res = await handleJsonCommand(service, {
+      command: "run_scenario_template",
+      params: {
+        connector: 1,
+        templateId: "essential-cp-behavior",
+        evSettings: { maxChargingPowerKw: 3 },
+      },
+    });
+
+    expect(loadScenarioTemplate).toHaveBeenCalledWith(
+      "essential-cp-behavior",
+      1,
+      { maxChargingPowerKw: 3 },
+    );
+    expect(runScenario).toHaveBeenCalledWith(1, "sid-1");
+    expect(res).toEqual({ scenarioId: "sid-1" });
+  });
+
+  it("load_scenario_template forwards evSettings too", async () => {
+    const loadScenarioTemplate = vi.fn().mockReturnValue("sid-2");
+    const service = {
+      loadScenarioTemplate,
+    } as unknown as CLIChargePointService;
+
+    await handleJsonCommand(service, {
+      command: "load_scenario_template",
+      params: {
+        connector: 2,
+        templateId: "full-charging-cycle",
+        evSettings: { maxChargingPowerKw: 6 },
+      },
+    });
+
+    expect(loadScenarioTemplate).toHaveBeenCalledWith(
+      "full-charging-cycle",
+      2,
+      { maxChargingPowerKw: 6 },
+    );
+  });
+
+  it("omits the override when no evSettings is given", async () => {
+    const loadScenarioTemplate = vi.fn().mockReturnValue("sid-3");
+    const runScenario = vi.fn();
+    const service = {
+      loadScenarioTemplate,
+      runScenario,
+    } as unknown as CLIChargePointService;
+
+    await handleJsonCommand(service, {
+      command: "run_scenario_template",
+      params: { connector: 1, templateId: "smart-charging" },
+    });
+
+    expect(loadScenarioTemplate).toHaveBeenCalledWith(
+      "smart-charging",
+      1,
+      undefined,
+    );
+  });
+});

--- a/src/cli/client.ts
+++ b/src/cli/client.ts
@@ -93,11 +93,14 @@ function formatHttpError(
   target: ClientTarget,
 ): string {
   if (target.kind === "unix") {
+    const hint =
+      " To target a TCP daemon pass --http-url http://host:port" +
+      " (client modes use --http-url, not the server's --http-host/--http-port).";
     if (err.code === "ENOENT") {
-      return `No server running (socket not found: ${target.path})`;
+      return `No server running (socket not found: ${target.path}).${hint}`;
     }
     if (err.code === "ECONNREFUSED") {
-      return `Server is not accepting connections at ${target.path}`;
+      return `Server is not accepting connections at ${target.path}.${hint}`;
     }
   } else {
     if (err.code === "ECONNREFUSED") {

--- a/src/cli/clientLocation.ts
+++ b/src/cli/clientLocation.ts
@@ -1,0 +1,57 @@
+import type { ClientLocation } from "./client";
+
+type BasicAuth = { username: string; password: string };
+
+export interface ClientLocationOptions {
+  /** Canonical client target / credentials. */
+  httpUrl: string | null;
+  unixSocket: string | null;
+  httpBasicAuth: BasicAuth | null;
+  /** Server-side listen flags, accepted as a deprecated client target. */
+  httpHost: string;
+  httpPort: number | null;
+  /** Outgoing-WS credentials, accepted as deprecated client credentials. */
+  basicAuth: BasicAuth | null;
+}
+
+/**
+ * Resolve the target + credentials for client modes (--send / --stop /
+ * --events). The canonical flags are `--http-url` and `--http-basic-auth-*`.
+ *
+ * For backward compatibility we still honor the server-side
+ * `--http-host`/`--http-port` (as the TCP target) and the outgoing-WS
+ * `--basic-auth-*` (as the client credentials) when the canonical flags are
+ * absent — these are the flags people reach for intuitively — but return a
+ * deprecation warning so the caller can nudge them to the right ones.
+ */
+export function resolveClientLocation(options: ClientLocationOptions): {
+  location: ClientLocation;
+  warnings: string[];
+} {
+  const warnings: string[] = [];
+  let httpUrl = options.httpUrl;
+  let basicAuth = options.httpBasicAuth;
+
+  if (!httpUrl && !options.unixSocket && options.httpPort != null) {
+    const host = options.httpHost || "127.0.0.1";
+    httpUrl = `http://${host}:${options.httpPort}`;
+    warnings.push(
+      `deprecated: derived client target ${httpUrl} from --http-port/--http-host; ` +
+        "use --http-url <url> for client modes (--send/--stop/--events).",
+    );
+  }
+
+  if (!basicAuth && options.basicAuth) {
+    basicAuth = options.basicAuth;
+    warnings.push(
+      "deprecated: using --basic-auth-user/--basic-auth-pass as the client " +
+        "credentials; use --http-basic-auth-user/--http-basic-auth-pass for " +
+        "client modes.",
+    );
+  }
+
+  return {
+    location: { httpUrl, unixSocket: options.unixSocket, basicAuth },
+    warnings,
+  };
+}

--- a/src/cli/jsonMode.ts
+++ b/src/cli/jsonMode.ts
@@ -179,7 +179,12 @@ export async function handleJsonCommand(
     case "load_scenario_template": {
       const templateId = requireString(params, "templateId");
       const connectorId = requirePositiveInt(params, "connector");
-      const scenarioId = service.loadScenarioTemplate(templateId, connectorId);
+      const evSettings = params.evSettings as Partial<EVSettings> | undefined;
+      const scenarioId = service.loadScenarioTemplate(
+        templateId,
+        connectorId,
+        evSettings,
+      );
       return { scenarioId };
     }
 
@@ -266,7 +271,12 @@ export async function handleJsonCommand(
     case "run_scenario_template": {
       const connectorId = requirePositiveInt(params, "connector");
       const templateId = requireString(params, "templateId");
-      const scenarioId = service.loadScenarioTemplate(templateId, connectorId);
+      const evSettings = params.evSettings as Partial<EVSettings> | undefined;
+      const scenarioId = service.loadScenarioTemplate(
+        templateId,
+        connectorId,
+        evSettings,
+      );
       service.runScenario(connectorId, scenarioId);
       return { scenarioId };
     }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -5,6 +5,7 @@ import type { CLIOptions, ChargePointInitOptions } from "./types";
 import { CLIChargePointService } from "./service";
 import { startRepl } from "./repl";
 import { startJsonMode } from "./jsonMode";
+import { resolveClientLocation } from "./clientLocation";
 import { BunSqliteDatabase } from "../cp/domain/persistence/BunSqliteDatabase";
 import type { Database } from "../cp/domain/persistence/Database";
 import { setGlobalLogFormat } from "../cp/shared/Logger";
@@ -613,11 +614,23 @@ async function main(): Promise<void> {
   // chatter via serverLog.
   setGlobalLogFormat(options.logFormat);
 
-  const clientLoc = {
+  // Client modes (--send/--stop/--events) target a running daemon. Resolve the
+  // canonical --http-url / --http-basic-auth-* flags, but keep honoring the
+  // server-side --http-host/--http-port and outgoing-WS --basic-auth-* flags
+  // with a deprecation warning for backward compatibility.
+  const isClientMode = options.stop || options.send !== null || options.events;
+  let clientLoc = {
     httpUrl: options.httpUrl,
     unixSocket: options.unixSocket,
     basicAuth: options.httpBasicAuth,
   };
+  if (isClientMode) {
+    const resolved = resolveClientLocation(options);
+    clientLoc = resolved.location;
+    for (const w of resolved.warnings) {
+      process.stderr.write(`Warning: ${w}\n`);
+    }
+  }
 
   if (options.stop) {
     await stopDaemon(clientLoc);

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -28,6 +28,7 @@ import {
   type ScenarioPositionSnapshot,
 } from "../cp/domain/persistence/ConnectorRuntimeRepository";
 import type { EVSettings } from "../cp/domain/connector/EVSettings";
+import { getDefaultEVSettings } from "../cp/domain/connector/EVSettings";
 import type { AutoMeterValueConfig } from "../cp/domain/connector/MeterValueCurve";
 import type { ActiveChargingProfile } from "../cp/domain/connector/Connector";
 import type {
@@ -545,7 +546,11 @@ export class CLIChargePointService {
     }
   }
 
-  loadScenarioTemplate(templateId: string, connectorId: number): string {
+  loadScenarioTemplate(
+    templateId: string,
+    connectorId: number,
+    evSettingsOverride?: Partial<EVSettings>,
+  ): string {
     const template = getTemplateById(templateId);
     if (!template) {
       throw new Error(`Unknown template: ${templateId}`);
@@ -554,6 +559,15 @@ export class CLIChargePointService {
       this._chargePoint.id,
       connectorId,
     );
+    // Let callers pin e.g. maxChargingPowerKw without authoring a custom
+    // scenario; otherwise the template's own evSettings clobber a prior
+    // set_ev_settings when the scenario starts.
+    if (evSettingsOverride) {
+      definition.evSettings = {
+        ...(definition.evSettings ?? getDefaultEVSettings()),
+        ...evSettingsOverride,
+      };
+    }
     return this.loadScenario(connectorId, definition);
   }
 


### PR DESCRIPTION
Two ergonomics fixes that bit while driving the simulator for charging tests.

## 1. Client-mode target/credentials are less surprising (backward compatible)
`--send` / `--stop` / `--events` only accepted `--http-url` for the target and `--http-basic-auth-*` for credentials. The intuitive `--http-host`/`--http-port` (the *server* listen flags) and `--basic-auth-*` (the *outgoing-WS* creds) were silently ignored, so the client fell back to the default unix socket and failed with an opaque error (`Was there a typo in the url or port?`).

`resolveClientLocation()` now, **only in client modes**:
- derives the TCP target from `--http-host`/`--http-port` when `--http-url`/`--unix-socket` are absent, and
- uses `--basic-auth-*` as the client credentials when `--http-basic-auth-*` are absent,

each with a **`deprecated:` warning** nudging to the canonical flag (kept for backward compatibility, as requested). The unix-socket connection error now also hints at `--http-url`.

## 2. Per-connector EV override on templates
`run_scenario_template` / `load_scenario_template` accept an optional **`evSettings`** object merged into the template before it runs:

```json
{"command":"run_scenario_template","params":{"connector":1,"templateId":"essential-cp-behavior","evSettings":{"maxChargingPowerKw":3}}}
```

This lets you pin a connector's charging power (→ `Power.Active.Import` → MaxPAI → low-power eligibility) **without authoring a whole custom scenario**. Previously the template's own `evSettings` (e.g. essential-cp-behavior = 150 kW) clobbered a prior `set_ev_settings`, so the only way to test a 3 kW low-power charge was to hand-build a scenario.

## Tests
- `clientLocation.test.ts` (6) — derivation, defaults, precedence, deprecation warnings, unix-socket suppression.
- `jsonMode.template.test.ts` (3) — `evSettings` forwarded to `loadScenarioTemplate` for both commands, omitted when absent.

`tsc --noEmit` clean; full suite **114/114** green.