### PR TITLE
fix(connector): stop at the EV target SoC instead of overshooting (#105)

### DIFF
--- a/src/cp/domain/connector/Connector.ts
+++ b/src/cp/domain/connector/Connector.ts
@@ -824,9 +824,51 @@ export class Connector {
     const current = this.effectiveSocPercent();
     if (current === null) return;
     if (current < this._evSettings.targetSoc) return;
+
+    // We've reached or exceeded the target SoC. A coarse curve / increment tick
+    // can land WELL past the target in a single step (e.g. 95% when the target
+    // is 80%), and we only stop *after* the value was applied — so clamp the
+    // meter back to the energy for exactly the target SoC and re-sync before
+    // stopping. Otherwise the session ends at the overshot value (#105).
+    const targetMeterWh = this.meterWhForSoc(this._evSettings.targetSoc);
+    if (targetMeterWh !== null && this.meterValueWh > targetMeterWh) {
+      this.meterValueWh = targetMeterWh;
+      this.eventsEmitter.emit("meterValueChange", {
+        meterValue: targetMeterWh,
+      });
+      if (this.socMeterSyncEnabledValue) {
+        const derived = this.socFromMeterValue(targetMeterWh);
+        if (derived !== null && this.socPercent !== derived) {
+          this.socPercent = derived;
+          this.eventsEmitter.emit("socChange", { soc: derived });
+        }
+      }
+    }
+
     this.meterScheduler.stop();
     this.eventsEmitter.emit("autoStopRequested", {
       reason: "targetSocReached",
     });
+  }
+
+  /**
+   * Inverse of {@link socFromMeterValue}: the integer meter Wh corresponding to
+   * exactly `soc` percent, using the same capacity / initialSoc / meterStart
+   * inputs so the round-trip is consistent. Returns null when capacity is
+   * unknown.
+   */
+  private meterWhForSoc(soc: number): number | null {
+    const transactionCapacity = this.transactionValue?.batteryCapacityKwh;
+    const capacity =
+      transactionCapacity && transactionCapacity > 0
+        ? transactionCapacity
+        : this._evSettings.batteryCapacityKwh;
+    if (capacity <= 0) return null;
+    const initial =
+      this.transactionValue?.initialSoc ?? this._evSettings.initialSoc ?? 0;
+    const meterStart = this.transactionValue?.meterStart ?? 0;
+    const deliveredKWh = ((soc - initial) / 100) * capacity;
+    if (deliveredKWh <= 0) return meterStart;
+    return Math.round(meterStart + deliveredKWh * 1000);
   }
 }

