### PR TITLE
fix(web-console): accept Basic Auth handshake header for socket.io

### DIFF
--- a/src/cli/server/__tests__/socketServer.auth.bun.test.ts
+++ b/src/cli/server/__tests__/socketServer.auth.bun.test.ts
@@ -55,6 +55,41 @@ describe("socket.io auth", () => {
     }
   });
 
+  it("connects with a Basic Auth handshake header (same-origin web console replay)", async () => {
+    // The bundled web console can't read the browser's cached Basic Auth
+    // credentials to put them in the `auth` payload; it relies on the browser
+    // replaying the `Authorization` header on the same-origin handshake. Pin
+    // the polling transport so the handshake is an HTTP request that carries
+    // the header.
+    const server = await authServer();
+    const socket = await connectTestClient(server, {
+      transports: ["polling"],
+      extraHeaders: {
+        Authorization: basicAuthHeader("operator", "top-secret"),
+      },
+    });
+    try {
+      expect(socket.connected).toBe(true);
+    } finally {
+      socket.disconnect();
+    }
+  });
+
+  it("rejects an incorrect Basic Auth handshake header", async () => {
+    const server = await authServer();
+    const socket = createTestClient(server, {
+      transports: ["polling"],
+      extraHeaders: { Authorization: basicAuthHeader("operator", "wrong") },
+    });
+    try {
+      const [err] = await waitForSocketEvent(socket, "connect_error");
+      expect(errorMessage(err)).toBe("unauthorized");
+      expect(socket.connected).toBe(false);
+    } finally {
+      socket.disconnect();
+    }
+  });
+
   it("keeps static Basic Auth while leaving healthz unauthenticated", async () => {
     const staticDir = await mkdtemp(join(tmpdir(), "ocpp-cp-sim-static-"));
     tempDirs.push(staticDir);
@@ -114,6 +149,10 @@ async function authServerWithLogCapture(): Promise<{
       process.stderr.write = originalWrite;
     },
   };
+}
+
+function basicAuthHeader(username: string, password: string): string {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
 }
 
 function errorMessage(err: unknown): string {

--- a/src/cli/server/httpServer.ts
+++ b/src/cli/server/httpServer.ts
@@ -338,7 +338,7 @@ function applyCacheControl(res: Response): Response {
  * Returns null when the header is missing, not Basic, or doesn't decode.
  * Tolerates the rare `Basic` scheme written in any case.
  */
-function parseBasicAuthHeader(
+export function parseBasicAuthHeader(
   header: string | null,
 ): { username: string; password: string } | null {
   if (!header) return null;
@@ -373,7 +373,7 @@ function parseBasicAuthHeader(
  * WWW-Authenticate already announces the server's identity. What we
  * defend against is byte-by-byte secret discovery via response timing.
  */
-function credentialsMatch(
+export function credentialsMatch(
   supplied: { username: string; password: string },
   expected: { username: string; password: string },
 ): boolean {

--- a/src/cli/server/socketServer.ts
+++ b/src/cli/server/socketServer.ts
@@ -33,7 +33,11 @@ import { LogLevel } from "../../cp/shared/Logger";
 import { redactSensitiveText } from "../../cp/shared/redaction";
 import type { CPRegistry } from "./CPRegistry";
 import type { EventBus } from "./eventBus";
-import { parseCreateBody } from "./httpServer";
+import {
+  parseCreateBody,
+  parseBasicAuthHeader,
+  credentialsMatch,
+} from "./httpServer";
 import {
   createRegistryEventBridge,
   type RegistryEventBridge,
@@ -695,6 +699,22 @@ function safeLogMessage(err: unknown): string {
   );
 }
 
+/**
+ * Read the `Authorization` header off a Socket.IO handshake, tolerating both
+ * the plain `IncomingHttpHeaders` record (Node/Engine.IO) and a `Headers`
+ * instance, plus the rare repeated-header array form.
+ */
+function handshakeAuthorizationHeader(headers: unknown): string | null {
+  if (!headers) return null;
+  if (typeof (headers as Headers).get === "function") {
+    return (headers as Headers).get("authorization");
+  }
+  const value = (headers as Record<string, unknown>).authorization;
+  if (typeof value === "string") return value;
+  if (Array.isArray(value) && typeof value[0] === "string") return value[0];
+  return null;
+}
+
 function registerSocketAuth(
   io: SocketIoServer,
   expected: SocketIoDeps["webConsoleBasicAuth"],
@@ -704,7 +724,25 @@ function registerSocketAuth(
       next();
       return;
     }
+    // 1) Explicit Socket.IO `auth` payload — used by the CLI client and any
+    //    cross-origin caller that holds the credentials and echoes them in.
     if (socketAuthMatches(socket.handshake.auth, expected)) {
+      next();
+      return;
+    }
+    // 2) HTTP `Authorization: Basic` header on the handshake request. The
+    //    bundled web console is served from the same origin as this daemon, so
+    //    it is loaded behind the browser's Basic Auth prompt; the browser then
+    //    replays those cached credentials on the same-origin Socket.IO
+    //    handshake. They are opaque to page JS and cannot be copied into the
+    //    `auth` payload above, so accepting the header lets the web console
+    //    connect under --web-console-basic-auth without a second credential
+    //    entry. (A WebSocket upgrade can't carry the header, but Socket.IO
+    //    authenticates once at the handshake, before the transport upgrade.)
+    const headerCreds = parseBasicAuthHeader(
+      handshakeAuthorizationHeader(socket.handshake.headers),
+    );
+    if (headerCreds && credentialsMatch(headerCreds, expected)) {
       next();
       return;
     }


### PR DESCRIPTION
## Background / symptom

When the daemon is exposed with `--web-console-basic-auth`, the bundled Web Console **shows nothing and the Remote badge is red** (empty chargepoint list). The daemon itself is healthy — the OCPP side (charger connection, heartbeats, scenarios) works fine.

## Root cause

The Web Console is served from the **same origin** as the daemon. Under `--web-console-basic-auth` the browser authenticates via its native Basic Auth prompt and caches the credentials. Those credentials are **opaque to page JS**, so the console cannot place them into the socket.io `auth` payload that `registerSocketAuth` was checking.

The browser does, however, automatically replay the cached `Authorization` header on the same-origin socket.io polling handshake. Since the previous implementation only inspected the `auth` payload, the same-origin Web Console was always rejected with `unauthorized`.

## Fix

socket.io authenticates once at the handshake (before the WebSocket upgrade, which can't carry the header). So in **addition** to the `auth` payload, we now also accept an HTTP `Authorization: Basic` header on the handshake request.

- Export `parseBasicAuthHeader` / `credentialsMatch` from `httpServer` and reuse them, so header parsing and the timing-safe comparison stay shared.
- Add `handshakeAuthorizationHeader` to read the header from both the Node `IncomingHttpHeaders` record and a `Headers` instance.
- The CLI client path (`auth` payload) is **unchanged** — no behavior change there.

## Tests

`src/cli/server/__tests__/socketServer.auth.bun.test.ts`:
- Connects with a valid Basic Auth handshake header (polling transport pinned so the HTTP handshake carries the header).
- Rejects a wrong Basic Auth handshake header with `unauthorized`.
- The existing `auth`-payload tests still pass.

```
bun test src/cli/server/__tests__/socketServer.auth.bun.test.ts
 5 pass / 0 fail
```

`tsc --noEmit` / `eslint` / `prettier --check` are all clean.