### PR TITLE
fix(web-console): stable remote connection (pin polling) + dedupe react (Scenario Editor)

### DIFF
--- a/src/data/remote/RemoteChargePointService.ts
+++ b/src/data/remote/RemoteChargePointService.ts
@@ -589,6 +589,16 @@ export class RemoteChargePointService implements ChargePointService {
     this.socket = io(baseUrl, {
       path: "/socket.io/",
       auth: authFromUrl(baseUrl),
+      // Pin the polling transport instead of upgrading to WebSocket. When the
+      // daemon is exposed behind an L7 proxy (e.g. the staging GCE Ingress),
+      // the WebSocket upgrade often can't complete — the upgrade request fails
+      // ("closed before the connection is established"), which then invalidates
+      // the engine.io session and the console churns through reconnects /
+      // "disconnected". HTTP long-polling traverses the proxy reliably (each
+      // poll is a normal request well under the LB's response timeout), so the
+      // session stays up. The cost is slightly higher update latency, which is
+      // immaterial for a status console.
+      transports: ["polling"],
     });
     this.connectionState = this.socket.connected ? "connected" : "connecting";
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,5 +53,13 @@ export default defineConfig({
       // devDependency in sync; it has no direct import and exists only for this.
       events: path.resolve(__dirname, "node_modules/events/events.js"),
     },
+    // Force a single React instance across every chunk. The Scenario Editor is
+    // a lazy chunk built around @xyflow/react, which leans heavily on React
+    // context/hooks. If the production build ever splits React such that the
+    // lazy chunk resolves a second copy, those hooks read a null dispatcher and
+    // throw React error #321 ("invalid hook call / more than one copy of
+    // React"), crashing the editor. Deduping pins react/react-dom to one
+    // module so the lazy chunk and the app share the same instance.
+    dedupe: ["react", "react-dom"],
   },
 });


### PR DESCRIPTION
Two independent web-console reliability fixes, surfaced once the console actually rendered (after #99/#100).

## 1. Pin the polling transport — remote console kept disconnecting

**Symptom:** In remote mode behind the staging GCE Ingress, the console intermittently shows `Remote · disconnected` with an empty charge-point list. The network tab shows the Socket.IO polling handshake succeed (a `sid` is issued), then the `transport=websocket` upgrade fail (`WebSocket is closed before the connection is established`), after which polling requests for that `sid` start returning `400` and the client churns through reconnects.

**Cause:** The WebSocket upgrade can't complete through the L7 proxy. socket.io marks the session as upgrading, the upgrade dies at the proxy, and the engine.io session is left invalid → `400 Session ID unknown` → disconnect loop. A fresh reload sometimes lands on a session that stays on polling, which is why "reload fixes it" — but it's not reliable.

**Fix:** Pin `transports: ['polling']` on the remote client (`RemoteChargePointService`). HTTP long-polling traverses the L7 proxy reliably (each poll is a normal request, comfortably under the LB response timeout), so the session stays up. Slightly higher update latency, immaterial for a status console. The same-origin Basic Auth handshake (header replay, #99) keeps working on polling. The CLI control path is unaffected (it uses HTTP `--send`, not socket.io).

## 2. Dedupe React — Scenario Editor crashed with React #321

**Symptom:** Opening the Scenario Editor crashes with `Minified React error #321` ("invalid hook call / more than one copy of React"); the editor blanks while the rest of the app renders fine. Reproduced on the deployed (CI) build; **not** reproducible in a local `vite build` of the same source — i.e. it depends on how the build environment splits chunks.

**Cause:** The Scenario Editor is a lazy chunk built on `@xyflow/react`, which leans heavily on React context/hooks. When Rollup splits React such that the lazy chunk resolves a second copy, those hooks read a null dispatcher and throw #321.

**Fix:** `resolve.dedupe: ['react', 'react-dom']` in `vite.config.ts` so every chunk shares one React instance regardless of how the build splits. There is only ever one `react` in `node_modules`; this just stops the bundler from duplicating it across chunks.

## Verification

- `tsc --noEmit`, `eslint`, `prettier --check`, `vite build` all clean.
- Built bundle contains the pinned `polling` transport; React internals stay in a single chunk after dedupe.
- Scenario Editor opens cleanly in a local production preview (no #321).
- End-to-end remote-connection stability (fix 1) verifies once deployed behind the staging Ingress.