### PR TITLE
feat(scenarios): built-in OCPP 1.6 Core certification scenarios (first slice)

### DIFF
--- a/src/cp/application/scenario/__tests__/cert16RemoteStart.test.ts
+++ b/src/cp/application/scenario/__tests__/cert16RemoteStart.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { ScenarioExecutor } from "../ScenarioExecutor";
+import { createScenarioExecutorCallbacks } from "../ScenarioRuntime";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import {
+  DefaultBootNotification,
+  OCPPStatus,
+} from "../../../domain/types/OcppTypes";
+import { getTemplateById } from "../../../../utils/scenarioTemplates";
+
+function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+async function waitUntil(predicate: () => boolean, ms = 500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > ms) {
+      throw new Error("Timed out waiting for predicate");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function newChargePoint(id: string): ChargePoint {
+  // wsUrl points at an unused local port — no real transport connection is
+  // ever attempted in this test, matching the pattern used by
+  // ScenarioLifecycle.wave1.test.ts / ScenarioExecutor.nodes.test.ts.
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    "ws://127.0.0.1:9/",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  return cp;
+}
+
+describe("cert16-tc010-remote-start (built-in certification template)", () => {
+  it("parks on RemoteStartTransaction, then runs Preparing → StartTransaction → Charging → bounded auto-meter", async () => {
+    const template = getTemplateById("cert16-tc010-remote-start");
+    expect(template).toBeDefined();
+
+    const cp = newChargePoint("CP-CERT-TC010");
+    const connector = cp.getConnector(1);
+    expect(connector).toBeDefined();
+
+    const scenario = template!.createScenario("CP-CERT-TC010", 1);
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector: connector!,
+    });
+    const executor = new ScenarioExecutor(scenario, callbacks);
+    const execution = executor.start();
+
+    try {
+      // Scenario is parked on the RemoteStartTrigger node waiting for the
+      // CSMS's RemoteStartTransaction.req.
+      await waitUntil(() => cp.isScenarioHandled(1));
+      expect(connector!.transaction).toBeNull();
+
+      // Simulate the CSMS issuing RemoteStartTransaction.req — the same
+      // entry point the real RemoteStartTransaction handler uses.
+      cp.notifyRemoteStartReceived(1, "CERT010-LIVE-TAG");
+
+      await waitUntil(() => connector!.status === OCPPStatus.Charging);
+
+      // StartTransaction.req used the tagId captured from the
+      // RemoteStartTransaction.req, not the node's fallback tagId.
+      expect(connector!.transaction?.tagId).toBe("CERT010-LIVE-TAG");
+      // The bounded auto-meter (meter-auto node) is running in the
+      // background; the scenario is parked inside that node's wait.
+      await waitUntil(() => connector!.isAutoMeterValueActive());
+    } finally {
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      ).catch(() => undefined);
+    }
+  });
+});

