### PR TITLE
fix(ui): show Connect/Disconnect correctly after auto-reconnect (#103)

### DIFF
--- a/src/components/ChargePoint.tsx
+++ b/src/components/ChargePoint.tsx
@@ -38,6 +38,7 @@ const ChargePoint: React.FC<ChargePointProps> = ({
     tagIDs && tagIDs.length > 0 ? tagIDs : TagID ? [TagID] : [];
   const {
     status: cpStatus,
+    connected: cpConnected,
     error: cpError,
     connectors,
     heartbeat,
@@ -174,6 +175,7 @@ const ChargePoint: React.FC<ChargePointProps> = ({
             <ChargePointControls
               chargePointId={cpId}
               cpStatus={cpStatus}
+              cpConnected={cpConnected}
               cpError={cpError}
               tagID={TagID}
               heartbeat={heartbeat}
@@ -370,6 +372,7 @@ const HeartbeatStatusChip: React.FC<{
 interface ChargePointControlsProps {
   chargePointId: string | null;
   cpStatus: string;
+  cpConnected: boolean;
   cpError: string;
   tagID: string;
   heartbeat: { intervalSeconds: number; lastSentAt: Date | null };
@@ -378,6 +381,7 @@ interface ChargePointControlsProps {
 const ChargePointControls: React.FC<ChargePointControlsProps> = ({
   chargePointId,
   cpStatus,
+  cpConnected,
   cpError,
   tagID,
   heartbeat,
@@ -420,7 +424,11 @@ const ChargePointControls: React.FC<ChargePointControlsProps> = ({
     }
   };
 
-  const isConnected = cpStatus !== OCPPStatus.Unavailable;
+  // Reflect the actual transport connection for Connect/Disconnect: after an
+  // auto-reconnect the socket is up before BootNotification is re-Accepted, so
+  // the OCPP `cpStatus` can still be Unavailable. Fall back to the status so a
+  // freshly-loaded, already-booted CP still reads as connected (#103).
+  const isConnected = cpConnected || cpStatus !== OCPPStatus.Unavailable;
 
   return (
     <div className="panel p-3">

--- a/src/data/hooks/useChargePointView.ts
+++ b/src/data/hooks/useChargePointView.ts
@@ -21,6 +21,15 @@ export interface HeartbeatView {
 
 interface ChargePointViewState {
   status: OCPPStatus;
+  /**
+   * Whether the underlying transport (WebSocket / SOAP) is up, tracked from the
+   * `connected` / `disconnected` lifecycle events. This is distinct from
+   * `status`: after an auto-reconnect the socket is up (`connected`) before
+   * BootNotification is re-Accepted, so the OCPP `status` may still read
+   * `Unavailable`. Use this for Connect/Disconnect affordances; use `status`
+   * for OCPP-readiness actions (#103).
+   */
+  connected: boolean;
   error: string;
   connectors: Map<number, ConnectorSnapshot>;
   heartbeat: HeartbeatView;
@@ -64,6 +73,7 @@ function patchConnector(
 export function useChargePointView(cpId: string | null): ChargePointViewState {
   const { chargePointService } = useDataContext();
   const [status, setStatus] = useState<OCPPStatus>(DEFAULT_STATUS);
+  const [connected, setConnected] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
   const [connectors, setConnectors] = useState<Map<number, ConnectorSnapshot>>(
     new Map(),
@@ -77,6 +87,7 @@ export function useChargePointView(cpId: string | null): ChargePointViewState {
   useEffect(() => {
     if (!cpId) {
       setStatus(DEFAULT_STATUS);
+      setConnected(false);
       setError("");
       setConnectors(new Map());
       setLogs([]);
@@ -91,12 +102,16 @@ export function useChargePointView(cpId: string | null): ChargePointViewState {
       if (cancelled) return;
       if (!snapshot) {
         setStatus(DEFAULT_STATUS);
+        setConnected(false);
         setError("");
         setConnectors(new Map());
         setHeartbeat({ intervalSeconds: 0, lastSentAt: null });
         return;
       }
       setStatus(snapshot.status);
+      // No explicit transport flag in the snapshot yet; a non-Unavailable
+      // status is the best proxy for "socket is up" on first load / resync.
+      setConnected(snapshot.status !== DEFAULT_STATUS);
       setError(snapshot.error ?? "");
       setConnectors(
         new Map(snapshot.connectors.map((c) => [c.id, c] as const)),
@@ -217,10 +232,13 @@ export function useChargePointView(cpId: string | null): ChargePointViewState {
             });
             break;
           case "connected":
-            // status is updated via separate status event; nothing else to do.
+            // Socket is up. This fires on reconnect before BootNotification is
+            // re-Accepted, so it — not `status` — is what flips the
+            // Connect/Disconnect buttons back (#103).
+            setConnected(true);
             break;
           case "disconnected":
-            // ditto — UI shows reason via status snapshot.
+            setConnected(false);
             break;
           default:
             break;
@@ -242,6 +260,7 @@ export function useChargePointView(cpId: string | null): ChargePointViewState {
 
   return {
     status,
+    connected,
     error,
     connectors: connectorsMemo,
     heartbeat,


### PR DESCRIPTION
## Problem
Issue #103: with the CSMS down and the CP auto-reconnecting, bringing the CSMS back logs **"WebSocket connected successfully"** — but the web console's **Connect button stays enabled and Disconnect stays disabled**, i.e. the UI still reads DISCONNECTED.

## Root cause
The Connect/Disconnect affordances derived "connected" from the OCPP **CP status**: `isConnected = cpStatus !== OCPPStatus.Unavailable` (`src/components/ChargePoint.tsx`). `cpStatus` only flips back to `Available` once **BootNotification is re-Accepted**, so a socket that has reconnected but not yet re-booted reads as disconnected. The transport lifecycle events that actually track the socket — `connected` / `disconnected` — were explicitly ignored by `useChargePointView` (it relied solely on `status`).

(The reconnect→reboot→status path itself is intact — verified there's no `_onOpenCallback`/outbox/boot-gate blocker and remote-mode `status_change` forwarding works; the defect is purely the UI coupling.)

## Fix
- `useChargePointView` now tracks a `connected` flag from the `connected`/`disconnected` events (seeded from the snapshot status on load) and exposes it in the view state.
- The controls derive `isConnected = connected || cpStatus !== Unavailable`: a freshly reconnected socket shows **Disconnect** immediately, while a freshly loaded, already-booted CP still reads connected. `cpStatus` continues to gate OCPP-readiness actions (Authorize, status changes).

## Verification
`tsc -b --noEmit`: no new errors. eslint + prettier clean. Full vitest: 315 passed (no regressions).

> Note: no unit test — this is UI wiring (hook event subscription + button derivation) and the repo has no React-hook test harness (no jsdom/testing-library). The root cause was independently confirmed and this fix recommended via a read-only Codex review.

Resolves #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
