### PR TITLE
fix(release): stamp the release version into the web bundle for Docker and desktop builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,6 +52,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Only tag-triggered semver releases get stamped; branch builds stay
+      # 0.0.0 (web console footer hides the version). The build context is
+      # the checkout, so the Dockerfile's UI stage picks up the stamped
+      # package.json and Vite bakes the version into the bundle (issue #93).
+      - name: Setup Node (for version stamping)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Resolve version
+        id: version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp package version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: npm version --no-git-tag-version --allow-same-version "${{ steps.version.outputs.version }}"
+
       - name: Compute image tags
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,23 @@ jobs:
           cd src-tauri
           npx @tauri-apps/cli icon icons/icon.svg
 
+      # Only tag-triggered semver releases get stamped; branch builds stay
+      # 0.0.0. tauri-action's beforeBuildCommand runs the Vite build, which
+      # bakes package.json's version into the web console footer, so the
+      # stamp must land before the Tauri build step.
+      - name: Resolve version
+        id: version
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp package version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: npm version --no-git-tag-version --allow-same-version "${{ steps.version.outputs.version }}"
+
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0
         env:


### PR DESCRIPTION
## Problem

Issue #93 follow-up: the web console footer added in #96 hides the version in every published build. `__APP_VERSION__` is filled from `package.json` at Vite build time, and `package.json` is permanently `0.0.0` — the CLI release workflow stamps it before building, but `docker-publish.yml` and `release.yml` never did. So ghcr images (e.g. `0.5.2`) and tagged desktop builds ship a web bundle stamped `0.0.0` and the footer renders without a version.

## Fix

- **docker-publish.yml**: for `v*` tag builds, resolve the version from the tag and run `npm version --no-git-tag-version --allow-same-version` before `docker/build-push-action` (mirrors `cli-release.yml`). The build context picks up the stamped `package.json` automatically.
- **release.yml**: same tag-gated stamping immediately before the Tauri build, whose `beforeBuildCommand` runs the identical Vite build. The version-resolve step sets `shell: bash` for the `windows-latest` matrix leg.
- Non-tag builds intentionally keep `0.0.0`, so the footer stays hidden for unstamped dev builds (current behavior).

## Verification

- Both workflows parse cleanly; the stamp command was exercised locally against `package.json`.
- Gates: eslint clean, vitest 399 passed, bun test 108 passed.
- Repo `package.json` itself is untouched — stamping happens only in CI.

Closes #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)