--- a/src/utils/scenarioTemplates.test.ts
+++ b/src/utils/scenarioTemplates.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { scenarioTemplates } from "./scenarioTemplates";
+import {
+  isScenarioDefinitionShape,
+  ScenarioNodeType,
+  type ScenarioDefinition,
+} from "../cp/application/scenario/ScenarioTypes";
+
+const KNOWN_NODE_TYPES = new Set<string>(Object.values(ScenarioNodeType));
+
+/**
+ * Every OCPP 1.6 Core certification scenario the brief for issue #110's
+ * first slice asks for. Fails loudly (rather than just "some templates
+ * exist") until each one is authored and registered.
+ */
+const EXPECTED_CERT16_IDS = [
+  "cert16-tc001-cold-boot",
+  "cert16-tc003-charging-plugin-first",
+  "cert16-tc004-charging-id-first",
+  "cert16-tc010-remote-start",
+  "cert16-tc011-remote-start-stop",
+  "cert16-tc012-remote-stop",
+  "cert16-tc017-unlock-occupied",
+  "cert16-tc018-unlock-failure",
+  "cert16-reservation-basic",
+];
+
+/** BFS from the single start node; true if any END node is reachable. */
+function canReachEndNode(scenario: ScenarioDefinition): boolean {
+  const startNode = scenario.nodes.find(
+    (n) => n.type === ScenarioNodeType.START,
+  );
+  if (!startNode) return false;
+
+  const nodeById = new Map(scenario.nodes.map((n) => [n.id, n]));
+  const targetsBySource = new Map<string, string[]>();
+  for (const edge of scenario.edges) {
+    const list = targetsBySource.get(edge.source) ?? [];
+    list.push(edge.target);
+    targetsBySource.set(edge.source, list);
+  }
+
+  const visited = new Set<string>();
+  const queue: string[] = [startNode.id];
+  while (queue.length > 0) {
+    const currentId = queue.shift()!;
+    if (visited.has(currentId)) continue;
+    visited.add(currentId);
+
+    const node = nodeById.get(currentId);
+    if (node?.type === ScenarioNodeType.END) return true;
+
+    for (const nextId of targetsBySource.get(currentId) ?? []) {
+      if (!visited.has(nextId)) queue.push(nextId);
+    }
+  }
+  return false;
+}
+
+describe("scenarioTemplates registry", () => {
+  it("has unique template ids", () => {
+    const ids = scenarioTemplates.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("registers every cert16 Core certification scenario from the brief", () => {
+    const ids = scenarioTemplates.map((t) => t.id);
+    for (const expectedId of EXPECTED_CERT16_IDS) {
+      expect(ids).toContain(expectedId);
+    }
+  });
+
+  for (const template of scenarioTemplates) {
+    describe(`template: ${template.id}`, () => {
+      const scenario = template.createScenario("CP-TEST", 1);
+
+      it("instantiates via createScenario() into a valid ScenarioDefinition shape", () => {
+        expect(isScenarioDefinitionShape(scenario)).toBe(true);
+      });
+
+      it("uses only known ScenarioNodeType values", () => {
+        for (const node of scenario.nodes) {
+          expect(KNOWN_NODE_TYPES.has(node.type as string)).toBe(true);
+        }
+      });
+
+      it("has edges that only reference existing node ids", () => {
+        const nodeIds = new Set(scenario.nodes.map((n) => n.id));
+        for (const edge of scenario.edges) {
+          expect(nodeIds.has(edge.source)).toBe(true);
+          expect(nodeIds.has(edge.target)).toBe(true);
+        }
+      });
+
+      it("has exactly one start node", () => {
+        const startNodes = scenario.nodes.filter(
+          (n) => n.type === ScenarioNodeType.START,
+        );
+        expect(startNodes).toHaveLength(1);
+      });
+
+      // Certification scenarios (this task's deliverable) must always be
+      // able to walk to completion — a cert run has to finish so the
+      // operator/CSMS log shows a bounded pass/fail. Pre-existing
+      // non-cert templates aren't held to this: e.g.
+      // status-triggered-actions is an intentional Heartbeat loop with
+      // an unreachable End node left over from the editor, stopped via
+      // the Stop button rather than by walking to completion — a
+      // pre-existing quirk out of scope for this change.
+      if (template.id.startsWith("cert16-")) {
+        it("can reach an end node by walking edges from start", () => {
+          expect(canReachEndNode(scenario)).toBe(true);
+        });
+      }
+    });
+  }
+});

--- a/src/utils/scenarioTemplates.ts
+++ b/src/utils/scenarioTemplates.ts
@@ -7,6 +7,18 @@ import multiStatusMonitorJson from "./scenarios/multi-status-monitor.json";
 import statusTriggeredActionsJson from "./scenarios/status-triggered-actions.json";
 import remoteStartAutoMeterJson from "./scenarios/remote-start-auto-meter.json";
 
+// OCPP 1.6 Core certification scenarios (issue #110, first slice). TC
+// numbers follow the issue's own numbering, not an external test suite.
+import cert16Tc001ColdBootJson from "./scenarios/cert16-tc001-cold-boot.json";
+import cert16Tc003ChargingPluginFirstJson from "./scenarios/cert16-tc003-charging-plugin-first.json";
+import cert16Tc004ChargingIdFirstJson from "./scenarios/cert16-tc004-charging-id-first.json";
+import cert16Tc010RemoteStartJson from "./scenarios/cert16-tc010-remote-start.json";
+import cert16Tc011RemoteStartStopJson from "./scenarios/cert16-tc011-remote-start-stop.json";
+import cert16Tc012RemoteStopJson from "./scenarios/cert16-tc012-remote-stop.json";
+import cert16Tc017UnlockOccupiedJson from "./scenarios/cert16-tc017-unlock-occupied.json";
+import cert16Tc018UnlockFailureJson from "./scenarios/cert16-tc018-unlock-failure.json";
+import cert16ReservationBasicJson from "./scenarios/cert16-reservation-basic.json";
+
 export interface ScenarioTemplate {
   id: string;
   name: string;
@@ -73,6 +85,18 @@ export const scenarioTemplates: ScenarioTemplate[] = [
   templateFromJson(multiStatusMonitorJson as ScenarioDefinition),
   templateFromJson(statusTriggeredActionsJson as ScenarioDefinition),
   templateFromJson(remoteStartAutoMeterJson as ScenarioDefinition),
+
+  // OCPP 1.6 Core certification scenarios (issue #110, first slice) —
+  // grouped together so they surface as a block in the template picker.
+  templateFromJson(cert16Tc001ColdBootJson as ScenarioDefinition),
+  templateFromJson(cert16Tc003ChargingPluginFirstJson as ScenarioDefinition),
+  templateFromJson(cert16Tc004ChargingIdFirstJson as ScenarioDefinition),
+  templateFromJson(cert16Tc010RemoteStartJson as ScenarioDefinition),
+  templateFromJson(cert16Tc011RemoteStartStopJson as ScenarioDefinition),
+  templateFromJson(cert16Tc012RemoteStopJson as ScenarioDefinition),
+  templateFromJson(cert16Tc017UnlockOccupiedJson as ScenarioDefinition),
+  templateFromJson(cert16Tc018UnlockFailureJson as ScenarioDefinition),
+  templateFromJson(cert16ReservationBasicJson as ScenarioDefinition),
 ];
 
 export function getTemplateById(

--- a/src/utils/scenarios/cert16-reservation-basic.json
+++ b/src/utils/scenarios/cert16-reservation-basic.json
@@ -1,0 +1,114 @@
+{
+  "id": "cert16-reservation-basic",
+  "name": "Cert 1.6 Core: Reservation (Basic)",
+  "description": "Parks waiting for ReserveNow.req (connector goes Reserved internally on Accepted); once the reserved idTag is presented, StatusNotification(Preparing) → StartTransaction.req (carries the reservationId) → StatusNotification(Charging) with bounded MeterValue.req → StopTransaction.req → StatusNotification(Finishing) → StatusNotification(Available).",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "trigger-reservation",
+      "type": "reservationTrigger",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Wait for ReserveNow", "timeout": 0 }
+    },
+    {
+      "id": "status-reserved",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 250 },
+      "data": { "label": "Set Reserved", "status": "Reserved" }
+    },
+    {
+      "id": "delay-arrival",
+      "type": "delay",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Reserved idTag arrives", "delaySeconds": 2 }
+    },
+    {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 450 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 550 },
+      "data": {
+        "label": "Start Transaction",
+        "action": "start",
+        "tagId": "CERT-RES01"
+      }
+    },
+    {
+      "id": "status-charging",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 650 },
+      "data": { "label": "Set Charging", "status": "Charging" }
+    },
+    {
+      "id": "meter-auto",
+      "type": "meterValue",
+      "position": { "x": 400, "y": 750 },
+      "data": {
+        "label": "Bounded Auto MeterValue",
+        "value": 0,
+        "sendMessage": true,
+        "autoIncrement": true,
+        "incrementInterval": 5,
+        "incrementAmount": 500,
+        "maxTime": 30,
+        "maxValue": 0
+      }
+    },
+    {
+      "id": "tx-stop",
+      "type": "transaction",
+      "position": { "x": 400, "y": 850 },
+      "data": { "label": "Stop Transaction", "action": "stop" }
+    },
+    {
+      "id": "status-finishing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 950 },
+      "data": { "label": "Set Finishing", "status": "Finishing" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 1050 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 1150 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "trigger-reservation" },
+    {
+      "id": "e2",
+      "source": "trigger-reservation",
+      "target": "status-reserved"
+    },
+    { "id": "e3", "source": "status-reserved", "target": "delay-arrival" },
+    { "id": "e4", "source": "delay-arrival", "target": "status-preparing" },
+    { "id": "e5", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e6", "source": "tx-start", "target": "status-charging" },
+    { "id": "e7", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e8", "source": "meter-auto", "target": "tx-stop" },
+    { "id": "e9", "source": "tx-stop", "target": "status-finishing" },
+    { "id": "e10", "source": "status-finishing", "target": "status-available" },
+    { "id": "e11", "source": "status-available", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc001-cold-boot.json
+++ b/src/utils/scenarios/cert16-tc001-cold-boot.json
@@ -1,0 +1,47 @@
+{
+  "id": "cert16-tc001-cold-boot",
+  "name": "Cert 1.6 Core: TC_001 Cold Boot",
+  "description": "BootNotification.req/.conf runs automatically on connect; scenario re-affirms StatusNotification(Available) for the target connector, then idles while the CP's own Heartbeat timer keeps running.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "status-notify-available",
+      "type": "statusNotification",
+      "position": { "x": 400, "y": 150 },
+      "data": {
+        "label": "StatusNotification: Available",
+        "status": "Available"
+      }
+    },
+    {
+      "id": "delay-idle",
+      "type": "delay",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Idle (Heartbeat continues automatically)",
+        "delaySeconds": 10
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "status-notify-available" },
+    { "id": "e2", "source": "status-notify-available", "target": "delay-idle" },
+    { "id": "e3", "source": "delay-idle", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc003-charging-plugin-first.json
+++ b/src/utils/scenarios/cert16-tc003-charging-plugin-first.json
@@ -1,0 +1,117 @@
+{
+  "id": "cert16-tc003-charging-plugin-first",
+  "name": "Cert 1.6 Core: TC_003 Charging Session (Plug-In First)",
+  "description": "Plug-in → StatusNotification(Preparing); idTag presented → StartTransaction.req → StatusNotification(Charging); bounded MeterValue.req while charging; StopTransaction.req → StatusNotification(Finishing) → StatusNotification(Available).",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "delay-connect",
+      "type": "delay",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Wait 2s", "delaySeconds": 2 }
+    },
+    {
+      "id": "plug-in",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 250 },
+      "data": { "label": "Plug In", "action": "plugin" }
+    },
+    {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
+      "id": "delay-idtag",
+      "type": "delay",
+      "position": { "x": 400, "y": 450 },
+      "data": { "label": "Present idTag", "delaySeconds": 2 }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 550 },
+      "data": {
+        "label": "Start Transaction",
+        "action": "start",
+        "tagId": "CERT003"
+      }
+    },
+    {
+      "id": "status-charging",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 650 },
+      "data": { "label": "Set Charging", "status": "Charging" }
+    },
+    {
+      "id": "meter-auto",
+      "type": "meterValue",
+      "position": { "x": 400, "y": 750 },
+      "data": {
+        "label": "Bounded Auto MeterValue",
+        "value": 0,
+        "sendMessage": true,
+        "autoIncrement": true,
+        "incrementInterval": 5,
+        "incrementAmount": 500,
+        "maxTime": 30,
+        "maxValue": 0
+      }
+    },
+    {
+      "id": "tx-stop",
+      "type": "transaction",
+      "position": { "x": 400, "y": 850 },
+      "data": { "label": "Stop Transaction", "action": "stop" }
+    },
+    {
+      "id": "status-finishing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 950 },
+      "data": { "label": "Set Finishing", "status": "Finishing" }
+    },
+    {
+      "id": "plug-out",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 1050 },
+      "data": { "label": "Plug Out", "action": "plugout" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 1150 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 1250 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "delay-connect" },
+    { "id": "e2", "source": "delay-connect", "target": "plug-in" },
+    { "id": "e3", "source": "plug-in", "target": "status-preparing" },
+    { "id": "e4", "source": "status-preparing", "target": "delay-idtag" },
+    { "id": "e5", "source": "delay-idtag", "target": "tx-start" },
+    { "id": "e6", "source": "tx-start", "target": "status-charging" },
+    { "id": "e7", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e8", "source": "meter-auto", "target": "tx-stop" },
+    { "id": "e9", "source": "tx-stop", "target": "status-finishing" },
+    { "id": "e10", "source": "status-finishing", "target": "plug-out" },
+    { "id": "e11", "source": "plug-out", "target": "status-available" },
+    { "id": "e12", "source": "status-available", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc004-charging-id-first.json
+++ b/src/utils/scenarios/cert16-tc004-charging-id-first.json
@@ -1,0 +1,96 @@
+{
+  "id": "cert16-tc004-charging-id-first",
+  "name": "Cert 1.6 Core: TC_004 Charging Session (Identification First)",
+  "description": "idTag presented before the cable is connected: StartTransaction.req fires first, then StatusNotification(Preparing) → StatusNotification(Charging); bounded MeterValue.req while charging; StopTransaction.req → StatusNotification(Finishing) → StatusNotification(Available).",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "delay-idtag",
+      "type": "delay",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Present idTag (before plug-in)", "delaySeconds": 2 }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Start Transaction",
+        "action": "start",
+        "tagId": "CERT004"
+      }
+    },
+    {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
+      "id": "status-charging",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 450 },
+      "data": { "label": "Set Charging", "status": "Charging" }
+    },
+    {
+      "id": "meter-auto",
+      "type": "meterValue",
+      "position": { "x": 400, "y": 550 },
+      "data": {
+        "label": "Bounded Auto MeterValue",
+        "value": 0,
+        "sendMessage": true,
+        "autoIncrement": true,
+        "incrementInterval": 5,
+        "incrementAmount": 500,
+        "maxTime": 30,
+        "maxValue": 0
+      }
+    },
+    {
+      "id": "tx-stop",
+      "type": "transaction",
+      "position": { "x": 400, "y": 650 },
+      "data": { "label": "Stop Transaction", "action": "stop" }
+    },
+    {
+      "id": "status-finishing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 750 },
+      "data": { "label": "Set Finishing", "status": "Finishing" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 850 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 950 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "delay-idtag" },
+    { "id": "e2", "source": "delay-idtag", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "status-preparing" },
+    { "id": "e4", "source": "status-preparing", "target": "status-charging" },
+    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e6", "source": "meter-auto", "target": "tx-stop" },
+    { "id": "e7", "source": "tx-stop", "target": "status-finishing" },
+    { "id": "e8", "source": "status-finishing", "target": "status-available" },
+    { "id": "e9", "source": "status-available", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc004-charging-id-first.json
+++ b/src/utils/scenarios/cert16-tc004-charging-id-first.json
@@ -1,7 +1,7 @@
 {
   "id": "cert16-tc004-charging-id-first",
   "name": "Cert 1.6 Core: TC_004 Charging Session (Identification First)",
-  "description": "idTag presented before the cable is connected: StartTransaction.req fires first, then StatusNotification(Preparing) → StatusNotification(Charging); bounded MeterValue.req while charging; StopTransaction.req → StatusNotification(Finishing) → StatusNotification(Available).",
+  "description": "idTag presented before the cable is connected: StatusNotification(Preparing) is entered on identification rather than plug-in, then StartTransaction.req → StatusNotification(Charging); bounded MeterValue.req while charging; StopTransaction.req → StatusNotification(Finishing) → StatusNotification(Available).",
   "targetType": "connector",
   "targetId": 1,
   "trigger": { "type": "manual" },
@@ -21,20 +21,20 @@
       "data": { "label": "Present idTag (before plug-in)", "delaySeconds": 2 }
     },
     {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 250 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
       "id": "tx-start",
       "type": "transaction",
-      "position": { "x": 400, "y": 250 },
+      "position": { "x": 400, "y": 350 },
       "data": {
         "label": "Start Transaction",
         "action": "start",
         "tagId": "CERT004"
       }
-    },
-    {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 350 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
     },
     {
       "id": "status-charging",
@@ -84,9 +84,9 @@
   ],
   "edges": [
     { "id": "e1", "source": "start-1", "target": "delay-idtag" },
-    { "id": "e2", "source": "delay-idtag", "target": "tx-start" },
-    { "id": "e3", "source": "tx-start", "target": "status-preparing" },
-    { "id": "e4", "source": "status-preparing", "target": "status-charging" },
+    { "id": "e2", "source": "delay-idtag", "target": "status-preparing" },
+    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e4", "source": "tx-start", "target": "status-charging" },
     { "id": "e5", "source": "status-charging", "target": "meter-auto" },
     { "id": "e6", "source": "meter-auto", "target": "tx-stop" },
     { "id": "e7", "source": "tx-stop", "target": "status-finishing" },

--- a/src/utils/scenarios/cert16-tc010-remote-start.json
+++ b/src/utils/scenarios/cert16-tc010-remote-start.json
@@ -1,0 +1,79 @@
+{
+  "id": "cert16-tc010-remote-start",
+  "name": "Cert 1.6 Core: TC_010 Remote Start Transaction",
+  "description": "Parks waiting for RemoteStartTransaction.req; on Accepted, StatusNotification(Preparing) → StartTransaction.req → StatusNotification(Charging), then bounded MeterValue.req while charging.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "trigger-remote-start",
+      "type": "remoteStartTrigger",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Wait for RemoteStartTransaction", "timeout": 0 }
+    },
+    {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 250 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 350 },
+      "data": {
+        "label": "Start Transaction",
+        "action": "start",
+        "tagId": "CERT010"
+      }
+    },
+    {
+      "id": "status-charging",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 450 },
+      "data": { "label": "Set Charging", "status": "Charging" }
+    },
+    {
+      "id": "meter-auto",
+      "type": "meterValue",
+      "position": { "x": 400, "y": 550 },
+      "data": {
+        "label": "Bounded Auto MeterValue",
+        "value": 0,
+        "sendMessage": true,
+        "autoIncrement": true,
+        "incrementInterval": 5,
+        "incrementAmount": 500,
+        "maxTime": 30,
+        "maxValue": 0
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 650 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "trigger-remote-start" },
+    {
+      "id": "e2",
+      "source": "trigger-remote-start",
+      "target": "status-preparing"
+    },
+    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e4", "source": "tx-start", "target": "status-charging" },
+    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e6", "source": "meter-auto", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc011-remote-start-stop.json
+++ b/src/utils/scenarios/cert16-tc011-remote-start-stop.json
@@ -1,0 +1,107 @@
+{
+  "id": "cert16-tc011-remote-start-stop",
+  "name": "Cert 1.6 Core: TC_011 Remote Start + Remote Stop Transaction",
+  "description": "RemoteStartTransaction.req → StatusNotification(Preparing) → StartTransaction.req → StatusNotification(Charging) with running MeterValue.req; on RemoteStopTransaction.req, StopTransaction.req → StatusNotification(Finishing) → StatusNotification(Available).",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "trigger-remote-start",
+      "type": "remoteStartTrigger",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Wait for RemoteStartTransaction", "timeout": 0 }
+    },
+    {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 250 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 350 },
+      "data": {
+        "label": "Start Transaction",
+        "action": "start",
+        "tagId": "CERT011"
+      }
+    },
+    {
+      "id": "status-charging",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 450 },
+      "data": { "label": "Set Charging", "status": "Charging" }
+    },
+    {
+      "id": "meter-auto",
+      "type": "meterValue",
+      "position": { "x": 400, "y": 550 },
+      "data": {
+        "label": "Auto MeterValue (until Remote Stop)",
+        "value": 0,
+        "sendMessage": true,
+        "autoIncrement": true,
+        "incrementInterval": 5,
+        "incrementAmount": 500,
+        "maxTime": 0,
+        "maxValue": 0
+      }
+    },
+    {
+      "id": "trigger-remote-stop",
+      "type": "remoteStopTrigger",
+      "position": { "x": 400, "y": 650 },
+      "data": { "label": "Wait for RemoteStopTransaction", "timeout": 0 }
+    },
+    {
+      "id": "tx-stop",
+      "type": "transaction",
+      "position": { "x": 400, "y": 750 },
+      "data": { "label": "Stop Transaction", "action": "stop" }
+    },
+    {
+      "id": "status-finishing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 850 },
+      "data": { "label": "Set Finishing", "status": "Finishing" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 950 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 1050 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "trigger-remote-start" },
+    {
+      "id": "e2",
+      "source": "trigger-remote-start",
+      "target": "status-preparing"
+    },
+    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e4", "source": "tx-start", "target": "status-charging" },
+    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e6", "source": "meter-auto", "target": "trigger-remote-stop" },
+    { "id": "e7", "source": "trigger-remote-stop", "target": "tx-stop" },
+    { "id": "e8", "source": "tx-stop", "target": "status-finishing" },
+    { "id": "e9", "source": "status-finishing", "target": "status-available" },
+    { "id": "e10", "source": "status-available", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc012-remote-stop.json
+++ b/src/utils/scenarios/cert16-tc012-remote-stop.json
@@ -1,0 +1,110 @@
+{
+  "id": "cert16-tc012-remote-stop",
+  "name": "Cert 1.6 Core: TC_012 Remote Stop Transaction",
+  "description": "Locally-started session (StartTransaction.req + running MeterValue.req) already Charging when RemoteStopTransaction.req arrives; StopTransaction.req → StatusNotification(Finishing) → StatusNotification(Available).",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "delay-connect",
+      "type": "delay",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Wait 2s", "delaySeconds": 2 }
+    },
+    {
+      "id": "plug-in",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 250 },
+      "data": { "label": "Plug In", "action": "plugin" }
+    },
+    {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 450 },
+      "data": {
+        "label": "Start Transaction",
+        "action": "start",
+        "tagId": "CERT012"
+      }
+    },
+    {
+      "id": "status-charging",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 550 },
+      "data": { "label": "Set Charging", "status": "Charging" }
+    },
+    {
+      "id": "meter-auto",
+      "type": "meterValue",
+      "position": { "x": 400, "y": 650 },
+      "data": {
+        "label": "Auto MeterValue (until Remote Stop)",
+        "value": 0,
+        "sendMessage": true,
+        "autoIncrement": true,
+        "incrementInterval": 5,
+        "incrementAmount": 500,
+        "maxTime": 0,
+        "maxValue": 0
+      }
+    },
+    {
+      "id": "trigger-remote-stop",
+      "type": "remoteStopTrigger",
+      "position": { "x": 400, "y": 750 },
+      "data": { "label": "Wait for RemoteStopTransaction", "timeout": 0 }
+    },
+    {
+      "id": "tx-stop",
+      "type": "transaction",
+      "position": { "x": 400, "y": 850 },
+      "data": { "label": "Stop Transaction", "action": "stop" }
+    },
+    {
+      "id": "status-finishing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 950 },
+      "data": { "label": "Set Finishing", "status": "Finishing" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 1050 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 1150 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "delay-connect" },
+    { "id": "e2", "source": "delay-connect", "target": "plug-in" },
+    { "id": "e3", "source": "plug-in", "target": "status-preparing" },
+    { "id": "e4", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e5", "source": "tx-start", "target": "status-charging" },
+    { "id": "e6", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e7", "source": "meter-auto", "target": "trigger-remote-stop" },
+    { "id": "e8", "source": "trigger-remote-stop", "target": "tx-stop" },
+    { "id": "e9", "source": "tx-stop", "target": "status-finishing" },
+    { "id": "e10", "source": "status-finishing", "target": "status-available" },
+    { "id": "e11", "source": "status-available", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc017-unlock-occupied.json
+++ b/src/utils/scenarios/cert16-tc017-unlock-occupied.json
@@ -1,0 +1,123 @@
+{
+  "id": "cert16-tc017-unlock-occupied",
+  "name": "Cert 1.6 Core: TC_017 Unlock Connector (Occupied, Succeeds)",
+  "description": "Session running (StartTransaction.req, Charging, MeterValue.req); pre-arms the connector's next UnlockConnector.req response as Unlocked so the CSMS can verify a successful remote unlock while occupied, then StopTransaction.req → StatusNotification(Finishing) → StatusNotification(Available).",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "delay-connect",
+      "type": "delay",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Wait 2s", "delaySeconds": 2 }
+    },
+    {
+      "id": "plug-in",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 250 },
+      "data": { "label": "Plug In", "action": "plugin" }
+    },
+    {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 450 },
+      "data": {
+        "label": "Start Transaction",
+        "action": "start",
+        "tagId": "CERT017"
+      }
+    },
+    {
+      "id": "status-charging",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 550 },
+      "data": { "label": "Set Charging", "status": "Charging" }
+    },
+    {
+      "id": "meter-auto",
+      "type": "meterValue",
+      "position": { "x": 400, "y": 650 },
+      "data": {
+        "label": "Bounded Auto MeterValue",
+        "value": 0,
+        "sendMessage": true,
+        "autoIncrement": true,
+        "incrementInterval": 5,
+        "incrementAmount": 500,
+        "maxTime": 15,
+        "maxValue": 0
+      }
+    },
+    {
+      "id": "unlock-arm",
+      "type": "unlockOutcome",
+      "position": { "x": 400, "y": 750 },
+      "data": {
+        "label": "Pre-arm UnlockConnector response: Unlocked",
+        "outcome": "Unlocked"
+      }
+    },
+    {
+      "id": "delay-unlock-window",
+      "type": "delay",
+      "position": { "x": 400, "y": 850 },
+      "data": {
+        "label": "Window for CSMS UnlockConnector.req",
+        "delaySeconds": 10
+      }
+    },
+    {
+      "id": "tx-stop",
+      "type": "transaction",
+      "position": { "x": 400, "y": 950 },
+      "data": { "label": "Stop Transaction", "action": "stop" }
+    },
+    {
+      "id": "status-finishing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 1050 },
+      "data": { "label": "Set Finishing", "status": "Finishing" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 1150 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 1250 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "delay-connect" },
+    { "id": "e2", "source": "delay-connect", "target": "plug-in" },
+    { "id": "e3", "source": "plug-in", "target": "status-preparing" },
+    { "id": "e4", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e5", "source": "tx-start", "target": "status-charging" },
+    { "id": "e6", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e7", "source": "meter-auto", "target": "unlock-arm" },
+    { "id": "e8", "source": "unlock-arm", "target": "delay-unlock-window" },
+    { "id": "e9", "source": "delay-unlock-window", "target": "tx-stop" },
+    { "id": "e10", "source": "tx-stop", "target": "status-finishing" },
+    { "id": "e11", "source": "status-finishing", "target": "status-available" },
+    { "id": "e12", "source": "status-available", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc018-unlock-failure.json
+++ b/src/utils/scenarios/cert16-tc018-unlock-failure.json
@@ -1,0 +1,123 @@
+{
+  "id": "cert16-tc018-unlock-failure",
+  "name": "Cert 1.6 Core: TC_018 Unlock Connector (Failure)",
+  "description": "Session running (StartTransaction.req, Charging, MeterValue.req); pre-arms the connector's next UnlockConnector.req response as UnlockFailed so the CSMS can verify the failure path (e.g. stuck lock), then the session ends normally via StopTransaction.req → StatusNotification(Finishing) → StatusNotification(Available).",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "delay-connect",
+      "type": "delay",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Wait 2s", "delaySeconds": 2 }
+    },
+    {
+      "id": "plug-in",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 250 },
+      "data": { "label": "Plug In", "action": "plugin" }
+    },
+    {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 450 },
+      "data": {
+        "label": "Start Transaction",
+        "action": "start",
+        "tagId": "CERT018"
+      }
+    },
+    {
+      "id": "status-charging",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 550 },
+      "data": { "label": "Set Charging", "status": "Charging" }
+    },
+    {
+      "id": "meter-auto",
+      "type": "meterValue",
+      "position": { "x": 400, "y": 650 },
+      "data": {
+        "label": "Bounded Auto MeterValue",
+        "value": 0,
+        "sendMessage": true,
+        "autoIncrement": true,
+        "incrementInterval": 5,
+        "incrementAmount": 500,
+        "maxTime": 15,
+        "maxValue": 0
+      }
+    },
+    {
+      "id": "unlock-arm",
+      "type": "unlockOutcome",
+      "position": { "x": 400, "y": 750 },
+      "data": {
+        "label": "Pre-arm UnlockConnector response: UnlockFailed",
+        "outcome": "UnlockFailed"
+      }
+    },
+    {
+      "id": "delay-unlock-window",
+      "type": "delay",
+      "position": { "x": 400, "y": 850 },
+      "data": {
+        "label": "Window for CSMS UnlockConnector.req",
+        "delaySeconds": 10
+      }
+    },
+    {
+      "id": "tx-stop",
+      "type": "transaction",
+      "position": { "x": 400, "y": 950 },
+      "data": { "label": "Stop Transaction", "action": "stop" }
+    },
+    {
+      "id": "status-finishing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 1050 },
+      "data": { "label": "Set Finishing", "status": "Finishing" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 1150 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 1250 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "delay-connect" },
+    { "id": "e2", "source": "delay-connect", "target": "plug-in" },
+    { "id": "e3", "source": "plug-in", "target": "status-preparing" },
+    { "id": "e4", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e5", "source": "tx-start", "target": "status-charging" },
+    { "id": "e6", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e7", "source": "meter-auto", "target": "unlock-arm" },
+    { "id": "e8", "source": "unlock-arm", "target": "delay-unlock-window" },
+    { "id": "e9", "source": "delay-unlock-window", "target": "tx-stop" },
+    { "id": "e10", "source": "tx-stop", "target": "status-finishing" },
+    { "id": "e11", "source": "status-finishing", "target": "status-available" },
+    { "id": "e12", "source": "status-available", "target": "end-1" }
+  ]
+}


### PR DESCRIPTION
First slice of #110: ships ready-to-run scenario templates for the OCPP 1.6 **Core profile** certification test cases, using the existing template mechanism — they appear in the web console's template picker and via `--scenario-template` / `list_scenario_templates` with no daemon changes.

## Included templates (`src/utils/scenarios/cert16-*.json`)

| Template | Flow |
|---|---|
| TC_001 Cold Boot | connect → boot → Available |
| TC_003 Charging session (plug-in first) | Preparing → StartTransaction → Charging + metering → StopTransaction → Finishing → Available |
| TC_004 Charging session (identification first) | Preparing entered on identification → same session flow |
| TC_010 Remote start | parks for RemoteStartTransaction → session |
| TC_011 Remote start/stop | remote start → session → parks for RemoteStopTransaction |
| TC_012 Remote stop | running session → parks for RemoteStopTransaction |
| TC_017 / TC_018 Unlock | pre-armed UnlockConnector outcome (Unlocked / UnlockFailed) around an occupied connector |
| Reservation (basic) | ReserveNow → reserved-tag session |

Each template is named `Cert 1.6 Core: TC_xxx …` with a one-line description of the CSMS-visible message flow; all bounded to run in under ~2 minutes. Flows are derived from OCPP 1.6 spec semantics (status-transition ordering, StartTransaction/StopTransaction sequencing).

## Tests

- New `scenarioTemplates.test.ts` integrity suite: every registered template instantiates, validates shape, node types, edge references, single start node, and (for the new templates) end-node reachability.
- New executor test drives the TC_010 remote-start scenario through a real ChargePoint (tagId capture + bounded auto-meter).
- Gates: eslint clean, vitest 471 passed, bun test 108 passed.

## Not in this slice (DSL gaps, follow-ups)

- TC_013/TC_014 (hard/soft reset) and TC_061 (clear auth cache) need new wait-for-message scenario primitives.
- No assertion nodes yet — scenarios orchestrate the CP side; CSMS-side pass/fail is judged by the CSMS/operator.
- Unlock scenarios model the CSMS unlock window as a fixed delay; reservation uses a fixed reserved tagId.

Part of #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)