### PR TITLE
fix: web-console light-mode UI + scenario "Charge until battery full" (#92, #93, #95)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import Navbar from "./components/Navbar.tsx";
+import Footer from "./components/Footer.tsx";
 import Settings from "./components/Settings.tsx";
 import TopPage from "./components/TopPage.tsx";
 import { DarkModeProvider } from "./contexts/DarkModeContext.tsx";
@@ -10,14 +11,15 @@ import V1App from "./v1/V1App.tsx";
 const V2App: React.FC = () => {
   return (
     <DarkModeProvider>
-      <div className="min-h-screen bg-gray-100 dark:bg-gray-900 transition-colors">
+      <div className="min-h-screen flex flex-col bg-gray-100 dark:bg-gray-900 transition-colors">
         <Navbar />
-        <div className="p-4">
+        <div className="p-4 flex-1">
           <Routes>
             <Route path="/" element={<TopPage />} />
             <Route path="/settings" element={<Settings />} />
           </Routes>
         </div>
+        <Footer />
       </div>
     </DarkModeProvider>
   );

--- a/src/components/ChargePoint.tsx
+++ b/src/components/ChargePoint.tsx
@@ -520,17 +520,32 @@ const SettingsView: React.FC<SettingsViewProps> = ({
     <div className="panel p-3">
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-4 text-sm flex-wrap">
+          {/* Labels use an explicit AA-contrast muted gray (≥4.5:1) rather
+              than the lighter `text-muted`, and values stay dark, so the
+              header stays readable (issue #92). */}
           <div className="flex items-center gap-2">
-            <span className="text-muted text-xs">ID:</span>
-            <span className="font-semibold text-primary">{cpId}</span>
+            <span className="text-xs text-gray-600 dark:text-gray-300">
+              ID:
+            </span>
+            <span className="font-semibold text-gray-900 dark:text-white">
+              {cpId}
+            </span>
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-muted text-xs">Connectors:</span>
-            <span className="text-secondary">{connectorCount}</span>
+            <span className="text-xs text-gray-600 dark:text-gray-300">
+              Connectors:
+            </span>
+            <span className="text-gray-900 dark:text-gray-100">
+              {connectorCount}
+            </span>
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-muted text-xs">Tag:</span>
-            <span className="font-mono text-secondary text-xs">{TagID}</span>
+            <span className="text-xs text-gray-600 dark:text-gray-300">
+              Tag:
+            </span>
+            <span className="font-mono text-xs text-gray-900 dark:text-gray-100">
+              {TagID}
+            </span>
           </div>
         </div>
         <button

--- a/src/components/Connector.tsx
+++ b/src/components/Connector.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, memo } from "react";
+import { Trash2 } from "lucide-react";
 import type { ChargePoint } from "../cp/domain/charge-point/ChargePoint";
 import * as ocpp from "../cp/domain/types/OcppTypes";
 import { OCPPAvailability } from "../cp/domain/types/OcppTypes";
@@ -423,10 +424,11 @@ const Connector: React.FC<ConnectorProps> = ({
                 e.stopPropagation();
                 handleRemoveConnector();
               }}
-              className="text-xs px-2 py-1 btn-danger rounded"
+              className="inline-flex items-center justify-center text-xs px-2 py-1 btn-danger rounded"
               title="Remove Connector"
+              aria-label="Remove Connector"
             >
-              🗑️
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,42 @@
+// components/Footer.tsx
+import React from "react";
+import { Github } from "lucide-react";
+
+const REPO_URL = "https://github.com/shiv3/ocpp-cp-simulator";
+
+/**
+ * Discreet footer pinned to the bottom of the app shell. Self-hosted /
+ * web-console users rarely land on the GitHub page, so this gives the
+ * project a cheap, always-visible discovery link (issue #93).
+ *
+ * The version is injected at build time (`__APP_VERSION__`, see vite.config).
+ * It's hidden for the unstamped dev default ("0.0.0") so we never show a
+ * meaningless "v0.0.0".
+ */
+const Footer: React.FC = () => {
+  const version =
+    typeof __APP_VERSION__ !== "undefined" && __APP_VERSION__ !== "0.0.0"
+      ? `v${__APP_VERSION__}`
+      : null;
+
+  return (
+    <footer className="mt-auto border-t border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-800/60 px-4 py-2">
+      <div className="flex items-center justify-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+        <span className="font-medium">ocpp-cp-simulator</span>
+        {version ? <span>{version}</span> : null}
+        <span aria-hidden="true">·</span>
+        <a
+          href={REPO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:underline"
+        >
+          <Github className="h-3.5 w-3.5" />
+          GitHub
+        </a>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/components/scenario/ScenarioEditor.tsx
+++ b/src/components/scenario/ScenarioEditor.tsx
@@ -42,6 +42,10 @@ import {
 import { OCPPStatus } from "../../cp/domain/types/OcppTypes";
 import { AutoMeterValueConfig } from "../../cp/domain/connector/MeterValueCurve";
 import {
+  meterNodeToCurveConfig,
+  applyCurveConfigToMeterNode,
+} from "./meterValueNodeConfig";
+import {
   type EVSettings,
   EV_PRESETS,
 } from "../../cp/domain/connector/EVSettings";
@@ -162,6 +166,35 @@ const nodeTypes: NodeTypes = {
   ),
   [ScenarioNodeType.END]: (props) => <StartEndNode {...props} nodeType="end" />,
 };
+
+// MiniMap fill per node type. Without an explicit nodeColor the minimap falls
+// back to React Flow's default #e2e2e2, which is invisible against the
+// light-mode white minimap background (the nodes looked unrendered). Colors
+// roughly mirror each node's accent on the canvas.
+const MINIMAP_NODE_COLORS: Record<string, string> = {
+  [ScenarioNodeType.START]: "#22c55e",
+  [ScenarioNodeType.END]: "#ef4444",
+  [ScenarioNodeType.STATUS_CHANGE]: "#3b82f6",
+  [ScenarioNodeType.STATUS_NOTIFICATION]: "#3b82f6",
+  [ScenarioNodeType.TRANSACTION]: "#10b981",
+  [ScenarioNodeType.METER_VALUE]: "#eab308",
+  [ScenarioNodeType.DELAY]: "#64748b",
+  [ScenarioNodeType.NOTIFICATION]: "#0ea5e9",
+  [ScenarioNodeType.CONNECTOR_PLUG]: "#14b8a6",
+  [ScenarioNodeType.REMOTE_START_TRIGGER]: "#6366f1",
+  [ScenarioNodeType.REMOTE_STOP_TRIGGER]: "#a855f7",
+  [ScenarioNodeType.STATUS_TRIGGER]: "#8b5cf6",
+  [ScenarioNodeType.RESERVE_NOW]: "#f97316",
+  [ScenarioNodeType.CANCEL_RESERVATION]: "#f43f5e",
+  [ScenarioNodeType.RESERVATION_TRIGGER]: "#f59e0b",
+  [ScenarioNodeType.UNLOCK_OUTCOME]: "#06b6d4",
+  [ScenarioNodeType.CONFIG_SET]: "#6b7280",
+  [ScenarioNodeType.DATA_TRANSFER]: "#a8a29e",
+};
+
+// slate-500 fallback — stays visible on both the white (light) and
+// #1f2937 (dark) minimap backgrounds.
+const MINIMAP_NODE_FALLBACK = "#64748b";
 
 const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
   cpId,
@@ -1851,14 +1884,10 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
     }
   };
 
-  // Handle curve modal save
+  // Handle curve modal save. Maps the modal's "Charge until battery full"
+  // checkbox onto the node's stopMode so the executor honors it (issue #95).
   const handleCurveModalSave = (config: AutoMeterValueConfig) => {
-    setFormData({
-      ...formData,
-      curvePoints: config.curvePoints,
-      incrementInterval: config.intervalSeconds,
-      autoCalculateInterval: config.autoCalculateInterval,
-    });
+    setFormData(applyCurveConfigToMeterNode(formData, config));
     setIsCurveModalOpen(false);
   };
 
@@ -1876,15 +1905,7 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
           <MeterValueCurveModal
             isOpen={isCurveModalOpen}
             onClose={() => setIsCurveModalOpen(false)}
-            initialConfig={{
-              enabled: true,
-              intervalSeconds: formData.incrementInterval || 10,
-              curvePoints: formData.curvePoints || [
-                { time: 0, value: 0 },
-                { time: 30, value: 50 },
-              ],
-              autoCalculateInterval: formData.autoCalculateInterval || false,
-            }}
+            initialConfig={meterNodeToCurveConfig(formData)}
             onSave={handleCurveModalSave}
           />
         </Suspense>
@@ -2417,6 +2438,11 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
               <MiniMap
                 pannable
                 zoomable
+                nodeColor={(node) =>
+                  MINIMAP_NODE_COLORS[node.type ?? ""] ?? MINIMAP_NODE_FALLBACK
+                }
+                nodeStrokeColor={isDark ? "#0f172a" : "#cbd5e1"}
+                nodeStrokeWidth={2}
                 maskColor={
                   isDark ? "rgba(15, 23, 42, 0.6)" : "rgba(240, 240, 240, 0.6)"
                 }

--- a/src/components/scenario/__tests__/meterValueNodeConfig.test.ts
+++ b/src/components/scenario/__tests__/meterValueNodeConfig.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  meterNodeToCurveConfig,
+  applyCurveConfigToMeterNode,
+} from "../meterValueNodeConfig";
+import { AutoMeterValueConfig } from "../../../cp/domain/connector/MeterValueCurve";
+
+describe("meterValueNodeConfig mapping (scenario MeterValue node ↔ curve modal)", () => {
+  describe("meterNodeToCurveConfig", () => {
+    it("derives stopAtTargetSoc from stopMode === 'evSettings'", () => {
+      expect(
+        meterNodeToCurveConfig({ stopMode: "evSettings" }).stopAtTargetSoc,
+      ).toBe(true);
+    });
+
+    it("leaves stopAtTargetSoc false for manual / unset stopMode", () => {
+      expect(
+        meterNodeToCurveConfig({ stopMode: "manual" }).stopAtTargetSoc,
+      ).toBe(false);
+      expect(meterNodeToCurveConfig({}).stopAtTargetSoc).toBe(false);
+    });
+
+    it("carries curve points and interval through to the modal", () => {
+      const config = meterNodeToCurveConfig({
+        curvePoints: [{ time: 0, value: 0 }],
+        incrementInterval: 42,
+        autoCalculateInterval: true,
+      });
+      expect(config.curvePoints).toEqual([{ time: 0, value: 0 }]);
+      expect(config.intervalSeconds).toBe(42);
+      expect(config.autoCalculateInterval).toBe(true);
+    });
+  });
+
+  describe("applyCurveConfigToMeterNode", () => {
+    it("persists 'Charge until battery full' as stopMode === 'evSettings'", () => {
+      const saved: AutoMeterValueConfig = {
+        enabled: true,
+        curvePoints: [{ time: 0, value: 0 }],
+        intervalSeconds: 10,
+        autoCalculateInterval: false,
+        stopAtTargetSoc: true,
+      };
+      const patched = applyCurveConfigToMeterNode(
+        { stopMode: "manual" },
+        saved,
+      );
+      expect(patched.stopMode).toBe("evSettings");
+    });
+
+    it("clears stopMode back to manual when the checkbox is unchecked", () => {
+      const saved: AutoMeterValueConfig = {
+        enabled: true,
+        curvePoints: [],
+        intervalSeconds: 10,
+        autoCalculateInterval: false,
+        stopAtTargetSoc: false,
+      };
+      const patched = applyCurveConfigToMeterNode(
+        { stopMode: "evSettings" },
+        saved,
+      );
+      expect(patched.stopMode).toBe("manual");
+    });
+
+    it("preserves unrelated form fields", () => {
+      const saved: AutoMeterValueConfig = {
+        enabled: true,
+        curvePoints: [{ time: 1, value: 2 }],
+        intervalSeconds: 15,
+        autoCalculateInterval: true,
+        stopAtTargetSoc: false,
+      };
+      const patched = applyCurveConfigToMeterNode(
+        { label: "Meter", incrementAmount: 1000, stopMode: "manual" },
+        saved,
+      );
+      expect(patched.label).toBe("Meter");
+      expect(patched.incrementAmount).toBe(1000);
+      expect(patched.curvePoints).toEqual([{ time: 1, value: 2 }]);
+      expect(patched.incrementInterval).toBe(15);
+    });
+  });
+
+  it("round-trips the checkbox: check → save → reopen shows it checked", () => {
+    // User opens the modal on a manual node and ticks "Charge until battery full".
+    const savedFromModal: AutoMeterValueConfig = {
+      ...meterNodeToCurveConfig({ stopMode: "manual" }),
+      stopAtTargetSoc: true,
+    };
+    const node = applyCurveConfigToMeterNode(
+      { stopMode: "manual" },
+      savedFromModal,
+    );
+    // Reopening the modal must reflect the persisted choice.
+    expect(meterNodeToCurveConfig(node).stopAtTargetSoc).toBe(true);
+  });
+});

--- a/src/components/scenario/meterValueNodeConfig.ts
+++ b/src/components/scenario/meterValueNodeConfig.ts
@@ -1,0 +1,59 @@
+import {
+  AutoMeterValueConfig,
+  CurvePoint,
+} from "../../cp/domain/connector/MeterValueCurve";
+
+/** Loosely-typed bag matching the ScenarioEditor node form state. */
+export type MeterNodeFormData = Record<string, unknown>;
+
+/** Fallback curve used when a MeterValue node has none configured yet. */
+const DEFAULT_CURVE_POINTS: CurvePoint[] = [
+  { time: 0, value: 0 },
+  { time: 30, value: 50 },
+];
+
+/**
+ * Build the {@link MeterValueCurveModal}'s `initialConfig` from a scenario
+ * MeterValue node's form data.
+ *
+ * A scenario expresses "charge until battery full" through
+ * `stopMode === "evSettings"` — that's what {@link ScenarioExecutor} honors,
+ * not the modal's own `stopAtTargetSoc`. We surface that flag as the modal
+ * checkbox so the two controls stay in sync and the checkbox round-trips
+ * (otherwise it always reopened unchecked — issue #95).
+ */
+export function meterNodeToCurveConfig(
+  formData: MeterNodeFormData,
+): AutoMeterValueConfig {
+  return {
+    enabled: true,
+    intervalSeconds: (formData.incrementInterval as number) || 10,
+    curvePoints:
+      (formData.curvePoints as CurvePoint[] | undefined) ??
+      DEFAULT_CURVE_POINTS,
+    autoCalculateInterval:
+      (formData.autoCalculateInterval as boolean | undefined) || false,
+    stopAtTargetSoc: formData.stopMode === "evSettings",
+  };
+}
+
+/**
+ * Merge a saved modal config back onto the MeterValue node form data.
+ *
+ * The modal's `stopAtTargetSoc` checkbox maps to the scenario's `stopMode`
+ * ("evSettings" when checked, "manual" when cleared) so the executor actually
+ * stops at the EV's target SoC. Without this, the checkbox was dropped on save
+ * and never took effect (issue #95).
+ */
+export function applyCurveConfigToMeterNode(
+  formData: MeterNodeFormData,
+  config: AutoMeterValueConfig,
+): MeterNodeFormData {
+  return {
+    ...formData,
+    curvePoints: config.curvePoints,
+    incrementInterval: config.intervalSeconds,
+    autoCalculateInterval: config.autoCalculateInterval,
+    stopMode: config.stopAtTargetSoc ? "evSettings" : "manual",
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -94,8 +94,10 @@
     @apply bg-emerald-500 hover:bg-emerald-600 dark:bg-emerald-500 dark:hover:bg-emerald-600 text-white font-medium py-2 px-4 rounded-lg shadow-sm transition-all disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
+  /* rose-600 (not -500) so white text/icons clear WCAG AA (~4.9:1) on the
+     red fill; -500 only reached ~3.9:1 (issue #92). */
   .btn-danger {
-    @apply bg-rose-500 hover:bg-rose-600 dark:bg-rose-500 dark:hover:bg-rose-600 text-white font-medium py-2 px-4 rounded-lg shadow-sm transition-all disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply bg-rose-600 hover:bg-rose-700 dark:bg-rose-600 dark:hover:bg-rose-700 text-white font-medium py-2 px-4 rounded-lg shadow-sm transition-all disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
   .btn-warning {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+/** App version injected at build time from package.json (see vite.config.ts). */
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,22 @@
 import path from "path";
+import { readFileSync } from "fs";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+
+// Surface the package version to the app (footer link, issue #93). Stays
+// "0.0.0" in dev and is stamped by the release tooling; the footer hides it
+// when unstamped.
+const pkgVersion = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf-8"),
+).version as string;
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   base: process.env.VITE_BASE_URL || "./",
+  define: {
+    __APP_VERSION__: JSON.stringify(pkgVersion),
+  },
   // The Tauri dev shell pins its devUrl to this port; if some unrelated
   // Vite server already holds 5173 we don't want to silently float to
   // 5174/5175 because Tauri would then end up loading the wrong app.


### PR DESCRIPTION
Addresses issues #92, #93, #95, plus a related light-mode rendering bug found while verifying.

## #95 — "Charge until battery full" never takes effect in a scenario 🐛
The meter-value curve modal's **stopAtTargetSoc** checkbox was dropped on save and not restored on reopen, and the scenario executor only honors `stopMode === "evSettings"` (never `stopAtTargetSoc`). So checking the box did nothing.

- Map the modal checkbox ↔ the node's `stopMode` (`evSettings`/`manual`), which the executor already honors — no executor change, and it stays in sync with the existing **Stop Mode** dropdown.
- Extracted the round-trip into `meterValueNodeConfig.ts` with unit tests (7 cases incl. check → save → reopen).

## #92 — Low-contrast text and icons 🎨
- Card-header labels (`ID:` / `Connectors:` / `Tag:`) now use an explicit AA-contrast gray instead of the lighter `text-muted`; values stay dark.
- The red **Remove Connector** button uses a white `Trash2` icon + `aria-label`, replacing a faint emoji that was hard to see on the red fill.
- `btn-danger`: `rose-600` (was `rose-500`) so white text/icons clear WCAG AA (~4.9:1).

## #93 — Web-console footer 🔗
Discreet footer pinned to the bottom of the shell: `ocpp-cp-simulator [vX.Y.Z] · GitHub`. The version is injected at build time (`__APP_VERSION__` from `package.json`) and hidden for the unstamped `0.0.0` dev default. (Sponsor link left out until `FUNDING.yml` / GitHub Sponsors is set up.)

## Extra — scenario-editor minimap unreadable in light mode
The minimap had no `nodeColor` and fell back to React Flow's `#e2e2e2`, invisible on the light-mode white minimap background (nodes looked unrendered). Added a per-node-type color map mirroring the canvas accents, with a visible stroke and slate fallback. Verified in both light and dark mode.

## Verification
- `vitest` 262 passed · `bun test` 80 pass / 0 fail · `eslint` clean · `vite build` OK
- Visually verified in a browser (light + dark): header readability, white danger-button icon, footer + GitHub link target, and the minimap rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)