### PR TITLE
refactor(scenario): centralize + sanitize scenario persistence (#101-class hardening)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,6 +27,50 @@ module.exports = {
   },
   overrides: [
     {
+      files: ["src/components/**/*.{ts,tsx}"],
+      rules: {
+        "no-restricted-syntax": [
+          "error",
+          {
+            selector:
+              "CallExpression[callee.type='MemberExpression'][callee.object.name='scenarioRepository'][callee.property.name='save']",
+            message:
+              "route scenario persistence through scenarioPersistence helpers (#101 class).",
+          },
+          {
+            selector:
+              "CallExpression[callee.type='MemberExpression'][callee.object.name='scenarioRepository'][callee.property.name='load']",
+            message:
+              "route scenario persistence through scenarioPersistence helpers (#101 class).",
+          },
+          {
+            selector:
+              "CallExpression[callee.type='MemberExpression'][callee.object.name='scenarioRepository'][callee.property.name='delete']",
+            message:
+              "route scenario persistence through scenarioPersistence helpers (#101 class).",
+          },
+          {
+            selector:
+              "CallExpression[callee.type='MemberExpression'][callee.object.name='chargePointService'][callee.property.name='loadScenario']",
+            message:
+              "route scenario persistence through scenarioPersistence helpers (#101 class).",
+          },
+          {
+            selector:
+              "CallExpression[callee.type='MemberExpression'][callee.object.name='chargePointService'][callee.property.name='removeScenario']",
+            message:
+              "route scenario persistence through scenarioPersistence helpers (#101 class).",
+          },
+        ],
+      },
+    },
+    {
+      files: ["src/components/scenario/scenarioPersistence.ts"],
+      rules: {
+        "no-restricted-syntax": "off",
+      },
+    },
+    {
       files: [
         "src/components/ui/**/*.tsx",
         "src/contexts/**/*.tsx",

--- a/src/components/TopPage.tsx
+++ b/src/components/TopPage.tsx
@@ -21,6 +21,7 @@ import { useGlobalTagIds } from "../data/hooks/useGlobalTagIds";
 import type { ChargePointSnapshot } from "../data/interfaces/ChargePointService";
 import { getTemplateById } from "../utils/scenarioTemplates";
 import type { Config } from "../store/store";
+import { saveEditorScenario } from "./scenario/scenarioPersistence";
 
 const DEFAULT_TAG_ID = "TAG001";
 
@@ -300,24 +301,31 @@ const TopPage: React.FC = () => {
     };
     updateConfig(newConfig);
 
-    // Brand-new CP (not an edit): seed the Essential CP Behavior template
-    // on every connector so the editor opens with the canonical demo
-    // flow already loaded, mirroring the daemon's CPRegistry.create
-    // path. Edits intentionally skip this — operators may have already
-    // tuned the scenario and we'd clobber it.
-    if (editingIndex === null) {
+    // Brand-new local CP (not an edit): seed the Essential CP Behavior
+    // template on every connector so the editor opens with the canonical demo
+    // flow already loaded, mirroring the daemon's CPRegistry.create path.
+    // Edits intentionally skip this — operators may have already tuned the
+    // scenario and we'd clobber it.
+    if (editingIndex === null && mode === "local") {
       const essential = getTemplateById("essential-cp-behavior");
       if (essential) {
         for (let cId = 1; cId <= cpConfig.connectorNumber; cId++) {
           const seeded = essential.createScenario(cpConfig.cpId, cId);
-          void scenarioRepository
-            .save(cpConfig.cpId, cId, seeded)
-            .catch((err) =>
-              console.warn(
-                `Failed to seed Essential CP Behavior for ${cpConfig.cpId}/connector ${cId}`,
-                err,
-              ),
-            );
+          void saveEditorScenario(
+            {
+              mode,
+              chargePointService,
+              scenarioRepository,
+              cpId: cpConfig.cpId,
+              connectorId: cId,
+            },
+            seeded,
+          ).catch((err) =>
+            console.warn(
+              `Failed to seed Essential CP Behavior for ${cpConfig.cpId}/connector ${cId}`,
+              err,
+            ),
+          );
         }
       }
     }

--- a/src/components/scenario/ScenarioEditor.tsx
+++ b/src/components/scenario/ScenarioEditor.tsx
@@ -46,9 +46,12 @@ import {
   applyCurveConfigToMeterNode,
 } from "./meterValueNodeConfig";
 import {
+  createLatestWinsSaver,
   persistEditorScenario,
   retargetScenarioToConnector,
+  saveEditorScenario,
 } from "./scenarioPersistence";
+import { serializeScenarioGraph } from "./scenarioSerialize";
 import {
   type EVSettings,
   EV_PRESETS,
@@ -84,6 +87,11 @@ import {
   scenarioTemplates,
   getTemplateById,
 } from "../../utils/scenarioTemplates";
+
+type EditorScenarioSaveRequest = {
+  deps: Parameters<typeof saveEditorScenario>[0];
+  scenario: ScenarioDefinition;
+};
 
 /**
  * Minimal Start → End scenario used as the editor's fallback when no
@@ -299,6 +307,13 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
   const [historyTick, setHistoryTick] = useState(0);
   const [saveFeedback, setSaveFeedback] = useState<"idle" | "saved">("idle");
   const saveFeedbackTimerRef = useRef<number | null>(null);
+  const saveRemoteEditorScenarioLatest = useMemo(
+    () =>
+      createLatestWinsSaver<EditorScenarioSaveRequest>(({ deps, scenario }) =>
+        saveEditorScenario(deps, scenario),
+      ),
+    [],
+  );
 
   const structuralKey = useCallback((ns: Node[], es: Edge[]): string => {
     return JSON.stringify({
@@ -313,6 +328,35 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
       })),
     });
   }, []);
+
+  const saveEditorScenarioLatest = useCallback(
+    (scenarioToSave: ScenarioDefinition): Promise<void> => {
+      const deps = {
+        mode,
+        chargePointService,
+        scenarioRepository,
+        cpId,
+        connectorId,
+      };
+
+      if (mode !== "remote") {
+        return saveEditorScenario(deps, scenarioToSave);
+      }
+
+      return saveRemoteEditorScenarioLatest({
+        deps,
+        scenario: scenarioToSave,
+      });
+    },
+    [
+      mode,
+      chargePointService,
+      scenarioRepository,
+      cpId,
+      connectorId,
+      saveRemoteEditorScenarioLatest,
+    ],
+  );
 
   // Reload scenario when props change
   useEffect(() => {
@@ -707,11 +751,16 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
     };
     setScenario(updatedScenario);
     if (scenario.id) {
-      // Auto-save through the repository (upsert). Fire-and-forget; if it
-      // fails we log to console rather than block the in-flight edit.
-      void scenarioRepository
-        .save(cpId, connectorId, updatedScenario)
-        .catch((err) => console.error("Failed to autosave scenario", err));
+      const serializedGraph = serializeScenarioGraph(nodes, cleanedEdges);
+      const scenarioToSave: ScenarioDefinition = {
+        ...updatedScenario,
+        ...serializedGraph,
+      };
+      // Auto-save through the mode-aware upsert boundary. Fire-and-forget; if
+      // it fails we log to console rather than block the in-flight edit.
+      void saveEditorScenarioLatest(scenarioToSave).catch((err) =>
+        console.error("Failed to autosave scenario", err),
+      );
     }
 
     // Keep ScenarioManager in sync while editing (local mode only).
@@ -823,19 +872,14 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
       updatedAt: new Date().toISOString(),
     };
     if (scenario.id) {
-      // Remote mode talks to the daemon (the browser-side sql.js path is
-      // a no-op there). Local mode keeps the sql.js path.
-      if (mode === "remote") {
-        void chargePointService
-          .loadScenario(cpId, connectorId, updated)
-          .catch((err) =>
-            console.error("Failed to save scenario to daemon", err),
-          );
-      } else {
-        void scenarioRepository
-          .save(cpId, connectorId, updated)
-          .catch((err) => console.error("Failed to save scenario", err));
-      }
+      const serializedGraph = serializeScenarioGraph(nodes, edges);
+      const scenarioToSave: ScenarioDefinition = {
+        ...updated,
+        ...serializedGraph,
+      };
+      void saveEditorScenarioLatest(scenarioToSave).catch((err) =>
+        console.error("Failed to save scenario", err),
+      );
     }
     setScenario(updated);
     setSaveFeedback("saved");
@@ -855,11 +899,7 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
     defaultExecutionMode,
     scenarioEnabled,
     scenarioEvSettings,
-    cpId,
-    connectorId,
-    mode,
-    chargePointService,
-    scenarioRepository,
+    saveEditorScenarioLatest,
   ]);
 
   // Keyboard shortcuts for undo / redo (Cmd/Ctrl+Z, Cmd/Ctrl+Shift+Z, Cmd/Ctrl+Y).
@@ -1094,10 +1134,10 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
 
   // File operations
   const handleExport = useCallback(() => {
+    const serializedGraph = serializeScenarioGraph(nodes, edges);
     const currentScenario: ScenarioDefinition = {
       ...scenario,
-      nodes,
-      edges,
+      ...serializedGraph,
     };
     exportScenarioToJSON(currentScenario);
   }, [scenario, nodes, edges]);
@@ -1122,23 +1162,33 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
           connectorId,
           new Date().toISOString(),
         );
-        setScenario(targeted);
-        setNodes(targeted.nodes);
-        setEdges(targeted.edges);
+        const serializedGraph = serializeScenarioGraph(
+          targeted.nodes,
+          targeted.edges,
+        );
+        const scenarioToPersist: ScenarioDefinition = {
+          ...targeted,
+          ...serializedGraph,
+        };
+        setScenario(scenarioToPersist);
+        setNodes(scenarioToPersist.nodes);
+        setEdges(scenarioToPersist.edges);
         // Mirror the props-reload effect so the metadata fields reflect the
         // uploaded scenario instead of the previously-open one.
-        setScenarioName(targeted.name);
-        setScenarioDescription(targeted.description || "");
-        setDefaultExecutionMode(targeted.defaultExecutionMode || "oneshot");
-        setScenarioEnabled(targeted.enabled !== false);
-        setScenarioEvSettings(targeted.evSettings ?? {});
+        setScenarioName(scenarioToPersist.name);
+        setScenarioDescription(scenarioToPersist.description || "");
+        setDefaultExecutionMode(
+          scenarioToPersist.defaultExecutionMode || "oneshot",
+        );
+        setScenarioEnabled(scenarioToPersist.enabled !== false);
+        setScenarioEvSettings(scenarioToPersist.evSettings ?? {});
 
         // Persist mode-aware: in remote mode the browser sql.js repository is a
         // no-op, so the upload has to be pushed to the daemon (and prior
         // scenarios cleaned up) or it's silently lost on reload (#101).
         await persistEditorScenario(
           { mode, chargePointService, scenarioRepository, cpId, connectorId },
-          targeted,
+          scenarioToPersist,
         );
       } catch (error) {
         alert(`Failed to import scenario: ${error}`);
@@ -1170,7 +1220,15 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
         return;
       }
 
-      const templateScenario = template.createScenario(cpId, connectorId);
+      const targeted = template.createScenario(cpId, connectorId);
+      const serializedGraph = serializeScenarioGraph(
+        targeted.nodes,
+        targeted.edges,
+      );
+      const templateScenario: ScenarioDefinition = {
+        ...targeted,
+        ...serializedGraph,
+      };
       setScenario(templateScenario);
       setNodes(templateScenario.nodes);
       setEdges(templateScenario.edges);

--- a/src/components/scenario/__tests__/scenarioPersistence.test.ts
+++ b/src/components/scenario/__tests__/scenarioPersistence.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  createLatestWinsSaver,
   persistEditorScenario,
   retargetScenarioToConnector,
+  saveEditorScenario,
 } from "../scenarioPersistence";
 import type { ScenarioDefinition } from "../../../cp/application/scenario/ScenarioTypes";
 
@@ -22,6 +24,26 @@ function makeService(existingIds: string[] = []) {
     removeScenario: vi.fn().mockResolvedValue(undefined),
     loadScenario: vi.fn().mockResolvedValue({ scenarioId: "x" }),
   };
+}
+
+type Deferred = {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: Error) => void;
+};
+
+function deferred(): Deferred {
+  const value = {} as Deferred;
+  value.promise = new Promise<void>((resolve, reject) => {
+    value.resolve = () => resolve();
+    value.reject = (error: Error) => reject(error);
+  });
+  return value;
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe("persistEditorScenario (scenario upload / template persistence — #101)", () => {
@@ -49,6 +71,65 @@ describe("persistEditorScenario (scenario upload / template persistence — #101
       uploaded,
     );
     expect(scenarioRepository.save).not.toHaveBeenCalled();
+  });
+
+  it("serializes the graph before remote persistence", async () => {
+    const chargePointService = makeService([]);
+    const scenarioRepository = { save: vi.fn().mockResolvedValue(undefined) };
+    const uploaded = {
+      ...scenario("new-1"),
+      nodes: [
+        {
+          id: "meter-1",
+          type: "meterValue",
+          position: { x: 10, y: 20 },
+          data: {
+            label: "Meter",
+            value: 10,
+            sendMessage: true,
+            progress: { remaining: 1 },
+            currentValue: 20,
+            style: { border: "1px solid red" },
+            className: "executing-node",
+          },
+          selected: true,
+          dragging: true,
+        },
+      ],
+      edges: [
+        {
+          id: "edge-1",
+          source: "start",
+          target: "meter-1",
+          selected: true,
+          style: { stroke: "red" },
+        },
+      ],
+    } as unknown as ScenarioDefinition;
+
+    await persistEditorScenario(
+      {
+        mode: "remote",
+        chargePointService,
+        scenarioRepository,
+        cpId: "CP1",
+        connectorId: 1,
+      },
+      uploaded,
+    );
+
+    const persisted = chargePointService.loadScenario.mock.calls[0][2];
+    expect(persisted.nodes[0]).not.toHaveProperty("selected");
+    expect(persisted.nodes[0]).not.toHaveProperty("dragging");
+    expect(persisted.nodes[0].data).not.toHaveProperty("progress");
+    expect(persisted.nodes[0].data).not.toHaveProperty("currentValue");
+    expect(persisted.nodes[0].data).not.toHaveProperty("style");
+    expect(persisted.nodes[0].data).not.toHaveProperty("className");
+    expect(persisted.edges[0]).toEqual({
+      id: "edge-1",
+      source: "start",
+      target: "meter-1",
+    });
   });
 
   it("remote mode removes stale prior scenarios but keeps the one being saved", async () => {
@@ -131,6 +212,148 @@ describe("persistEditorScenario (scenario upload / template persistence — #101
     expect(chargePointService.listScenarios).not.toHaveBeenCalled();
     expect(chargePointService.removeScenario).not.toHaveBeenCalled();
     expect(chargePointService.loadScenario).not.toHaveBeenCalled();
+  });
+});
+
+describe("saveEditorScenario (editor autosave / manual save upsert)", () => {
+  it("remote mode upserts through daemon loadScenario without pruning siblings", async () => {
+    const chargePointService = makeService(["old-a"]);
+    const scenarioRepository = { save: vi.fn().mockResolvedValue(undefined) };
+    const edited = scenario("edited-1");
+
+    await saveEditorScenario(
+      {
+        mode: "remote",
+        chargePointService,
+        scenarioRepository,
+        cpId: "CP1",
+        connectorId: 1,
+      },
+      edited,
+    );
+
+    expect(chargePointService.loadScenario).toHaveBeenCalledWith(
+      "CP1",
+      1,
+      edited,
+    );
+    expect(chargePointService.listScenarios).not.toHaveBeenCalled();
+    expect(chargePointService.removeScenario).not.toHaveBeenCalled();
+    expect(scenarioRepository.save).not.toHaveBeenCalled();
+  });
+
+  it("local mode upserts through the repository without touching daemon scenario APIs", async () => {
+    const chargePointService = makeService(["old-a"]);
+    const scenarioRepository = { save: vi.fn().mockResolvedValue(undefined) };
+    const edited = scenario("edited-1");
+
+    await saveEditorScenario(
+      {
+        mode: "local",
+        chargePointService,
+        scenarioRepository,
+        cpId: "CP1",
+        connectorId: 1,
+      },
+      edited,
+    );
+
+    expect(scenarioRepository.save).toHaveBeenCalledWith("CP1", 1, edited);
+    expect(chargePointService.listScenarios).not.toHaveBeenCalled();
+    expect(chargePointService.removeScenario).not.toHaveBeenCalled();
+    expect(chargePointService.loadScenario).not.toHaveBeenCalled();
+  });
+});
+
+describe("createLatestWinsSaver", () => {
+  it("saves a queued newer payload after the in-flight save", async () => {
+    const gates: Deferred[] = [];
+    const persisted: string[] = [];
+    const saveFn = vi.fn((payload: string) => {
+      const gate = deferred();
+      gates.push(gate);
+      return gate.promise.then(() => {
+        persisted.push(payload);
+      });
+    });
+    const saveLatest = createLatestWinsSaver(saveFn);
+
+    const saveA = saveLatest("A");
+    await flushPromises();
+    expect(saveFn).toHaveBeenCalledTimes(1);
+    expect(saveFn).toHaveBeenLastCalledWith("A");
+
+    const saveB = saveLatest("B");
+    expect(saveFn).toHaveBeenCalledTimes(1);
+
+    gates[0].resolve();
+    await saveA;
+    await flushPromises();
+    expect(saveFn).toHaveBeenCalledTimes(2);
+    expect(saveFn).toHaveBeenLastCalledWith("B");
+
+    gates[1].resolve();
+    await saveB;
+    expect(persisted).toEqual(["A", "B"]);
+  });
+
+  it("lets an even newer queued save supersede an older queued save", async () => {
+    const gates: Deferred[] = [];
+    const persisted: string[] = [];
+    const saveFn = vi.fn((payload: string) => {
+      const gate = deferred();
+      gates.push(gate);
+      return gate.promise.then(() => {
+        persisted.push(payload);
+      });
+    });
+    const saveLatest = createLatestWinsSaver(saveFn);
+
+    const saveA = saveLatest("A");
+    await flushPromises();
+    const saveB = saveLatest("B");
+    const saveC = saveLatest("C");
+
+    gates[0].resolve();
+    await saveA;
+    await saveB;
+    await flushPromises();
+
+    expect(saveFn).toHaveBeenCalledTimes(2);
+    expect(saveFn).toHaveBeenNthCalledWith(1, "A");
+    expect(saveFn).toHaveBeenNthCalledWith(2, "C");
+    expect(saveFn).not.toHaveBeenCalledWith("B");
+
+    gates[1].resolve();
+    await saveC;
+    expect(persisted).toEqual(["A", "C"]);
+  });
+
+  it("continues with the latest queued save after an in-flight failure", async () => {
+    const gates: Deferred[] = [];
+    const persisted: string[] = [];
+    const saveFn = vi.fn((payload: string) => {
+      const gate = deferred();
+      gates.push(gate);
+      return gate.promise.then(() => {
+        persisted.push(payload);
+      });
+    });
+    const saveLatest = createLatestWinsSaver(saveFn);
+
+    const saveA = saveLatest("A");
+    await flushPromises();
+    const saveB = saveLatest("B");
+
+    gates[0].reject(new Error("A failed"));
+    await expect(saveA).rejects.toThrow("A failed");
+    await flushPromises();
+    expect(saveFn).toHaveBeenCalledTimes(2);
+    expect(saveFn).toHaveBeenLastCalledWith("B");
+
+    gates[1].resolve();
+    await saveB;
+    expect(persisted).toEqual(["B"]);
   });
 });
 

--- a/src/components/scenario/__tests__/scenarioSerialize.test.ts
+++ b/src/components/scenario/__tests__/scenarioSerialize.test.ts
@@ -1,0 +1,74 @@
+import type { Edge, Node } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+import { ScenarioNodeType } from "../../../cp/application/scenario/ScenarioTypes";
+import { serializeScenarioGraph } from "../scenarioSerialize";
+
+describe("serializeScenarioGraph", () => {
+  it("strips runtime overlays while preserving scenario graph data", () => {
+    const nodes = [
+      {
+        id: "meter-1",
+        type: ScenarioNodeType.METER_VALUE,
+        position: { x: 120, y: 240 },
+        data: {
+          label: "Meter value",
+          value: 1500,
+          sendMessage: true,
+          progress: { remaining: 1, total: 5 },
+          currentValue: 3000,
+          style: { border: "3px solid #10b981" },
+          className: "executing-node",
+        },
+        selected: true,
+        dragging: true,
+        style: { border: "3px solid #10b981" },
+        className: "executing-node",
+        width: 180,
+        height: 90,
+        measured: { width: 180, height: 90 },
+        positionAbsolute: { x: 120, y: 240 },
+      },
+    ] as unknown as Node[];
+    const edges = [
+      {
+        id: "edge-1",
+        source: "start",
+        target: "meter-1",
+        selected: true,
+        style: { stroke: "#10b981" },
+      },
+    ] as unknown as Edge[];
+
+    const serialized = serializeScenarioGraph(nodes, edges);
+
+    expect(serialized.nodes[0]).toEqual({
+      id: "meter-1",
+      type: ScenarioNodeType.METER_VALUE,
+      position: { x: 120, y: 240 },
+      data: {
+        label: "Meter value",
+        value: 1500,
+        sendMessage: true,
+      },
+    });
+    expect(serialized.nodes[0]).not.toHaveProperty("selected");
+    expect(serialized.nodes[0]).not.toHaveProperty("dragging");
+    expect(serialized.nodes[0]).not.toHaveProperty("style");
+    expect(serialized.nodes[0]).not.toHaveProperty("className");
+    expect(serialized.nodes[0]).not.toHaveProperty("width");
+    expect(serialized.nodes[0]).not.toHaveProperty("height");
+    expect(serialized.nodes[0]).not.toHaveProperty("measured");
+    expect(serialized.nodes[0]).not.toHaveProperty("positionAbsolute");
+    expect(serialized.nodes[0].data).not.toHaveProperty("progress");
+    expect(serialized.nodes[0].data).not.toHaveProperty("currentValue");
+    expect(serialized.nodes[0].data).not.toHaveProperty("style");
+    expect(serialized.nodes[0].data).not.toHaveProperty("className");
+    expect(serialized.edges[0]).toEqual({
+      id: "edge-1",
+      source: "start",
+      target: "meter-1",
+    });
+    expect(serialized.nodes[0]).not.toBe(nodes[0]);
+    expect(serialized.nodes[0].position).not.toBe(nodes[0].position);
+  });
+});

--- a/src/components/scenario/scenarioPersistence.ts
+++ b/src/components/scenario/scenarioPersistence.ts
@@ -1,6 +1,7 @@
 import type { ScenarioDefinition } from "../../cp/application/scenario/ScenarioTypes";
 import type { ChargePointService } from "../../data/interfaces/ChargePointService";
 import type { ScenarioRepository } from "../../cp/domain/persistence/ScenarioRepository";
+import { serializeScenarioGraph } from "./scenarioSerialize";
 
 /**
  * Dependencies needed to durably persist a scenario the user just loaded into
@@ -17,6 +18,34 @@ export interface PersistEditorScenarioDeps {
   scenarioRepository: Pick<ScenarioRepository, "save">;
   cpId: string;
   connectorId: number | null;
+}
+
+export function createLatestWinsSaver<T>(
+  saveFn: (payload: T) => Promise<void>,
+): (payload: T) => Promise<void> {
+  let latestSeq = 0;
+  let tail: Promise<void> = Promise.resolve();
+
+  return (payload: T): Promise<void> => {
+    const seq = ++latestSeq;
+    const next = tail
+      .catch(() => undefined)
+      .then(async () => {
+        if (seq !== latestSeq) return;
+        await saveFn(payload);
+      });
+    tail = next;
+    return next;
+  };
+}
+
+function serializeScenarioForPersistence(
+  scenario: ScenarioDefinition,
+): ScenarioDefinition {
+  return {
+    ...scenario,
+    ...serializeScenarioGraph(scenario.nodes, scenario.edges),
+  };
 }
 
 /**
@@ -43,6 +72,7 @@ export async function persistEditorScenario(
 ): Promise<void> {
   const { mode, chargePointService, scenarioRepository, cpId, connectorId } =
     deps;
+  const scenarioToPersist = serializeScenarioForPersistence(scenario);
 
   if (mode === "remote") {
     // The daemon's scenario RPCs are connector-scoped and require a positive
@@ -55,7 +85,7 @@ export async function persistEditorScenario(
     );
     await Promise.all(
       existing
-        .filter((item) => item.scenarioId !== scenario.id)
+        .filter((item) => item.scenarioId !== scenarioToPersist.id)
         .map((item) =>
           chargePointService
             .removeScenario(cpId, remoteConnectorId, item.scenarioId)
@@ -67,11 +97,42 @@ export async function persistEditorScenario(
             ),
         ),
     );
-    await chargePointService.loadScenario(cpId, remoteConnectorId, scenario);
+    await chargePointService.loadScenario(
+      cpId,
+      remoteConnectorId,
+      scenarioToPersist,
+    );
     return;
   }
 
-  await scenarioRepository.save(cpId, connectorId, scenario);
+  await scenarioRepository.save(cpId, connectorId, scenarioToPersist);
+}
+
+/**
+ * Mode-aware upsert for the scenario currently being edited. Unlike
+ * `persistEditorScenario`, this deliberately does not prune sibling daemon
+ * scenarios: autosave/manual-save are updates to the open scenario, not a
+ * replacement import/template operation.
+ */
+export async function saveEditorScenario(
+  deps: PersistEditorScenarioDeps,
+  scenario: ScenarioDefinition,
+): Promise<void> {
+  const { mode, chargePointService, scenarioRepository, cpId, connectorId } =
+    deps;
+  const scenarioToPersist = serializeScenarioForPersistence(scenario);
+
+  if (mode === "remote") {
+    const remoteConnectorId = connectorId as number;
+    await chargePointService.loadScenario(
+      cpId,
+      remoteConnectorId,
+      scenarioToPersist,
+    );
+    return;
+  }
+
+  await scenarioRepository.save(cpId, connectorId, scenarioToPersist);
 }
 
 /**

--- a/src/components/scenario/scenarioSerialize.ts
+++ b/src/components/scenario/scenarioSerialize.ts
@@ -1,0 +1,79 @@
+import type { Edge } from "@xyflow/react";
+import type {
+  ScenarioDefinition,
+  ScenarioNode,
+} from "../../cp/application/scenario/ScenarioTypes";
+
+const RUNTIME_NODE_DATA_KEYS = new Set([
+  "progress",
+  "currentValue",
+  "style",
+  "className",
+]);
+
+const RUNTIME_EDGE_KEYS = new Set([
+  "selected",
+  "style",
+  "className",
+  "interactionWidth",
+  "ariaLabel",
+  "domAttributes",
+]);
+
+function deepClone<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => deepClone(item)) as T;
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, deepClone(child)]),
+    ) as T;
+  }
+
+  return value;
+}
+
+type SerializableNode = {
+  id: string;
+  type?: string;
+  position: { x: number; y: number };
+  data: object;
+};
+
+function serializeNodeData(
+  data: SerializableNode["data"],
+): ScenarioNode["data"] {
+  return Object.fromEntries(
+    Object.entries(data).flatMap(([key, value]) =>
+      RUNTIME_NODE_DATA_KEYS.has(key) ? [] : [[key, deepClone(value)]],
+    ),
+  ) as unknown as ScenarioNode["data"];
+}
+
+function serializeNode(node: SerializableNode): ScenarioNode {
+  return {
+    id: node.id,
+    type: node.type,
+    position: deepClone(node.position),
+    data: serializeNodeData(node.data),
+  } as ScenarioNode;
+}
+
+function serializeEdge(edge: Edge): Edge {
+  return Object.fromEntries(
+    Object.entries(edge).flatMap(([key, value]) =>
+      RUNTIME_EDGE_KEYS.has(key) ? [] : [[key, deepClone(value)]],
+    ),
+  ) as Edge;
+}
+
+export function serializeScenarioGraph(
+  nodes: readonly SerializableNode[],
+  edges: readonly Edge[],
+): Pick<ScenarioDefinition, "nodes" | "edges"> {
+  return {
+    nodes: nodes.map(serializeNode),
+    edges: edges.map(serializeEdge),
+  };
+}


### PR DESCRIPTION
Part of a comprehensive scenario-editor quality pass to stop the recent UI bug *classes* from recurring. This branch hardens **scenario persistence**.

## Problems rooted out
- **Autosave silent data loss in remote mode** — the autosave effect called `scenarioRepository.save` directly, which is a no-op in remote (daemon) mode, so edits vanished on reload. Same class as #101, but worse: no explicit user action.
- **Runtime state contaminating persisted data** — execution `progress`, highlight `style`/`className`, and live meter `currentValue` were written into `node.data` and then autosaved/exported, polluting the persisted source of truth.
- **Duplicated, mode-unaware save paths** — autosave/manual reimplemented the mode check instead of going through a single helper.

## Fix
- `serializeScenarioGraph` strips runtime/display overlays; the persistence helpers sanitize **at the boundary**, so no save/export path can persist them (the in-memory graph keeps overlays for display).
- `saveEditorScenario` = mode-aware **upsert (no prune)** for autosave + manual save; `persistEditorScenario` (prune) stays for import/template. Remote autosave runs through `createLatestWinsSaver` so a stale in-flight save can't clobber a newer one. Autosave fire timing is unchanged (same debounce/structural-key).
- All component save paths route through the helpers; an **ESLint denylist** forbids raw `scenarioRepository.save/load/delete` and `chargePointService.loadScenario/removeScenario` outside the helper, so the class can't silently return.

## Tests / gates
- New `scenarioSerialize.test.ts` (overlays never persist; real data/position preserved) + extended `scenarioPersistence.test.ts` (`saveEditorScenario` upsert-no-prune; latest-wins ordering). Full vitest **325 passed**. `tsc -b` no new errors. eslint clean.
- Codex-reviewed (blocker-free). Accepted limitation: the ESLint denylist catches direct calls, not aliased/destructured variants (guardrail, not a wall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