--- a/src/cp/domain/connector/__tests__/Connector.autoStop.test.ts
+++ b/src/cp/domain/connector/__tests__/Connector.autoStop.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Connector } from "../Connector";
+import { Logger, LogLevel } from "../../../shared/Logger";
+import { OCPPStatus } from "../../types/OcppTypes";
+import type { Transaction } from "../Transaction";
+
+function transaction(meterStart: number): Transaction {
+  return {
+    id: 7,
+    connectorId: 1,
+    tagId: "TAG-SOC",
+    meterStart,
+    meterStop: null,
+    startTime: new Date("2026-06-28T00:00:00.000Z"),
+    stopTime: null,
+    meterSent: false,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Connector stopAtTargetSoc auto-stop (overshoot — #105)", () => {
+  it("clamps the meter to the target-SoC energy when a coarse tick overshoots", () => {
+    vi.useFakeTimers();
+    const connector = new Connector(1, new Logger(LogLevel.ERROR));
+    connector.evSettings = {
+      ...connector.evSettings,
+      batteryCapacityKwh: 75,
+      initialSoc: 20,
+      targetSoc: 80,
+    };
+    // Enable the target-SoC stop but keep the curve disabled so beginTransaction
+    // doesn't auto-start it — we drive a deliberately coarse increment instead.
+    connector.autoMeterValueConfig = {
+      enabled: false,
+      intervalSeconds: 1,
+      curvePoints: [{ time: 0, value: 0 }],
+      autoCalculateInterval: false,
+      stopAtTargetSoc: true,
+    };
+    connector.status = OCPPStatus.Charging;
+    connector.beginTransaction(transaction(0));
+
+    let autoStops = 0;
+    connector.events.on("autoStopRequested", () => {
+      autoStops += 1;
+    });
+
+    // 20%→80% on a 75 kWh battery = 45_000 Wh. A 28_125 Wh/tick increment lands
+    // at 56_250 Wh (95% SoC) on the 2nd tick — past the 80% target.
+    connector.startManualMeterStrategy({
+      kind: "increment",
+      intervalSeconds: 1,
+      incrementValue: 28_125,
+    });
+
+    vi.advanceTimersByTime(1_000); // tick 1 -> 28_125 Wh (57.5%), below target
+    expect(connector.meterValue).toBe(28_125);
+    expect(autoStops).toBe(0);
+    expect(connector.isAutoMeterValueActive()).toBe(true);
+
+    vi.advanceTimersByTime(1_000); // tick 2 -> 56_250 Wh (95%) -> auto-stop
+    // Clamped back to exactly the target SoC instead of stranding at 95%.
+    expect(connector.meterValue).toBe(45_000);
+    expect(connector.soc).toBe(80);
+    expect(autoStops).toBe(1);
+    expect(connector.isAutoMeterValueActive()).toBe(false);
+  });
+
+  it("stops exactly at the target without clamping when a tick lands on it", () => {
+    vi.useFakeTimers();
+    const connector = new Connector(1, new Logger(LogLevel.ERROR));
+    connector.evSettings = {
+      ...connector.evSettings,
+      batteryCapacityKwh: 75,
+      initialSoc: 20,
+      targetSoc: 80,
+    };
+    connector.autoMeterValueConfig = {
+      enabled: false,
+      intervalSeconds: 1,
+      curvePoints: [{ time: 0, value: 0 }],
+      autoCalculateInterval: false,
+      stopAtTargetSoc: true,
+    };
+    connector.status = OCPPStatus.Charging;
+    connector.beginTransaction(transaction(0));
+
+    // 15_000 Wh/tick lands exactly on 45_000 Wh (80%) on the 3rd tick.
+    connector.startManualMeterStrategy({
+      kind: "increment",
+      intervalSeconds: 1,
+      incrementValue: 15_000,
+    });
+
+    vi.advanceTimersByTime(3_000);
+    expect(connector.meterValue).toBe(45_000);
+    expect(connector.soc).toBe(80);
+    expect(connector.isAutoMeterValueActive()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem
Issue #105: with an EV **target SoC of 80%**, charging didn't stop near the target — it ran on to ~95%.

## Root cause
`Connector.checkAutoStop()` (gated on `stopAtTargetSoc`) runs **after** each meter tick is applied and only `stop()`s the scheduler once `SoC >= targetSoc`. A coarse curve/increment tick can jump **well past** the target in a single step (e.g. straight to 95% when the target is 80%), so the session ended at the overshot value — the meter was never pulled back to the target.

## Fix
When the target is reached/exceeded, clamp the meter back to the energy for **exactly** the target SoC (the inverse of `socFromMeterValue`, sharing the same capacity / initialSoc / meterStart inputs) and re-sync SoC, then stop. Added a `meterWhForSoc` helper.

## Tests
New `Connector.autoStop.test.ts`:
- A `28_125 Wh`/tick increment overshoots the `45_000 Wh` (80%) target to `56_250 Wh` (95%) → now clamped back to `45_000 Wh` / 80%. (This test fails on `main`: `expected 56250 to be 45000`.)
- An exact-landing tick still stops at the target without clamping (no behavior change for the non-overshoot case).

Full suite: 317 passed. `tsc -b --noEmit`: no new errors. eslint + prettier clean.

Resolves #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
