### PR TITLE
test(scenario): single all-cases example scenario + cross-version e2e

### DIFF
--- a/docs/examples/scenarios/all-cases.json
+++ b/docs/examples/scenarios/all-cases.json
@@ -1,0 +1,317 @@
+{
+  "id": "all-cases",
+  "name": "All node types (OCPP 1.6 / 2.0.1 / 2.1)",
+  "description": "A single coverage reference that exercises EVERY scenario node type in one flow. The scenario engine is version-agnostic: run this same file under --ocpp-version OCPP-1.6J, OCPP-2.0.1, or OCPP-2.1 and each node emits the wire message appropriate to that version (2.1 output is identical to 2.0.1). It is an INTEGRATION scenario — three nodes block until a cooperating CSMS acts: reservationTrigger (CSMS ReserveNow), remoteStartTrigger (CSMS RemoteStartTransaction on 1.6 / RequestStartTransaction on 2.x), and remoteStopTrigger (CSMS RemoteStopTransaction on 1.6 / RequestStopTransaction on 2.x). Apply with `--scenario-template-file docs/examples/scenarios/all-cases.json --scenario-connector all`. Per-version notes are on each node. This is a node-type catalogue, not a realistic single session.",
+  "targetType": "connector",
+  "targetId": 1,
+  "evSettings": {
+    "modelName": "Reference EV",
+    "batteryCapacityKwh": 60,
+    "maxChargingPowerKw": 50,
+    "initialSoc": 20,
+    "targetSoc": 80
+  },
+  "nodes": [
+    {
+      "id": "start",
+      "type": "start",
+      "position": { "x": 400, "y": 0 },
+      "data": {
+        "label": "Start on connect",
+        "description": "Fires once the CP is connected and BootNotification has been Accepted (ChargePoint status Available). triggerOn:\"status\" + targetStatus is the alternative.",
+        "triggerOn": "connect"
+      }
+    },
+    {
+      "id": "boot-delay",
+      "type": "delay",
+      "position": { "x": 400, "y": 90 },
+      "data": {
+        "label": "Delay 2s (settle after boot)",
+        "description": "Pure timer. Gives the CSMS time to Accept BootNotification before we exercise the connector.",
+        "delaySeconds": 2
+      }
+    },
+    {
+      "id": "config-set",
+      "type": "configSet",
+      "position": { "x": 400, "y": 180 },
+      "data": {
+        "label": "configSet MeterValuesSampledData",
+        "description": "§5.3 ChangeConfiguration applied LOCALLY (no CSMS round-trip). Use 1.6 key names on every version — the 2.x device model maps SampledDataCtrlr/TxUpdatedMeasurands back to this key, so it also drives 2.x MeterValues content.",
+        "key": "MeterValuesSampledData",
+        "value": "Energy.Active.Import.Register"
+      }
+    },
+    {
+      "id": "config-set-interval",
+      "type": "configSet",
+      "position": { "x": 400, "y": 270 },
+      "data": {
+        "label": "configSet MeterValueSampleInterval=5",
+        "description": "Second local config change. Maps to SampledDataCtrlr/TxUpdatedInterval on 2.x.",
+        "key": "MeterValueSampleInterval",
+        "value": "5"
+      }
+    },
+    {
+      "id": "heartbeat",
+      "type": "notification",
+      "position": { "x": 400, "y": 360 },
+      "data": {
+        "label": "Heartbeat.req",
+        "description": "notification node. Only messageType Heartbeat and StatusNotification are handled; any other type is a no-op. Heartbeat works on all versions.",
+        "messageType": "Heartbeat",
+        "payload": {}
+      }
+    },
+    {
+      "id": "status-notif-available",
+      "type": "statusNotification",
+      "position": { "x": 400, "y": 450 },
+      "data": {
+        "label": "StatusNotification Available (errorCode NoError)",
+        "description": "§4.9 explicit StatusNotification.req. On 1.6 errorCode/info/vendorErrorCode reach the wire; on 2.x those fields are dropped (2.0.1 StatusNotification has no errorCode) — only the mapped connectorStatus is sent.",
+        "status": "Available",
+        "errorCode": "NoError",
+        "info": "Connector ready",
+        "connectorId": 1
+      }
+    },
+    {
+      "id": "reserve-now",
+      "type": "reserveNow",
+      "position": { "x": 400, "y": 540 },
+      "data": {
+        "label": "reserveNow (CP-side, id 101)",
+        "description": "CP-initiated reservation via reservationManager. On Accepted the connector goes Reserved (StatusNotification Reserved on all versions; Reserved maps 1:1 on 2.x).",
+        "expiryMinutes": 30,
+        "idTag": "RESV-TAG",
+        "reservationId": 101
+      }
+    },
+    {
+      "id": "await-reserved",
+      "type": "statusTrigger",
+      "position": { "x": 400, "y": 630 },
+      "data": {
+        "label": "Wait for status Reserved",
+        "description": "statusTrigger waits for the connector to reach targetStatus. reserveNow above set Reserved synchronously, so this resolves immediately.",
+        "targetStatus": "Reserved",
+        "timeout": 10
+      }
+    },
+    {
+      "id": "cancel-reservation",
+      "type": "cancelReservation",
+      "position": { "x": 400, "y": 720 },
+      "data": {
+        "label": "cancelReservation (id 101)",
+        "description": "Cancels reservation 101 and resets the connector to Available.",
+        "reservationId": 101
+      }
+    },
+    {
+      "id": "await-csms-reservation",
+      "type": "reservationTrigger",
+      "position": { "x": 400, "y": 810 },
+      "data": {
+        "label": "Wait for CSMS ReserveNow (BLOCKING)",
+        "description": "Blocks until the CSMS sends ReserveNow for this connector (reservationManager records it; connector goes Reserved). timeout 0 = wait forever. Version-independent.",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "clear-reserved",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 900 },
+      "data": {
+        "label": "statusChange Available (clear CSMS reservation)",
+        "description": "statusChange mutates connector status and emits a StatusNotification (1.6: raw status; 2.x: mapped). Used here to drop the CSMS-reserved connector back to Available before charging.",
+        "status": "Available"
+      }
+    },
+    {
+      "id": "await-remote-start",
+      "type": "remoteStartTrigger",
+      "position": { "x": 400, "y": 990 },
+      "data": {
+        "label": "Wait for RemoteStartTransaction (BLOCKING)",
+        "description": "Blocks until the CSMS sends a remote-start request — RemoteStartTransaction.req on 1.6 (§5.11), RequestStartTransaction on 2.x. The forwarded idTag + remoteStartId flow into the next transaction node and set triggerReason RemoteStart (2.x only; 1.6 has no triggerReason field).",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "start-tx",
+      "type": "transaction",
+      "position": { "x": 400, "y": 1080 },
+      "data": {
+        "label": "StartTransaction / TransactionEvent(Started)",
+        "description": "1.6 → StartTransaction.req; 2.x → TransactionEvent(eventType Started, triggerReason RemoteStart, transactionInfo.remoteStartId). The domain auto-transitions Available → Preparing → Charging.",
+        "action": "start",
+        "tagId": "RESV-TAG",
+        "batteryCapacityKwh": 60,
+        "initialSoc": 20
+      }
+    },
+    {
+      "id": "auto-meter",
+      "type": "meterValue",
+      "position": { "x": 400, "y": 1170 },
+      "data": {
+        "label": "MeterValues (auto-increment, stop at 1000 Wh)",
+        "description": "§5.9 periodic MeterValues.req (1.6) / MeterValues (2.x, measurands from MeterValuesSampledData). Auto-increments 500 Wh/s and stops at the EARLIEST of maxValue (1000 Wh delivered since tx start) or maxTime.",
+        "value": 0,
+        "sendMessage": true,
+        "autoIncrement": true,
+        "incrementInterval": 1,
+        "incrementAmount": 500,
+        "stopMode": "manual",
+        "maxValue": 1000,
+        "maxTime": 0
+      }
+    },
+    {
+      "id": "data-transfer",
+      "type": "dataTransfer",
+      "position": { "x": 400, "y": 1260 },
+      "data": {
+        "label": "DataTransfer.req (CP → CSMS)",
+        "description": "§4.3 vendor-specific DataTransfer. Implemented on all versions (1.6 DataTransfer.req; 2.x DataTransfer CALL — same wire shape).",
+        "vendorId": "com.example.vendor",
+        "messageId": "DiagnosticsPing",
+        "data": "{\"firmware\":\"1.0.0\"}"
+      }
+    },
+    {
+      "id": "suspend-ev",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 1350 },
+      "data": {
+        "label": "statusChange SuspendedEV",
+        "description": "Mid-charge suspend. On 2.x this also emits a TransactionEvent(Updated, triggerReason ChargingStateChanged) because a transaction is active; on 1.6 it is just a StatusNotification. Note: SuspendedEV maps to connectorStatus \"Occupied\" on 2.x.",
+        "status": "SuspendedEV"
+      }
+    },
+    {
+      "id": "resume-charging",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 1440 },
+      "data": {
+        "label": "statusChange Charging (resume)",
+        "description": "Resume. On 2.x emits another TransactionEvent(Updated, ChargingStateChanged). Charging maps to \"Occupied\" on 2.x.",
+        "status": "Charging"
+      }
+    },
+    {
+      "id": "arm-unlock",
+      "type": "unlockOutcome",
+      "position": { "x": 400, "y": 1530 },
+      "data": {
+        "label": "unlockOutcome NotSupported (pre-arm)",
+        "description": "§5.18 / §7.46 — pre-arms the response to the NEXT CSMS UnlockConnector.req. Emits nothing itself. On 1.6 returns NotSupported verbatim; on 2.x there is no NotSupported, so it is coerced to UnlockFailed.",
+        "outcome": "NotSupported"
+      }
+    },
+    {
+      "id": "fault",
+      "type": "statusNotification",
+      "position": { "x": 400, "y": 1620 },
+      "data": {
+        "label": "StatusNotification Faulted (GroundFailure)",
+        "description": "§4.9 fault injection with errorCode + vendorErrorCode. On 1.6 the full fault context reaches the wire; on 2.x only connectorStatus Faulted is sent (errorCode/vendorErrorCode dropped).",
+        "status": "Faulted",
+        "errorCode": "GroundFailure",
+        "info": "Simulated ground fault",
+        "vendorErrorCode": "GF-001",
+        "vendorId": "com.example.vendor"
+      }
+    },
+    {
+      "id": "fault-recover",
+      "type": "statusNotification",
+      "position": { "x": 400, "y": 1710 },
+      "data": {
+        "label": "StatusNotification Charging (recover)",
+        "description": "Clear the fault and return to Charging so the transaction can be stopped cleanly. statusNotification suppresses the 2.x ChargingStateChanged TransactionEvent (unlike statusChange).",
+        "status": "Charging",
+        "errorCode": "NoError",
+        "connectorId": 1
+      }
+    },
+    {
+      "id": "await-remote-stop",
+      "type": "remoteStopTrigger",
+      "position": { "x": 400, "y": 1800 },
+      "data": {
+        "label": "Wait for RemoteStopTransaction (BLOCKING)",
+        "description": "Counterpart of remoteStartTrigger. Blocks until the CSMS sends a remote-stop request — RemoteStopTransaction.req on 1.6, RequestStopTransaction on 2.x — for the active transaction; the scenario's next transaction-stop node performs the actual stop with reason Remote (triggerReason RemoteStop on 2.x).",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "stop-tx",
+      "type": "transaction",
+      "position": { "x": 400, "y": 1890 },
+      "data": {
+        "label": "StopTransaction / TransactionEvent(Ended)",
+        "description": "1.6 → StopTransaction.req (reason Remote); 2.x → TransactionEvent(eventType Ended, triggerReason RemoteStop, stoppedReason Remote). The domain transitions Charging → Finishing → Available.",
+        "action": "stop"
+      }
+    },
+    {
+      "id": "plug-out",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 1980 },
+      "data": {
+        "label": "connectorPlug plugout",
+        "description": "Models the cable being unplugged. NOTE: this node is a no-op in the daemon/CLI runtime (it emits no OCPP traffic and changes no state) — included for node-type completeness.",
+        "action": "plugout"
+      }
+    },
+    {
+      "id": "end",
+      "type": "end",
+      "position": { "x": 400, "y": 2070 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start", "target": "boot-delay" },
+    { "id": "e2", "source": "boot-delay", "target": "config-set" },
+    { "id": "e3", "source": "config-set", "target": "config-set-interval" },
+    { "id": "e4", "source": "config-set-interval", "target": "heartbeat" },
+    { "id": "e5", "source": "heartbeat", "target": "status-notif-available" },
+    { "id": "e6", "source": "status-notif-available", "target": "reserve-now" },
+    { "id": "e7", "source": "reserve-now", "target": "await-reserved" },
+    { "id": "e8", "source": "await-reserved", "target": "cancel-reservation" },
+    {
+      "id": "e9",
+      "source": "cancel-reservation",
+      "target": "await-csms-reservation"
+    },
+    {
+      "id": "e10",
+      "source": "await-csms-reservation",
+      "target": "clear-reserved"
+    },
+    { "id": "e11", "source": "clear-reserved", "target": "await-remote-start" },
+    { "id": "e12", "source": "await-remote-start", "target": "start-tx" },
+    { "id": "e13", "source": "start-tx", "target": "auto-meter" },
+    { "id": "e14", "source": "auto-meter", "target": "data-transfer" },
+    { "id": "e15", "source": "data-transfer", "target": "suspend-ev" },
+    { "id": "e16", "source": "suspend-ev", "target": "resume-charging" },
+    { "id": "e17", "source": "resume-charging", "target": "arm-unlock" },
+    { "id": "e18", "source": "arm-unlock", "target": "fault" },
+    { "id": "e19", "source": "fault", "target": "fault-recover" },
+    { "id": "e20", "source": "fault-recover", "target": "await-remote-stop" },
+    { "id": "e21", "source": "await-remote-stop", "target": "stop-tx" },
+    { "id": "e22", "source": "stop-tx", "target": "plug-out" },
+    { "id": "e23", "source": "plug-out", "target": "end" }
+  ],
+  "createdAt": "2026-06-29T00:00:00.000Z",
+  "updatedAt": "2026-06-29T00:00:00.000Z",
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true
+}

--- a/e2e/comprehensive.gocpp.e2e.ts
+++ b/e2e/comprehensive.gocpp.e2e.ts
@@ -1,0 +1,467 @@
+import { readFileSync } from "node:fs";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { ChargePoint } from "../src/cp/domain/charge-point/ChargePoint";
+import {
+  DefaultBootNotification,
+  OCPPStatus,
+} from "../src/cp/domain/types/OcppTypes";
+import type { ScenarioDefinition } from "../src/cp/application/scenario/ScenarioTypes";
+import {
+  startCsms,
+  stopAllCsms,
+  type CommandResponse,
+  type CsmsHandle,
+} from "./support/gocppCsms";
+import type { Frame } from "./support/frameLog";
+import { runScenario, waitUntil } from "./support/scenarioRunner";
+
+type OcppVersion = "OCPP-1.6J" | "OCPP-2.0.1" | "OCPP-2.1";
+
+interface VersionCase {
+  version: OcppVersion;
+  label: string;
+  cpPrefix: string;
+}
+
+const WAIT_TIMEOUT_MS = 12_000;
+const TEST_TIMEOUT_MS = 60_000;
+const SCENARIO_TIMEOUT_MS = 45_000;
+const REMOTE_TAG = "ALLCASES-REMOTE-TAG";
+const CSMS_RESERVATION_ID = 7777;
+const SCENARIO_FILE = `${import.meta.dir}/../docs/examples/scenarios/all-cases.json`;
+
+const VERSION_CASES: VersionCase[] = [
+  { version: "OCPP-1.6J", label: "1.6", cpPrefix: "cp16" },
+  { version: "OCPP-2.0.1", label: "2.0.1", cpPrefix: "cp201" },
+  { version: "OCPP-2.1", label: "2.1", cpPrefix: "cp21" },
+];
+
+const csmsByVersion = new Map<OcppVersion, CsmsHandle>();
+
+function loadScenario(): ScenarioDefinition {
+  // Parse fresh per run so sequential versions never share mutable state, and
+  // so this exercises the same JSON the daemon loads via
+  // --scenario-template-file.
+  return JSON.parse(readFileSync(SCENARIO_FILE, "utf-8")) as ScenarioDefinition;
+}
+
+beforeAll(async () => {
+  for (const { version } of VERSION_CASES) {
+    csmsByVersion.set(version, await startCsms(version));
+  }
+});
+
+afterAll(async () => {
+  await stopAllCsms();
+});
+
+describe("all-cases scenario covers every node type across versions", () => {
+  for (const versionCase of VERSION_CASES) {
+    test(
+      `all-cases.json runs to completion on OCPP ${versionCase.label}`,
+      async () => {
+        const csms = getCsms(versionCase.version);
+        const cpId = `${versionCase.cpPrefix}-all-cases`;
+        const cp = makeChargePoint(cpId, versionCase.version, csms);
+        let reserveDriven = false;
+        let startDriven = false;
+        let stopDriven = false;
+
+        try {
+          await connectBootReady(cp, cpId, csms, versionCase.version);
+          const sinceSeq = lastSeq(csms, cpId);
+
+          const result = await runScenario(cp, loadScenario(), {
+            timeoutMs: SCENARIO_TIMEOUT_MS,
+            // reservationTrigger has no park flag — drive the CSMS ReserveNow
+            // when the executor reaches that node.
+            onNodeExecute: async (_nodeId, nodeType) => {
+              if (nodeType !== "reservationTrigger") return;
+              reserveDriven = true;
+              assertCommandResult(
+                await sendReserveNow(csms, cpId, versionCase.version),
+              );
+            },
+            onParkStart: async () => {
+              startDriven = true;
+              const res = assertCommandResult(
+                await sendRemoteStart(csms, cpId, versionCase.version),
+              );
+              expect(res).toMatchObject({ status: "Accepted" });
+            },
+            onParkStop: async () => {
+              const transactionId =
+                versionCase.version === "OCPP-1.6J"
+                  ? await waitForNumericTransactionId(cp, 1)
+                  : transactionIdOf(
+                      await waitForTransactionEvent(
+                        csms,
+                        cpId,
+                        "Started",
+                        sinceSeq,
+                      ),
+                    );
+              stopDriven = true;
+              const res = assertCommandResult(
+                await sendRemoteStop(
+                  csms,
+                  cpId,
+                  versionCase.version,
+                  transactionId,
+                ),
+              );
+              expect(res).toMatchObject({ status: "Accepted" });
+            },
+          });
+
+          // Completion proves every node on the linear path executed through to
+          // the `end` node without erroring.
+          expect(result.errored).toBe(false);
+          expect(result.completed).toBe(true);
+          expect(reserveDriven).toBe(true);
+          expect(startDriven).toBe(true);
+          expect(stopDriven).toBe(true);
+
+          // Common to all versions.
+          await waitForAction(csms, cpId, "Heartbeat", sinceSeq);
+          const dataTransfer = await waitForPayload(
+            csms,
+            cpId,
+            "DataTransfer",
+            (p) => p.vendorId === "com.example.vendor",
+            sinceSeq,
+          );
+          expect(payloadOf(dataTransfer)).toMatchObject({
+            vendorId: "com.example.vendor",
+            messageId: "DiagnosticsPing",
+          });
+
+          if (versionCase.version === "OCPP-1.6J") {
+            await assert16(csms, cpId, sinceSeq);
+          } else {
+            await assert2x(csms, cpId, sinceSeq);
+          }
+        } finally {
+          await cp.disconnect();
+        }
+      },
+      TEST_TIMEOUT_MS,
+    );
+  }
+});
+
+async function assert16(
+  csms: CsmsHandle,
+  cpId: string,
+  sinceSeq: number,
+): Promise<void> {
+  const start = await waitForPayload(
+    csms,
+    cpId,
+    "StartTransaction",
+    (p) => p.idTag === REMOTE_TAG,
+    sinceSeq,
+  );
+  await waitForPayload(
+    csms,
+    cpId,
+    "MeterValues",
+    (p) => typeof p.transactionId === "number",
+    start.seq,
+  );
+  await waitForPayload(
+    csms,
+    cpId,
+    "StopTransaction",
+    (p) => p.reason === "Remote",
+    start.seq,
+  );
+  // 1.6 StatusNotification carries the full fault context on the wire.
+  const fault = await waitForPayload(
+    csms,
+    cpId,
+    "StatusNotification",
+    (p) => p.status === "Faulted",
+    sinceSeq,
+  );
+  expect(payloadOf(fault)).toMatchObject({
+    status: "Faulted",
+    errorCode: "GroundFailure",
+    vendorErrorCode: "GF-001",
+  });
+}
+
+async function assert2x(
+  csms: CsmsHandle,
+  cpId: string,
+  sinceSeq: number,
+): Promise<void> {
+  const started = await waitForTransactionEvent(
+    csms,
+    cpId,
+    "Started",
+    sinceSeq,
+  );
+  expect(payloadOf(started)).toMatchObject({
+    eventType: "Started",
+    triggerReason: "RemoteStart",
+    idToken: { idToken: REMOTE_TAG },
+  });
+  const transactionId = transactionIdOf(started);
+  await waitForPayload(
+    csms,
+    cpId,
+    "MeterValues",
+    (p) => p.evseId === 1,
+    started.seq,
+  );
+  await waitForPayload(
+    csms,
+    cpId,
+    "TransactionEvent",
+    (p) =>
+      p.eventType === "Ended" &&
+      isRecord(p.transactionInfo) &&
+      p.transactionInfo.transactionId === transactionId,
+    started.seq,
+  );
+  // 2.x StatusNotification has no errorCode field — the fault context is
+  // dropped; only the mapped connectorStatus is sent.
+  const fault = await waitForPayload(
+    csms,
+    cpId,
+    "StatusNotification",
+    (p) => p.connectorStatus === "Faulted",
+    sinceSeq,
+  );
+  const faultPayload = payloadOf(fault);
+  expect(faultPayload).toMatchObject({ connectorStatus: "Faulted", evseId: 1 });
+  expect(faultPayload.errorCode).toBeUndefined();
+  expect(faultPayload.vendorErrorCode).toBeUndefined();
+}
+
+function makeChargePoint(
+  cpId: string,
+  version: OcppVersion,
+  csms: CsmsHandle,
+): ChargePoint {
+  const cp = new ChargePoint(
+    cpId,
+    DefaultBootNotification,
+    1,
+    csms.ocppUrl,
+    null,
+    null,
+    null,
+    {},
+    [],
+    version,
+  );
+  cp.logger.setEnabledTypes();
+  cp.events.on("error", () => undefined);
+  cp.connectors.forEach((connector) => {
+    connector.setOnMeterValueSend((connectorId) => {
+      cp.sendMeterValue(connectorId);
+    });
+  });
+  return cp;
+}
+
+async function connectBootReady(
+  cp: ChargePoint,
+  cpId: string,
+  csms: CsmsHandle,
+  version: OcppVersion,
+): Promise<void> {
+  await cp.connect();
+  const boot = await csms.frames.waitForCall("BootNotification", {
+    cpId,
+    timeoutMs: WAIT_TIMEOUT_MS,
+  });
+  if (version !== "OCPP-1.6J") {
+    await waitForPayload(
+      csms,
+      cpId,
+      "StatusNotification",
+      (p) => p.connectorStatus === "Available",
+      boot.seq,
+    );
+  }
+  await waitUntil(() => cp.getConnector(1)?.status === OCPPStatus.Available);
+}
+
+function getCsms(version: OcppVersion): CsmsHandle {
+  const csms = csmsByVersion.get(version);
+  if (!csms) throw new Error(`CSMS not started for ${version}`);
+  return csms;
+}
+
+function lastSeq(csms: CsmsHandle, cpId: string): number {
+  const frames = csms.frames.byCp(cpId);
+  return frames.length === 0 ? 0 : frames[frames.length - 1]!.seq;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function payloadOf(frame: Frame): Record<string, unknown> {
+  if (!isRecord(frame.payload)) {
+    throw new Error(`Expected ${frame.action} payload to be an object`);
+  }
+  return frame.payload;
+}
+
+async function waitForPayload(
+  csms: CsmsHandle,
+  cpId: string,
+  action: string,
+  pred: (payload: Record<string, unknown>) => boolean,
+  sinceSeq: number,
+): Promise<Frame> {
+  return csms.frames.waitForFrame(
+    (frame) =>
+      frame.cpId === cpId &&
+      frame.action === action &&
+      frame.seq > sinceSeq &&
+      isRecord(frame.payload) &&
+      pred(frame.payload),
+    { timeoutMs: WAIT_TIMEOUT_MS },
+  );
+}
+
+async function waitForAction(
+  csms: CsmsHandle,
+  cpId: string,
+  action: string,
+  sinceSeq: number,
+): Promise<Frame> {
+  return csms.frames.waitForFrame(
+    (frame) =>
+      frame.cpId === cpId && frame.action === action && frame.seq > sinceSeq,
+    { timeoutMs: WAIT_TIMEOUT_MS },
+  );
+}
+
+async function waitForTransactionEvent(
+  csms: CsmsHandle,
+  cpId: string,
+  eventType: string,
+  sinceSeq: number,
+): Promise<Frame> {
+  return waitForPayload(
+    csms,
+    cpId,
+    "TransactionEvent",
+    (p) => p.eventType === eventType,
+    sinceSeq,
+  );
+}
+
+function transactionIdOf(frame: Frame): string {
+  const payload = payloadOf(frame);
+  if (!isRecord(payload.transactionInfo)) {
+    throw new Error("Expected transactionInfo to be an object");
+  }
+  const transactionId = payload.transactionInfo.transactionId;
+  if (typeof transactionId !== "string" || transactionId.length === 0) {
+    throw new Error("Expected transactionInfo.transactionId to be a string");
+  }
+  return transactionId;
+}
+
+async function waitForNumericTransactionId(
+  cp: ChargePoint,
+  connectorId: number,
+): Promise<number> {
+  let transactionId = 0;
+  await waitUntil(() => {
+    const id = cp.getConnector(connectorId)?.transaction?.id;
+    if (typeof id === "number" && id > 0) {
+      transactionId = id;
+      return true;
+    }
+    return false;
+  });
+  return transactionId;
+}
+
+function assertCommandResult(
+  response: CommandResponse,
+): Record<string, unknown> {
+  if (!response.ok) {
+    throw new Error(response.error ?? "CSMS command failed");
+  }
+  const result = response.result;
+  if (!isRecord(result)) {
+    throw new Error("Expected CSMS command result to be an object");
+  }
+  return result;
+}
+
+function sendReserveNow(
+  csms: CsmsHandle,
+  cpId: string,
+  version: OcppVersion,
+): Promise<CommandResponse> {
+  const expiry = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+  if (version === "OCPP-1.6J") {
+    return csms.command({
+      cpId,
+      action: "ReserveNow",
+      connectorId: 1,
+      expiryDate: expiry,
+      idTag: REMOTE_TAG,
+      reservationId: CSMS_RESERVATION_ID,
+    });
+  }
+  return csms.command({
+    cpId,
+    action: "ReserveNow",
+    evseId: 1,
+    expiryDateTime: expiry,
+    id: CSMS_RESERVATION_ID,
+    idToken: { idToken: REMOTE_TAG, type: "ISO14443" },
+  });
+}
+
+function sendRemoteStart(
+  csms: CsmsHandle,
+  cpId: string,
+  version: OcppVersion,
+): Promise<CommandResponse> {
+  if (version === "OCPP-1.6J") {
+    return csms.command({
+      cpId,
+      action: "RemoteStartTransaction",
+      idTag: REMOTE_TAG,
+      connectorId: 1,
+    });
+  }
+  return csms.command({
+    cpId,
+    action: "RequestStartTransaction",
+    idToken: { idToken: REMOTE_TAG, type: "ISO14443" },
+    evseId: 1,
+  });
+}
+
+function sendRemoteStop(
+  csms: CsmsHandle,
+  cpId: string,
+  version: OcppVersion,
+  transactionId: number | string,
+): Promise<CommandResponse> {
+  if (version === "OCPP-1.6J") {
+    return csms.command({
+      cpId,
+      action: "RemoteStopTransaction",
+      transactionId,
+    });
+  }
+  return csms.command({
+    cpId,
+    action: "RequestStopTransaction",
+    transactionId,
+  });
+}

--- a/e2e/csms/command.go
+++ b/e2e/csms/command.go
@@ -283,6 +283,17 @@ func (h *controlHandler) dispatch21(ctx context.Context, conn *csms.Conn, action
 			Activate:      cmd.Activate,
 			TransactionID: cmd.TransactionID,
 		})
+	case "ReserveNow":
+		cmd, err := decodeCommand[reserveNow21Command](body)
+		if err != nil {
+			return nil, err
+		}
+		return client.ReserveNow(ctx, v21msg.ReserveNowRequest{
+			EVSEID:         cmd.EVSEID,
+			ExpiryDateTime: cmd.ExpiryDateTime,
+			ID:             cmd.ID,
+			IDToken:        cmd.IDToken,
+		})
 	default:
 		return nil, fmt.Errorf("unsupported 2.1 action %q", action)
 	}
