### PR TITLE
fix(ev): make Default EV Settings take effect on existing connectors (#107)

### DIFF
--- a/src/data/interfaces/ChargePointService.ts
+++ b/src/data/interfaces/ChargePointService.ts
@@ -311,6 +311,14 @@ export interface ChargePointService {
     connectorId: number,
     settings: EVSettings,
   ): Promise<void>;
+  /**
+   * Push the (new) Default EV Settings onto every existing connector. New
+   * connectors already pick the default up at construction via
+   * `getDefaultEVSettings()`; this propagates a mid-session change to the
+   * connectors that are already live so the editor reflects it without a page
+   * reload (#107).
+   */
+  applyDefaultEVSettings(settings: EVSettings): Promise<void>;
   setAutoMeterValueConfig(
     id: string,
     connectorId: number,

--- a/src/data/local/LocalChargePointService.evDefaults.test.ts
+++ b/src/data/local/LocalChargePointService.evDefaults.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DefaultBootNotification } from "../../cp/domain/types/OcppTypes";
+import { LocalChargePointService } from "./LocalChargePointService";
+import type { LocalChargePointDefinition } from "./LocalChargePointService";
+import type { EVSettings } from "../../cp/domain/connector/EVSettings";
+
+function localDefinition(
+  overrides: Partial<LocalChargePointDefinition> = {},
+): LocalChargePointDefinition {
+  return {
+    id: "CP-EV",
+    connectorNumber: 2,
+    bootNotification: DefaultBootNotification,
+    wsUrl: "ws://localhost:9000/ocpp/",
+    basicAuth: null,
+    autoMeterValueSetting: null,
+    ocppVersion: "OCPP-1.6J",
+    ...overrides,
+  };
+}
+
+let service: LocalChargePointService | null = null;
+
+afterEach(async () => {
+  // Remove the CP (disconnects it + clears its reconnect timers).
+  await service?.syncLocalChargePoints([]).catch(() => undefined);
+  service = null;
+});
+
+describe("LocalChargePointService.applyDefaultEVSettings (#107)", () => {
+  it("pushes the new default onto every existing connector", async () => {
+    service = new LocalChargePointService();
+    await service.syncLocalChargePoints([
+      localDefinition({ connectorNumber: 2 }),
+    ]);
+
+    const next: EVSettings = {
+      modelName: "Nissan Leaf (40kWh)",
+      batteryCapacityKwh: 40,
+      maxChargingPowerKw: 50,
+      initialSoc: 10,
+      targetSoc: 30,
+    };
+    await service.applyDefaultEVSettings(next);
+
+    const snapshot = await service.getChargePoint("CP-EV");
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.connectors.length).toBe(2);
+    for (const connector of snapshot?.connectors ?? []) {
+      expect(connector.evSettings?.targetSoc).toBe(30);
+      expect(connector.evSettings?.batteryCapacityKwh).toBe(40);
+      expect(connector.evSettings?.initialSoc).toBe(10);
+    }
+  });
+});

--- a/src/data/local/LocalChargePointService.ts
+++ b/src/data/local/LocalChargePointService.ts
@@ -350,6 +350,19 @@ export class LocalChargePointService implements ChargePointService {
     connector.evSettings = settings;
   }
 
+  async applyDefaultEVSettings(settings: EVSettings): Promise<void> {
+    // Connectors freeze getDefaultEVSettings() at construction, so a mid-session
+    // change to the Default EV Settings wouldn't reach the ones already live.
+    // Push it onto every connector (per-connector EV settings aren't a
+    // user-editable, persisted concept — they only come from the default or a
+    // running scenario) so the editor reflects the new default immediately (#107).
+    this.chargePoints.forEach((chargePoint) => {
+      chargePoint.connectors.forEach((connector) => {
+        connector.evSettings = { ...settings };
+      });
+    });
+  }
+
   async setAutoMeterValueConfig(
     id: string,
     connectorId: number,

--- a/src/data/providers/DataProvider.tsx
+++ b/src/data/providers/DataProvider.tsx
@@ -273,6 +273,19 @@ export const DataProvider: React.FC<DataProviderProps> = ({
   const chargePointService: ChargePointService =
     remoteChargePointService ?? localChargePointService;
 
+  // Keep already-live connectors in sync with the Default EV Settings. They
+  // freeze getDefaultEVSettings() at construction, so a mid-session change
+  // would otherwise only take effect after a page reload (#107). Firing on
+  // mount too is a harmless no-op: fresh connectors already hold the default.
+  useEffect(() => {
+    if (!defaultEvSettings) return;
+    void chargePointService
+      .applyDefaultEVSettings(defaultEvSettings)
+      .catch((err) =>
+        console.error("Failed to apply default EV settings", err),
+      );
+  }, [defaultEvSettings, chargePointService]);
+
   // Wait for mode resolution (so we don't render local UI just to swap to
   // remote a moment later) AND for the DB to be ready in local mode. In
   // remote mode `dbReady` flips immediately because there's no DB to wait on.

--- a/src/data/remote/RemoteChargePointService.ts
+++ b/src/data/remote/RemoteChargePointService.ts
@@ -764,6 +764,24 @@ export class RemoteChargePointService implements ChargePointService {
     });
   }
 
+  async applyDefaultEVSettings(settings: EVSettings): Promise<void> {
+    // The daemon's connectors never see the browser-only Default EV Settings,
+    // so push it onto every connector of every known charge point (#107).
+    const cps = await this.listChargePoints().catch(() => []);
+    await Promise.all(
+      cps.flatMap((cp) =>
+        cp.connectors.map((connector) =>
+          this.setEVSettings(cp.id, connector.id, settings).catch((err) =>
+            console.warn(
+              `Failed to apply default EV settings to ${cp.id}/${connector.id}`,
+              err,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   async setAutoMeterValueConfig(
     id: string,
     connectorId: number,


### PR DESCRIPTION
## Problem
Issue #107: setting **Default EV Settings** (e.g. target SoC 30%) does not take effect — the scenario editor / connector panel still shows the built-in 80%.

## Root cause
Connectors capture `getDefaultEVSettings()` **at construction** (`Connector.ts`). Saving the Default EV Settings updates the module-level override, `localStorage`, and React state — but **not the connectors that are already live**, so they keep the value they captured. The connector panel (and the scenario EV form's placeholder) therefore keeps showing the old default until a full page reload. In **remote mode** it's worse: the daemon's connectors never see the browser-only default at all.

(There is no per-connector EV-settings editor in the UI — a connector's EV settings come only from the default at construction or from a running scenario — so propagating the default to every connector is safe.)

## Fix
- Add `ChargePointService.applyDefaultEVSettings(settings)`:
  - **Local**: iterate every connector of every charge point and set `evSettings`.
  - **Remote**: `listChargePoints()` then push to each connector via the existing `set_ev_settings` RPC.
- `DataProvider` propagates `defaultEvSettings` changes to the live connectors via an effect. New connectors continue to pick the default up at construction.

## Tests / gates
- New `LocalChargePointService.evDefaults.test.ts`: after `applyDefaultEVSettings`, every connector reflects the new targetSoc / capacity / initialSoc.
- `tsc -b --noEmit`: no new errors. eslint + prettier clean. Full vitest: 318 passed.

Resolves #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
