### PR TITLE
fix(scenario): persist uploaded scenarios in remote mode + retarget on import (#101)

### DIFF
--- a/src/components/scenario/ScenarioEditor.tsx
+++ b/src/components/scenario/ScenarioEditor.tsx
@@ -46,6 +46,10 @@ import {
   applyCurveConfigToMeterNode,
 } from "./meterValueNodeConfig";
 import {
+  persistEditorScenario,
+  retargetScenarioToConnector,
+} from "./scenarioPersistence";
+import {
   type EVSettings,
   EV_PRESETS,
 } from "../../cp/domain/connector/EVSettings";
@@ -1109,18 +1113,46 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
 
       try {
         const imported = await importScenarioFromJSON(file);
-        setScenario(imported);
-        setNodes(imported.nodes);
-        setEdges(imported.edges);
+        // Retarget the uploaded scenario to the connector it's imported into.
+        // A file exported from a different connector keeps its old targetId,
+        // which the connector-scoped filters drop on the next refresh — so the
+        // upload would appear to "not save" (#101).
+        const targeted = retargetScenarioToConnector(
+          imported,
+          connectorId,
+          new Date().toISOString(),
+        );
+        setScenario(targeted);
+        setNodes(targeted.nodes);
+        setEdges(targeted.edges);
+        // Mirror the props-reload effect so the metadata fields reflect the
+        // uploaded scenario instead of the previously-open one.
+        setScenarioName(targeted.name);
+        setScenarioDescription(targeted.description || "");
+        setDefaultExecutionMode(targeted.defaultExecutionMode || "oneshot");
+        setScenarioEnabled(targeted.enabled !== false);
+        setScenarioEvSettings(targeted.evSettings ?? {});
 
-        // Repository.save is upsert (`INSERT … ON CONFLICT DO UPDATE`),
-        // so we don't need to look the existing row up first.
-        await scenarioRepository.save(cpId, connectorId, imported);
+        // Persist mode-aware: in remote mode the browser sql.js repository is a
+        // no-op, so the upload has to be pushed to the daemon (and prior
+        // scenarios cleaned up) or it's silently lost on reload (#101).
+        await persistEditorScenario(
+          { mode, chargePointService, scenarioRepository, cpId, connectorId },
+          targeted,
+        );
       } catch (error) {
         alert(`Failed to import scenario: ${error}`);
       }
     },