@@ -407,6 +418,14 @@ type reserveNow201Command struct {
 	ExpiryDateTime time.Time           `json:"expiryDateTime"`
 	ID             int32               `json:"id"`
 	IDToken        v201msg.IdTokenType `json:"idToken"`
+}
+
+type reserveNow21Command struct {
+	commandEnvelope
+	EVSEID         *int32             `json:"evseId,omitempty"`
+	ExpiryDateTime time.Time          `json:"expiryDateTime"`
+	ID             int32              `json:"id"`
+	IDToken        v21msg.IdTokenType `json:"idToken"`
 }
 
 type usePriorityChargingCommand struct {

--- a/e2e/support/scenarioRunner.ts
+++ b/e2e/support/scenarioRunner.ts
@@ -14,6 +14,10 @@ const POLL_MS = 25;
 interface RunScenarioOptions {
   onParkStart?: () => Promise<void> | void;
   onParkStop?: () => Promise<void> | void;
+  /** Fired (once per node) when the executor begins a node. Lets a test
+   *  drive a CSMS-initiated action that a wait-node is parked on but which
+   *  has no dedicated park flag (e.g. reservationTrigger → CSMS ReserveNow). */
+  onNodeExecute?: (nodeId: string, nodeType: string) => Promise<void> | void;
   timeoutMs?: number;
 }
 
@@ -29,6 +33,7 @@ export async function runScenario(
   {
     onParkStart,
     onParkStop,
+    onNodeExecute,
     timeoutMs = DEFAULT_TIMEOUT_MS,
   }: RunScenarioOptions = {},
 ): Promise<ScenarioRunResult> {
@@ -73,6 +78,19 @@ export async function runScenario(
     errored = true;
     errorInfo = info;
   });
+
+  if (onNodeExecute) {
+    const seen = new Set<string>();
+    events.on("node.execute", (data) => {
+      const payload = data as { nodeId?: string; nodeType?: string };
+      const nodeId = payload.nodeId ?? "";
+      if (seen.has(nodeId)) return;
+      seen.add(nodeId);
+      void Promise.resolve(
+        onNodeExecute(nodeId, String(payload.nodeType ?? "")),
+      ).catch(() => undefined);
+    });
+  }
 
   const executor = new ScenarioExecutor(def, callbacks, events);
   let keepWatching = true;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run && bun test bun.test",
     "test:vitest": "vitest run",
     "test:bun": "bun test bun.test",
-    "test:e2e": "bun run e2e/support/buildCsms.ts && bun test --timeout 60000 ./e2e/ocpp16.gocpp.e2e.ts ./e2e/ocpp201.gocpp.e2e.ts ./e2e/ocpp21.gocpp.e2e.ts ./e2e/scenario.gocpp.e2e.ts",
+    "test:e2e": "bun run e2e/support/buildCsms.ts && bun test --timeout 60000 ./e2e/ocpp16.gocpp.e2e.ts ./e2e/ocpp201.gocpp.e2e.ts ./e2e/ocpp21.gocpp.e2e.ts ./e2e/scenario.gocpp.e2e.ts ./e2e/comprehensive.gocpp.e2e.ts",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",


### PR DESCRIPTION
## What

A single example scenario — `docs/examples/scenarios/all-cases.json` — that exercises **every** scenario node type in one linear graph, and runs across **OCPP 1.6 / 2.0.1 / 2.1**.

The scenario engine is version-agnostic: the same file runs under `--ocpp-version OCPP-1.6J | OCPP-2.0.1 | OCPP-2.1` and each node emits the wire message appropriate to that version (2.1 outbound is identical to 2.0.1). Apply it with:

```
--scenario-template-file docs/examples/scenarios/all-cases.json --scenario-connector all
```

### Node-type coverage (all 18)
`start`, `delay`, `configSet`, `notification` (Heartbeat), `statusNotification` (Available / Faulted+GroundFailure / recover), `reserveNow`, `statusTrigger`, `cancelReservation`, `reservationTrigger`, `statusChange`, `remoteStartTrigger`, `transaction` (start/stop), `meterValue` (auto-increment), `dataTransfer`, `unlockOutcome`, `connectorPlug`, `end`.

Each node's `description` documents its per-version behavior, e.g.:
- `statusNotification` errorCode/vendorErrorCode reach the wire on **1.6** but are dropped on **2.x** (2.0.1 StatusNotification has no errorCode field);
- non-Available/Reserved/Unavailable/Faulted statuses map to `"Occupied"` on 2.x;
- `unlockOutcome: "NotSupported"` coerces to `UnlockFailed` on 2.x;
- transaction `triggerReason`/`remoteStartId` are 2.x-only;
- `configSet` uses 1.6 key names on every version;
- `connectorPlug` is a daemon no-op (included for completeness).

It is an **integration** scenario — three nodes block until a cooperating CSMS acts (`reservationTrigger` → ReserveNow; `remoteStartTrigger` → RemoteStart/RequestStart; `remoteStopTrigger` → RemoteStop/RequestStop). A node-type catalogue, not a realistic single session.

## Validation

`e2e/comprehensive.gocpp.e2e.ts` runs the file against the gocpp CSMS for all three versions and drives the three CSMS-initiated waits at their park points. It asserts:
- the scenario **runs to completion** (proving every node on the path executed), and
- the version divergence: **1.6** StatusNotification carries the Faulted `errorCode` (`GroundFailure`) while **2.x** drops it; **2.x** `TransactionEvent` carries `triggerReason: RemoteStart`.

The `reservationTrigger` has no park flag, so a small generic `onNodeExecute` hook was added to the scenario runner to drive the CSMS ReserveNow when the executor reaches that node. A `ReserveNow` case was also added to the **2.1** CSMS dispatch in `e2e/csms/command.go` (it was only wired for 1.6/2.0.1).

`bun run test:e2e` → **44 pass** (was 41); `tsc -b --noEmit` 545 (unchanged); lint clean; `go vet` clean.

## Notes

e2e requires Go 1.26 + a sibling `../gocpp` checkout (documented in `e2e/README.md`; CI does not yet provision these).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpJ7a7PhocAZUVnxvfyVuH
