### PR TITLE
fix(web-console): polyfill node `events` so the SOAP/xmlbuilder2 path loads

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,7 @@
         "eslint-config-prettier": "^9.1.2",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "events": "^3.3.0",
         "husky": "^9.1.7",
         "json-schema-to-typescript": "^15.0.4",
         "lint-staged": "^15.5.2",
@@ -674,6 +675,8 @@
     "eventemitter2": ["eventemitter2@6.4.9", "", {}, "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="],
 
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "eslint-config-prettier": "^9.1.2",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "events": "^3.3.0",
     "husky": "^9.1.7",
     "json-schema-to-typescript": "^15.0.4",
     "lint-staged": "^15.5.2",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,18 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // The OCPP 1.5 SOAP transport (daemon-only) pulls in xmlbuilder2, whose
+      // streaming builder declares `class XMLBuilderCBImpl extends
+      // require("events").EventEmitter` at module load. That code is never
+      // executed in the browser web console, but it is statically reachable
+      // from the shared ChargePoint domain class and therefore bundled. Vite
+      // externalizes Node's `events` for the browser, leaving EventEmitter
+      // undefined, so the class declaration throws "Class extends value
+      // undefined" while the bundle initializes — blanking the whole console.
+      // Resolve `events` to its browser polyfill (the `events` npm package) so
+      // the otherwise-unused module evaluates cleanly. Keep the `events`
+      // devDependency in sync; it has no direct import and exists only for this.
+      events: path.resolve(__dirname, "node_modules/events/events.js"),
     },
   },
 });


### PR DESCRIPTION
## Symptom

The bundled web console renders a **blank white page**. The browser console shows, at bundle init:

```
Uncaught TypeError: Class extends value undefined is not a constructor or null
    at node_modules/xmlbuilder2/lib/builder/XMLBuilderCBImpl.js
```

preceded by:

```
Module "events" has been externalized for browser compatibility.
Cannot access "events.EventEmitter" in client code.
```

(Regression since #91/#94 — i.e. the OCPP 1.5 SOAP / xmlbuilder2 work. The previous image rendered fine.)

## Root cause

The OCPP 1.5 SOAP transport (`src/cp/infrastructure/transport/soap/*`) pulls in **xmlbuilder2**, whose streaming builder declares at module load:

```js
// node_modules/xmlbuilder2/lib/builder/XMLBuilderCBImpl.js
const events_1 = require("events");
class XMLBuilderCBImpl extends events_1.EventEmitter { ... }
```

That transport is **daemon-only** and never executed in the browser web console — but it is **statically reachable** from the shared `ChargePoint` domain class:

```
src/cp/domain/charge-point/ChargePoint.ts
  import { OCPPSoapHandler } from "../../infrastructure/transport/soap"   // barrel
    -> soap/OCPPSoapHandler.ts -> soap/soapEnvelope.ts
      -> import { create } from "xmlbuilder2"   // pulls XMLBuilderCBImpl
```

so it gets bundled into the browser build. Vite externalizes Node's `events` for the browser, leaving `EventEmitter` **undefined**, so `class XMLBuilderCBImpl extends undefined` throws while the bundle initializes and React never mounts → blank page.

`ChargePoint` constructs the SOAP handler synchronously (its `_messageHandler` is used immediately by `Outbox`), so a lazy/dynamic import there isn't a small change. The crash is purely at **module-evaluation** time, though — the SOAP code is never *run* in the browser.

## Fix

Add the **`events` browser polyfill** (the `events` npm package — the canonical browserify shim) and alias bare `events` imports to it in `vite.config.ts`. xmlbuilder2's *only* Node builtin across its entire `lib/` is `events` (verified: a single `require("events")`), so the polyfill fully resolves the crash; the otherwise-unused SOAP module then evaluates cleanly.

- Daemon (bun) builds are unaffected — the alias is Vite/browser-only; the daemon keeps using the real Node `events`.
- Only `bun.lock` is updated (the repo's source-of-truth lockfile; `package-lock.json` is not kept in sync with feature deps and is regenerated by the npm-based Pages deploy).

## Verification

- `bun run build` (vite production build) succeeds.
- Loaded the **production** bundle via `vite preview` in a real browser: the console renders (`Local / ChargePoint / Settings`) with **no console errors**. Previously: blank page + the class-extends error.
- The `events externalized` warning is gone.

## Note (follow-up, optional)

A leaner alternative is to keep SOAP/xmlbuilder2 out of the browser bundle entirely (e.g. inject the SOAP handler from the CLI side, or dynamic-import it), avoiding shipping xmlbuilder2 to the browser at all. That's a larger refactor of `ChargePoint`'s construction path; this PR is the minimal, low-risk fix to unblock the web console.