-    [cpId, connectorId, scenarioRepository, setNodes, setEdges],
+    [
+      cpId,
+      connectorId,
+      mode,
+      chargePointService,
+      scenarioRepository,
+      setNodes,
+      setEdges,
+    ],
   );
 
   const handleLoadTemplate = useCallback(
@@ -1142,50 +1174,24 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
       setScenario(templateScenario);
       setNodes(templateScenario.nodes);
       setEdges(templateScenario.edges);
+      // Keep the metadata fields in sync with the loaded template.
+      setScenarioName(templateScenario.name);
+      setScenarioDescription(templateScenario.description || "");
+      setDefaultExecutionMode(
+        templateScenario.defaultExecutionMode || "oneshot",
+      );
+      setScenarioEnabled(templateScenario.enabled !== false);
+      setScenarioEvSettings(templateScenario.evSettings ?? {});
 
-      void (async () => {
-        // Remote mode: scenarioRepository.save no-ops (sql.js isn't loaded),
-        // so a save here would vanish on reload — the daemon would still
-        // hand us the previous scenario via listScenarios on next mount.
-        // Push through chargePointService.loadScenario instead, and clean
-        // up the prior scenarios so listScenarios doesn't keep returning
-        // them at index 0 (the daemon orders by insertion / updated_at).
-        if (mode === "remote") {
-          try {
-            const existing = await chargePointService.listScenarios(
-              cpId,
-              connectorId,
-            );
-            await Promise.all(
-              existing
-                .filter((item) => item.scenarioId !== templateScenario.id)
-                .map((item) =>
-                  chargePointService
-                    .removeScenario(cpId, connectorId, item.scenarioId)
-                    .catch((err) =>
-                      console.warn(
-                        `Failed to remove stale scenario ${item.scenarioId}`,
-                        err,
-                      ),
-                    ),
-                ),
-            );
-            await chargePointService.loadScenario(
-              cpId,
-              connectorId,
-              templateScenario,
-            );
-          } catch (err) {
-            console.error("Failed to persist template scenario", err);
-          }
-          return;
-        }
-        try {
-          await scenarioRepository.save(cpId, connectorId, templateScenario);
-        } catch (err) {
-          console.error("Failed to save template scenario", err);
-        }
-      })();
+      // Same mode-aware persistence as the file-upload path: remote mode pushes
+      // through the daemon and prunes stale scenarios; local mode upserts into
+      // the browser sql.js repository (#101).
+      void persistEditorScenario(
+        { mode, chargePointService, scenarioRepository, cpId, connectorId },
+        templateScenario,
+      ).catch((err) =>
+        console.error("Failed to persist template scenario", err),
+      );
     },
     [
       cpId,

--- a/src/components/scenario/__tests__/scenarioPersistence.test.ts
+++ b/src/components/scenario/__tests__/scenarioPersistence.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  persistEditorScenario,
+  retargetScenarioToConnector,
+} from "../scenarioPersistence";
+import type { ScenarioDefinition } from "../../../cp/application/scenario/ScenarioTypes";
+
+const scenario = (id: string): ScenarioDefinition =>
+  ({
+    id,
+    name: `Scenario ${id}`,
+    nodes: [],
+    edges: [],
+    trigger: { type: "manual" },
+  }) as unknown as ScenarioDefinition;
+
+function makeService(existingIds: string[] = []) {
+  return {
+    listScenarios: vi
+      .fn()
+      .mockResolvedValue(existingIds.map((scenarioId) => ({ scenarioId }))),
+    removeScenario: vi.fn().mockResolvedValue(undefined),
+    loadScenario: vi.fn().mockResolvedValue({ scenarioId: "x" }),
+  };
+}
+
+describe("persistEditorScenario (scenario upload / template persistence — #101)", () => {
+  it("remote mode pushes the scenario to the daemon (not the no-op sql.js repo)", async () => {
+    const chargePointService = makeService([]);
+    const scenarioRepository = { save: vi.fn().mockResolvedValue(undefined) };
+    const uploaded = scenario("new-1");
+
+    await persistEditorScenario(
+      {
+        mode: "remote",
+        chargePointService,
+        scenarioRepository,
+        cpId: "CP1",
+        connectorId: 1,
+      },
+      uploaded,
+    );
+
+    // The bug: upload only called scenarioRepository.save, a no-op in remote
+    // mode, so the upload vanished on reload. It must reach the daemon.
+    expect(chargePointService.loadScenario).toHaveBeenCalledWith(
+      "CP1",
+      1,
+      uploaded,
+    );
+    expect(scenarioRepository.save).not.toHaveBeenCalled();
+  });
+
+  it("remote mode removes stale prior scenarios but keeps the one being saved", async () => {
+    const chargePointService = makeService(["old-a", "old-b", "new-1"]);
+    const scenarioRepository = { save: vi.fn().mockResolvedValue(undefined) };
+
+    await persistEditorScenario(
+      {
+        mode: "remote",
+        chargePointService,
+        scenarioRepository,
+        cpId: "CP1",
+        connectorId: 2,
+      },
+      scenario("new-1"),
+    );
+
+    expect(chargePointService.removeScenario).toHaveBeenCalledWith(
+      "CP1",
+      2,
+      "old-a",
+    );
+    expect(chargePointService.removeScenario).toHaveBeenCalledWith(
+      "CP1",
+      2,
+      "old-b",
+    );
+    // The incoming scenario id must NOT be removed.
+    expect(chargePointService.removeScenario).not.toHaveBeenCalledWith(
+      "CP1",
+      2,
+      "new-1",
+    );
+    expect(chargePointService.removeScenario).toHaveBeenCalledTimes(2);
+  });
+
+  it("remote mode still saves when a stale removal fails", async () => {
+    const chargePointService = makeService(["old-a"]);
+    chargePointService.removeScenario.mockRejectedValueOnce(new Error("boom"));
+    const scenarioRepository = { save: vi.fn().mockResolvedValue(undefined) };
+    const uploaded = scenario("new-1");
+
+    await expect(
+      persistEditorScenario(
+        {
+          mode: "remote",
+          chargePointService,
+          scenarioRepository,
+          cpId: "CP1",
+          connectorId: 1,
+        },
+        uploaded,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(chargePointService.loadScenario).toHaveBeenCalledWith(
+      "CP1",
+      1,
+      uploaded,
+    );
+  });
+
+  it("local mode upserts into the sql.js repository and never touches the daemon", async () => {
+    const chargePointService = makeService(["old-a"]);
+    const scenarioRepository = { save: vi.fn().mockResolvedValue(undefined) };
+    const uploaded = scenario("new-1");
+
+    await persistEditorScenario(
+      {
+        mode: "local",
+        chargePointService,
+        scenarioRepository,
+        cpId: "CP1",
+        connectorId: 1,
+      },
+      uploaded,
+    );
+
+    expect(scenarioRepository.save).toHaveBeenCalledWith("CP1", 1, uploaded);
+    expect(chargePointService.listScenarios).not.toHaveBeenCalled();
+    expect(chargePointService.removeScenario).not.toHaveBeenCalled();
+    expect(chargePointService.loadScenario).not.toHaveBeenCalled();
+  });
+});
+
+describe("retargetScenarioToConnector (upload retargeting — #101)", () => {
+  const now = "2026-06-30T00:00:00.000Z";
+
+  it("retargets a file exported from another connector to the current one", () => {
+    const fromConnector1 = {
+      ...scenario("up-1"),
+      targetType: "connector",
+      targetId: 1,
+    } as unknown as ScenarioDefinition;
+
+    const out = retargetScenarioToConnector(fromConnector1, 2, now);
+
+    expect(out.targetType).toBe("connector");
+    expect(out.targetId).toBe(2);
+    expect(out.updatedAt).toBe(now);
+    // Content is preserved; only targeting/timestamp change.
+    expect(out.id).toBe("up-1");
+    expect(out.nodes).toBe(fromConnector1.nodes);
+  });
+
+  it("targets the charge point when connectorId is null", () => {
+    const out = retargetScenarioToConnector(scenario("up-2"), null, now);
+    expect(out.targetType).toBe("chargePoint");
+    expect(out.targetId).toBeUndefined();
+  });
+});

--- a/src/components/scenario/scenarioPersistence.ts
+++ b/src/components/scenario/scenarioPersistence.ts
@@ -1,0 +1,95 @@
+import type { ScenarioDefinition } from "../../cp/application/scenario/ScenarioTypes";
+import type { ChargePointService } from "../../data/interfaces/ChargePointService";
+import type { ScenarioRepository } from "../../cp/domain/persistence/ScenarioRepository";
+
+/**
+ * Dependencies needed to durably persist a scenario the user just loaded into
+ * the editor. Narrowed to the handful of methods we call so tests can pass
+ * lightweight mocks.
+ */
+export interface PersistEditorScenarioDeps {
+  /** `"remote"` (daemon-backed) or `"local"` (browser sql.js). */
+  mode: string;
+  chargePointService: Pick<
+    ChargePointService,
+    "listScenarios" | "removeScenario" | "loadScenario"
+  >;
+  scenarioRepository: Pick<ScenarioRepository, "save">;
+  cpId: string;
+  connectorId: number | null;
+}
+
+/**
+ * Durably persist a scenario the user just dropped into the editor — either by
+ * uploading a JSON file (`handleFileChange`) or loading a template
+ * (`handleLoadTemplate`).
+ *
+ * **Remote (daemon) mode:** the browser-side `scenarioRepository` is a no-op
+ * (DataProvider constructs it with `database === null`), so a `repository.save`
+ * here would silently vanish on reload and the daemon's `listScenarios` would
+ * keep handing back the PREVIOUS scenario on the next mount. We push through the
+ * daemon instead, and remove the prior scenarios so a stale one doesn't keep
+ * winning index 0 (the daemon orders by insertion / updated_at).
+ *
+ * **Local mode:** upsert into the browser sql.js repository.
+ *
+ * `handleLoadTemplate` already did this; `handleFileChange` (upload) did not —
+ * uploaded scenarios were lost on refresh in remote mode (GitHub #101). Sharing
+ * one helper keeps both paths correct.
+ */
+export async function persistEditorScenario(
+  deps: PersistEditorScenarioDeps,
+  scenario: ScenarioDefinition,
+): Promise<void> {
+  const { mode, chargePointService, scenarioRepository, cpId, connectorId } =
+    deps;
+
+  if (mode === "remote") {
+    // The daemon's scenario RPCs are connector-scoped and require a positive
+    // int (CP-level scenarios go through the local sql.js path), so narrow the
+    // nullable editor connectorId here.
+    const remoteConnectorId = connectorId as number;
+    const existing = await chargePointService.listScenarios(
+      cpId,
+      remoteConnectorId,
+    );
+    await Promise.all(
+      existing
+        .filter((item) => item.scenarioId !== scenario.id)
+        .map((item) =>
+          chargePointService
+            .removeScenario(cpId, remoteConnectorId, item.scenarioId)
+            .catch((err) =>
+              console.warn(
+                `Failed to remove stale scenario ${item.scenarioId}`,
+                err,
+              ),
+            ),
+        ),
+    );
+    await chargePointService.loadScenario(cpId, remoteConnectorId, scenario);
+    return;
+  }
+
+  await scenarioRepository.save(cpId, connectorId, scenario);
+}
+
+/**
+ * Point an imported scenario at the connector it's being loaded into. A file
+ * exported from another connector keeps its original `targetId`, which the
+ * connector-scoped selection filters drop on the next refresh — so the upload
+ * looks like it "didn't save" (#101). `now` is injected for testability and to
+ * win the `updated_at DESC` ordering local mode lists by.
+ */
+export function retargetScenarioToConnector(
+  scenario: ScenarioDefinition,
+  connectorId: number | null,
+  now: string,
+): ScenarioDefinition {
+  return {
+    ...scenario,
+    targetType: connectorId === null ? "chargePoint" : "connector",
+    targetId: connectorId ?? undefined,
+    updatedAt: now,
+  };
+}


### PR DESCRIPTION
## Problem
Issue #101: in the web-console Scenario Editor, uploading a new scenario file → **Save** → refreshing the browser still showed the **OLD** scenario. The upload didn't survive a refresh.

## Root cause
`handleFileChange` (upload) only called the browser sql.js `scenarioRepository.save`, which is a **no-op in remote (daemon) mode** — `DataProvider` constructs the repository with `database === null`. So the uploaded scenario never reached the daemon, and on refresh `listScenarios` handed back the previous scenario. `handleLoadTemplate` already pushed through the daemon and pruned stale scenarios; the upload path was missing that.

Second contributor: an imported file keeps its original `targetId`, so a scenario exported from a *different* connector is dropped by the connector-scoped selection filter on refresh.

## Fix
- Extract mode-aware persistence into `persistEditorScenario` (remote: prune stale scenarios + `chargePointService.loadScenario`; local: sql.js upsert) and use it from both `handleFileChange` and `handleLoadTemplate`.
- Retarget uploaded scenarios to the current connector (`retargetScenarioToConnector`).
- Sync editor metadata state (name/description/mode/enabled/evSettings) on upload/template load, mirroring the props-reload effect.

## Tests / gates
- New `scenarioPersistence.test.ts` — 6 cases: remote push (not the no-op repo), stale pruning, removal-failure tolerance, local upsert, retargeting (connector + CP-level).
- `tsc -b --noEmit`: no new errors. eslint + prettier clean. Full vitest: 315 passed.

## Out of scope (separate from #101, noted for follow-up)
- `handleManualSave` doesn't prune stale scenarios — only matters for plain edit+save when multiple scenarios already exist; id-stable edits don't accumulate.
- Remote auto-save still no-ops (remote requires an explicit Save by design).
- Local sql.js persistence is debounced 200ms, so a near-instant hard refresh can race the IndexedDB flush.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
