### PR TITLE
fix(ev-settings): scenario/explicit EV settings win over Default EV Settings propagation

### DIFF
--- a/src/cli/server/RegistryChargePointService.ts
+++ b/src/cli/server/RegistryChargePointService.ts
@@ -308,11 +308,12 @@ export class RegistryChargePointService implements ChargePointService {
   }
 
   async applyDefaultEVSettings(settings: EVSettings): Promise<void> {
+    // Routes through the connector-level default path (#105) rather than
+    // setEVSettings — setEVSettings marks an explicit override, which would
+    // make this default propagation stick forever and defeat the very
+    // override it's supposed to respect.
     for (const cpId of this.registry.list()) {
-      const service = this.requireService(cpId);
-      for (const connector of service.getStatus().connectors) {
-        service.setEVSettings(connector.id, { ...settings });
-      }
+      this.requireService(cpId).applyDefaultEVSettings(settings);
     }
   }
 

--- a/src/cli/server/__tests__/RegistryChargePointService.test.ts
+++ b/src/cli/server/__tests__/RegistryChargePointService.test.ts
@@ -2,7 +2,10 @@ import { readFileSync } from "node:fs";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { ScenarioDefinition } from "../../../cp/application/scenario/ScenarioTypes";
+import {
+  ScenarioNodeType,
+  type ScenarioDefinition,
+} from "../../../cp/application/scenario/ScenarioTypes";
 import type { EVSettings } from "../../../cp/domain/connector/EVSettings";
 import type { AutoMeterValueConfig } from "../../../cp/domain/connector/MeterValueCurve";
 import type {
@@ -388,6 +391,92 @@ describe("RegistryChargePointService", () => {
     expect(perCp.getEVSettings(1)).toEqual(overrideSettings);
   });
 
+  it("keeps an explicit override after a scenario WITHOUT evSettings completes (#105)", async () => {
+    const { registry, service } = createFacade();
+    const perCp = registry.create(
+      {
+        cpId: "cp-ev-no-scenario-ev",
+        wsUrl: "ws://example.test/ocpp",
+        connectors: 1,
+        vendor: "FacadeVendor",
+        model: "FacadeModel",
+        basicAuth: null,
+      },
+      { seedDefault: false },
+    );
+
+    const overrideSettings: EVSettings = {
+      modelName: "Override EV",
+      batteryCapacityKwh: 50,
+      maxChargingPowerKw: 40,
+      initialSoc: 20,
+      targetSoc: 50,
+    };
+    perCp.setEVSettings(1, overrideSettings);
+
+    // A scenario that never touches EV settings runs to completion on the
+    // same connector — it must NOT release the explicit override.
+    const scenarioId = perCp.loadScenario(
+      1,
+      runnableScenario("scenario-no-ev", 1),
+    );
+    perCp.runScenario(1, scenarioId);
+    await waitForScenarioIdle(perCp, 1, scenarioId);
+
+    await service.applyDefaultEVSettings({
+      modelName: "Generic EV",
+      batteryCapacityKwh: 75,
+      maxChargingPowerKw: 150,
+      initialSoc: 20,
+      targetSoc: 80,
+    });
+
+    expect(perCp.getEVSettings(1)).toEqual(overrideSettings);
+  });
+
+  it("releases a scenario's evSettings override when the scenario is stopped (#105)", async () => {
+    const { registry, service } = createFacade();
+    const perCp = registry.create(
+      {
+        cpId: "cp-ev-scenario-stop",
+        wsUrl: "ws://example.test/ocpp",
+        connectors: 1,
+        vendor: "FacadeVendor",
+        model: "FacadeModel",
+        basicAuth: null,
+      },
+      { seedDefault: false },
+    );
+
+    // Parks on the STATUS_TRIGGER wait (the connector never reaches
+    // Charging here) after applying its declared evSettings.
+    const scenarioId = perCp.loadScenario(
+      1,
+      parkedScenario("scenario-with-ev", 1, { targetSoc: 50 }),
+    );
+    perCp.runScenario(1, scenarioId);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(perCp.getEVSettings(1).targetSoc).toBe(50);
+
+    const nextDefault: EVSettings = {
+      modelName: "Generic EV",
+      batteryCapacityKwh: 75,
+      maxChargingPowerKw: 150,
+      initialSoc: 20,
+      targetSoc: 80,
+    };
+
+    // Default propagation while the scenario is active: override wins.
+    await service.applyDefaultEVSettings(nextDefault);
+    expect(perCp.getEVSettings(1).targetSoc).toBe(50);
+
+    perCp.stopScenario(1, scenarioId);
+
+    // The owning scenario stopped — the next default propagation applies.
+    await service.applyDefaultEVSettings(nextDefault);
+    expect(perCp.getEVSettings(1).targetSoc).toBe(80);
+  });
+
   it("delegates per-CP subscriptions and returns the unsubscribe callback", () => {
     const { registry, service } = createFacade();
     const perCp = registry.create(
@@ -604,6 +693,88 @@ function scenarioDefinition(
     updatedAt: "2026-06-30T00:00:01.000Z",
     enabled: true,
   };
+}
+
+/** Start -> End: runs to natural completion immediately; no evSettings. */
+function runnableScenario(id: string, connectorId: number): ScenarioDefinition {
+  return {
+    ...scenarioDefinition(id, connectorId),
+    nodes: [
+      {
+        id: "start",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "end",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 100 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [{ id: "e-start", source: "start", target: "end" }],
+    trigger: { type: "manual" },
+    defaultExecutionMode: "oneshot",
+  };
+}
+
+/**
+ * Start -> STATUS_TRIGGER wait (a status the test never produces) -> End,
+ * with declared evSettings: applies its EV settings override on start and
+ * then parks so tests can exercise the running-scenario window.
+ */
+function parkedScenario(
+  id: string,
+  connectorId: number,
+  evSettings: Partial<EVSettings>,
+): ScenarioDefinition {
+  return {
+    ...scenarioDefinition(id, connectorId),
+    nodes: [
+      {
+        id: "start",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "wait",
+        type: ScenarioNodeType.STATUS_TRIGGER,
+        position: { x: 0, y: 100 },
+        data: { label: "Wait", targetStatus: OCPPStatus.Charging, timeout: 0 },
+      },
+      {
+        id: "end",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 200 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e-start", source: "start", target: "wait" },
+      { id: "e-wait", source: "wait", target: "end" },
+    ],
+    trigger: { type: "manual" },
+    defaultExecutionMode: "oneshot",
+    evSettings,
+  };
+}
+
+/** Poll until the scenario's executor exits (runScenario is fire-and-forget). */
+async function waitForScenarioIdle(
+  perCp: ReturnType<CPRegistry["create"]>,
+  connectorId: number,
+  scenarioId: string,
+): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    const item = perCp
+      .listScenarios(connectorId)
+      .find((s) => s.scenarioId === scenarioId);
+    if (item && !item.active) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`scenario ${scenarioId} did not complete`);
 }
 
 function autoMeterConfig(): AutoMeterValueConfig {

--- a/src/cli/server/__tests__/RegistryChargePointService.test.ts
+++ b/src/cli/server/__tests__/RegistryChargePointService.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ScenarioDefinition } from "../../../cp/application/scenario/ScenarioTypes";
+import type { EVSettings } from "../../../cp/domain/connector/EVSettings";
 import type { AutoMeterValueConfig } from "../../../cp/domain/connector/MeterValueCurve";
 import type {
   Database,
@@ -347,6 +348,44 @@ describe("RegistryChargePointService", () => {
     await expect(
       service.sendStatusNotification("missing-cp", 1, OCPPStatus.Available),
     ).rejects.toThrow("cpId not found: missing-cp");
+  });
+
+  it("applyDefaultEVSettings respects an active override instead of clobbering it (#105)", async () => {
+    const { registry, service } = createFacade();
+    const perCp = registry.create(
+      {
+        cpId: "cp-ev-default",
+        wsUrl: "ws://example.test/ocpp",
+        connectors: 1,
+        vendor: "FacadeVendor",
+        model: "FacadeModel",
+        basicAuth: null,
+      },
+      { seedDefault: false },
+    );
+
+    const overrideSettings: EVSettings = {
+      modelName: "Override EV",
+      batteryCapacityKwh: 50,
+      maxChargingPowerKw: 40,
+      initialSoc: 20,
+      targetSoc: 50,
+    };
+    const nextDefault: EVSettings = {
+      modelName: "Generic EV",
+      batteryCapacityKwh: 75,
+      maxChargingPowerKw: 150,
+      initialSoc: 20,
+      targetSoc: 80,
+    };
+
+    // setEVSettings is the explicit/scenario path — it must mark an
+    // override that a later default propagation can't clobber.
+    perCp.setEVSettings(1, overrideSettings);
+
+    await service.applyDefaultEVSettings(nextDefault);
+
+    expect(perCp.getEVSettings(1)).toEqual(overrideSettings);
   });
 
   it("delegates per-CP subscriptions and returns the unsubscribe callback", () => {

--- a/src/cli/server/socketServer.ts
+++ b/src/cli/server/socketServer.ts
@@ -374,6 +374,8 @@ async function dispatchValidatedRpc(
       return getSocMeterSync(deps, rawParams);
     case "connector_settings.soc_meter_sync.save":
       return saveSocMeterSync(deps, rawParams);
+    case "ev_settings.apply_default":
+      return applyDefaultEVSettingsRpc(deps, rawParams);
     case "server.shutdown":
       return shutdownServer(deps);
     case "events.subscribe":
@@ -522,6 +524,22 @@ async function saveConfig(
   });
   deps.registryEvents?.emitConfigChanged(saved);
   return { ok: true };
+}
+
+async function applyDefaultEVSettingsRpc(
+  deps: RuntimeSocketIoDeps,
+  rawParams: unknown,
+): Promise<undefined> {
+  const params =
+    METHODS["ev_settings.apply_default"].params.safeParse(rawParams);
+  if (!params.success) throw new RpcFailure("invalid_params", "");
+
+  await runFacadeOperation(() =>
+    deps.chargePointService.applyDefaultEVSettings(
+      params.data.settings as unknown as EVSettings,
+    ),
+  );
+  return undefined;
 }
 
 async function listScenarioDefinitions(

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -918,10 +918,14 @@ export class CLIChargePointService {
       // connector_runtime row's transaction_json itself is already
       // null by the time the Stop Transaction node ran).
       this._scenarioPositionByConnector.delete(connectorId);
-      // Release the EV settings override (#105): a future Default EV
-      // Settings propagation should be free to apply now that this
-      // scenario is no longer driving the connector.
-      connector.clearEvSettingsOverride();
+      // Release the EV settings override (#105) — but only if THIS scenario
+      // declared evSettings and therefore owns the override (ScenarioExecutor
+      // only calls onSetEVSettings for declared evSettings). A scenario that
+      // never touched EV settings must not release an explicit
+      // set_ev_settings override on the same connector.
+      if (entry.definition.evSettings) {
+        connector.clearEvSettingsOverride();
+      }
       this.persistConnectorRuntime(connector, connectorId);
     });
   }
@@ -975,9 +979,12 @@ export class CLIChargePointService {
     }
     executor.stop();
     this._executors.delete(scenarioId);
-    // Release the EV settings override (#105) — see runScenario's
+    // Release the EV settings override (#105) — only when this scenario
+    // declared evSettings and therefore owns it; see runScenario's
     // executor.start().finally() for the natural-completion counterpart.
-    this._chargePoint.connectors.get(connectorId)?.clearEvSettingsOverride();
+    if (this._scenarios.get(scenarioId)?.definition.evSettings) {
+      this._chargePoint.connectors.get(connectorId)?.clearEvSettingsOverride();
+    }
     // Surface the stop to remote subscribers — executor.stop() bypasses
     // the onStateChange("completed") path used by runScenario(), so the
     // browser's active-scenario tracker would otherwise still believe
@@ -995,10 +1002,13 @@ export class CLIChargePointService {
         if (executor) {
           executor.stop();
           this._executors.delete(scenarioId);
-          // Release the EV settings override (#105), same as stopScenario.
-          this._chargePoint.connectors
-            .get(connectorId)
-            ?.clearEvSettingsOverride();
+          // Release the EV settings override (#105) only for the owning
+          // (evSettings-declaring) scenario, same as stopScenario.
+          if (entry.definition.evSettings) {
+            this._chargePoint.connectors
+              .get(connectorId)
+              ?.clearEvSettingsOverride();
+          }
           this.emit({
             event: "scenario_completed",
             data: { connectorId, scenarioId },

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -538,12 +538,26 @@ export class CLIChargePointService {
   }
 
   setEVSettings(connectorId: number, settings: EVSettings): void {
+    // Explicit set (#105): marks the connector overridden so a later Default
+    // EV Settings propagation doesn't clobber it. See applyDefaultEVSettings
+    // for the default-propagation counterpart, which respects this flag.
     const connector = this.requireConnector(connectorId);
-    connector.evSettings = settings;
+    connector.applyEvSettingsOverride(settings);
   }
 
   getEVSettings(connectorId: number): EVSettings {
     return this.requireConnector(connectorId).evSettings;
+  }
+
+  /**
+   * Default EV Settings propagation (#105): pushed onto every connector of
+   * this CP, but only takes effect on connectors that don't currently have
+   * an explicit/scenario override active (see Connector.applyDefaultEvSettings).
+   */
+  applyDefaultEVSettings(settings: EVSettings): void {
+    this._chargePoint.connectors.forEach((connector) => {
+      connector.applyDefaultEvSettings(settings);
+    });
   }
 
   setAutoMeterValueConfig(
@@ -904,6 +918,10 @@ export class CLIChargePointService {
       // connector_runtime row's transaction_json itself is already
       // null by the time the Stop Transaction node ran).
       this._scenarioPositionByConnector.delete(connectorId);
+      // Release the EV settings override (#105): a future Default EV
+      // Settings propagation should be free to apply now that this
+      // scenario is no longer driving the connector.
+      connector.clearEvSettingsOverride();
       this.persistConnectorRuntime(connector, connectorId);
     });
   }
@@ -957,6 +975,9 @@ export class CLIChargePointService {
     }
     executor.stop();
     this._executors.delete(scenarioId);
+    // Release the EV settings override (#105) — see runScenario's
+    // executor.start().finally() for the natural-completion counterpart.
+    this._chargePoint.connectors.get(connectorId)?.clearEvSettingsOverride();
     // Surface the stop to remote subscribers — executor.stop() bypasses
     // the onStateChange("completed") path used by runScenario(), so the
     // browser's active-scenario tracker would otherwise still believe
@@ -974,6 +995,10 @@ export class CLIChargePointService {
         if (executor) {
           executor.stop();
           this._executors.delete(scenarioId);
+          // Release the EV settings override (#105), same as stopScenario.
+          this._chargePoint.connectors
+            .get(connectorId)
+            ?.clearEvSettingsOverride();
           this.emit({
             event: "scenario_completed",
             data: { connectorId, scenarioId },

--- a/src/cp/application/scenario/ScenarioManager.ts
+++ b/src/cp/application/scenario/ScenarioManager.ts
@@ -298,11 +298,14 @@ export class ScenarioManager {
     } finally {
       // Clean up when completed
       this.executors.delete(scenarioId);
-      // Release the EV settings override (#105) — a running scenario's
-      // evSettings must win over Default EV Settings propagation only
-      // while it's active; once it completes, a future default push may
-      // apply again.
-      this.connector.clearEvSettingsOverride();
+      // Release the EV settings override (#105) — but only if THIS scenario
+      // declared evSettings and therefore owns the override (ScenarioExecutor
+      // only calls onSetEVSettings for declared evSettings). A scenario that
+      // never touched EV settings must not release an explicit override that
+      // was set on the same connector.
+      if (scenario.evSettings) {
+        this.connector.clearEvSettingsOverride();
+      }
     }
   }
 
@@ -315,9 +318,12 @@ export class ScenarioManager {
       console.log(`[ScenarioManager] Stopping scenario: ${scenarioId}`);
       executor.stop();
       this.executors.delete(scenarioId);
-      // Release the EV settings override (#105), same as executeScenario's
+      // Release the EV settings override (#105) only for the owning
+      // (evSettings-declaring) scenario, same as executeScenario's
       // natural-completion path above.
-      this.connector.clearEvSettingsOverride();
+      if (this.scenarios.get(scenarioId)?.evSettings) {
+        this.connector.clearEvSettingsOverride();
+      }
     }
   }
 

--- a/src/cp/application/scenario/ScenarioManager.ts
+++ b/src/cp/application/scenario/ScenarioManager.ts
@@ -298,6 +298,11 @@ export class ScenarioManager {
     } finally {
       // Clean up when completed
       this.executors.delete(scenarioId);
+      // Release the EV settings override (#105) — a running scenario's
+      // evSettings must win over Default EV Settings propagation only
+      // while it's active; once it completes, a future default push may
+      // apply again.
+      this.connector.clearEvSettingsOverride();
     }
   }
 
@@ -310,6 +315,9 @@ export class ScenarioManager {
       console.log(`[ScenarioManager] Stopping scenario: ${scenarioId}`);
       executor.stop();
       this.executors.delete(scenarioId);
+      // Release the EV settings override (#105), same as executeScenario's
+      // natural-completion path above.
+      this.connector.clearEvSettingsOverride();
     }
   }
 

--- a/src/cp/application/scenario/ScenarioRuntime.ts
+++ b/src/cp/application/scenario/ScenarioRuntime.ts
@@ -397,11 +397,14 @@ export const createScenarioExecutorCallbacks = (
       connector.stopAutoMeterValue();
     },
     onSetEVSettings: (settings) => {
-      // Merge — only specified fields land on the connector. The connector
-      // setter spreads `_evSettings = { ...settings }` and emits
+      // Merge — only specified fields land on the connector. Routes through
+      // the override path (#105) so this scenario's evSettings win over any
+      // later Default EV Settings propagation until the scenario
+      // stops/completes (see ScenarioManager/CLIChargePointService scenario
+      // stop paths, which clear the override). Still emits
       // `evSettingsChange`, which surfaces to subscribers and (in remote
       // mode) the browser via the `connector_ev_settings` event.
-      connector.evSettings = { ...connector.evSettings, ...settings };
+      connector.applyEvSettingsOverride(settings);
     },
     onGetEVSettings: () => connector.evSettings,
     onSendNotification: async (messageType, payload) => {

--- a/src/cp/application/scenario/__tests__/ScenarioManager.evSettingsOverride.test.ts
+++ b/src/cp/application/scenario/__tests__/ScenarioManager.evSettingsOverride.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { Connector } from "../../../domain/connector/Connector";
+import type { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { Logger, LogLevel } from "../../../shared/Logger";
+import { OCPPStatus } from "../../../domain/types/OcppTypes";
+import { createScenarioExecutorCallbacks } from "../ScenarioRuntime";
+import { ScenarioManager } from "../ScenarioManager";
+import { ScenarioDefinition, ScenarioNodeType } from "../ScenarioTypes";
+import {
+  defaultEVSettings,
+  type EVSettings,
+} from "../../../domain/connector/EVSettings";
+
+function makeConnector(): Connector {
+  // ERROR-level logger so tests stay quiet without overriding stdout.
+  return new Connector(1, new Logger(LogLevel.ERROR));
+}
+
+// A ScenarioManager only needs `status` (gate for executeScenario) and
+// `logger` (scenario execution logging) from its ChargePoint — the rest of
+// the callbacks this scenario exercises (onSetEVSettings, onWaitForStatus)
+// operate on the connector directly.
+function makeChargePointStub(): ChargePoint {
+  return {
+    status: OCPPStatus.Available,
+    logger: new Logger(LogLevel.ERROR),
+  } as unknown as ChargePoint;
+}
+
+// Start -> wait indefinitely for a status this test never reaches -> End.
+// Declares `evSettings`, which ScenarioExecutor applies via onSetEVSettings
+// before the first node runs, and then stays "running" (paused on the wait)
+// so we can exercise default-propagation-while-active before stopping it.
+function scenarioWithEvSettingsOverride(
+  evSettings: Partial<EVSettings>,
+): ScenarioDefinition {
+  return {
+    id: "sc-ev-override",
+    name: "ev override test",
+    targetType: "connector",
+    targetId: 1,
+    nodes: [
+      {
+        id: "start",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "wait",
+        type: ScenarioNodeType.STATUS_TRIGGER,
+        position: { x: 0, y: 100 },
+        data: {
+          label: "Wait",
+          targetStatus: OCPPStatus.Charging,
+          timeout: 0,
+        },
+      },
+      {
+        id: "end",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 200 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e-start", source: "start", target: "wait" },
+      { id: "e-wait", source: "wait", target: "end" },
+    ],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    defaultExecutionMode: "oneshot",
+    enabled: true,
+    trigger: { type: "manual" },
+    evSettings,
+  };
+}
+
+describe("ScenarioManager EV settings override (#105)", () => {
+  it("keeps a running scenario's evSettings override across a default propagation, and clears it on stop", async () => {
+    const connector = makeConnector();
+    const chargePoint = makeChargePointStub();
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint,
+      connector,
+    });
+    const manager = new ScenarioManager(connector, chargePoint, callbacks);
+
+    const scenarioOverride: Partial<EVSettings> = { targetSoc: 50 };
+    const scenario = scenarioWithEvSettingsOverride(scenarioOverride);
+    manager.loadScenarios([scenario]);
+
+    // Fire-and-forget: the scenario parks indefinitely on the STATUS_TRIGGER
+    // wait node (never reaches Charging), so this promise doesn't resolve
+    // until we stop the scenario below.
+    void manager.executeScenario(scenario.id);
+
+    // Let the microtask queue settle so the START node runs and
+    // onSetEVSettings applies the scenario's evSettings.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(connector.evSettings.targetSoc).toBe(50);
+
+    // Simulate a Default EV Settings propagation while the scenario is
+    // still active (e.g. a browser reload re-pushing the default in remote
+    // mode, #107) — the override must win.
+    connector.applyDefaultEvSettings({ ...defaultEVSettings, targetSoc: 80 });
+    expect(connector.evSettings.targetSoc).toBe(50);
+
+    manager.stopScenario(scenario.id);
+
+    // Override cleared: the next default propagation is free to apply.
+    connector.applyDefaultEvSettings({ ...defaultEVSettings, targetSoc: 80 });
+    expect(connector.evSettings.targetSoc).toBe(80);
+  });
+});

--- a/src/cp/application/scenario/__tests__/ScenarioManager.evSettingsOverride.test.ts
+++ b/src/cp/application/scenario/__tests__/ScenarioManager.evSettingsOverride.test.ts
@@ -76,6 +76,43 @@ function scenarioWithEvSettingsOverride(
   };
 }
 
+// Start -> End: runs to natural completion immediately. Only carries
+// `evSettings` when the caller provides them, so tests cover both a
+// scenario that owns an EV settings override and one that never touches
+// EV settings at all.
+function completingScenario(
+  id: string,
+  evSettings?: Partial<EVSettings>,
+): ScenarioDefinition {
+  return {
+    id,
+    name: `completing ${id}`,
+    targetType: "connector",
+    targetId: 1,
+    nodes: [
+      {
+        id: "start",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "end",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 100 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [{ id: "e-start", source: "start", target: "end" }],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    defaultExecutionMode: "oneshot",
+    enabled: true,
+    trigger: { type: "manual" },
+    ...(evSettings ? { evSettings } : {}),
+  };
+}
+
 describe("ScenarioManager EV settings override (#105)", () => {
   it("keeps a running scenario's evSettings override across a default propagation, and clears it on stop", async () => {
     const connector = makeConnector();
@@ -109,6 +146,51 @@ describe("ScenarioManager EV settings override (#105)", () => {
     manager.stopScenario(scenario.id);
 
     // Override cleared: the next default propagation is free to apply.
+    connector.applyDefaultEvSettings({ ...defaultEVSettings, targetSoc: 80 });
+    expect(connector.evSettings.targetSoc).toBe(80);
+  });
+
+  it("does not release an explicit override when a scenario WITHOUT evSettings completes", async () => {
+    const connector = makeConnector();
+    const chargePoint = makeChargePointStub();
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint,
+      connector,
+    });
+    const manager = new ScenarioManager(connector, chargePoint, callbacks);
+
+    // Explicit (set_ev_settings-style) override, independent of any scenario.
+    connector.applyEvSettingsOverride({ targetSoc: 50 });
+
+    // A scenario that never touches EV settings runs to natural completion
+    // on the same connector (e.g. a status auto-trigger scenario).
+    const scenario = completingScenario("sc-no-ev");
+    manager.loadScenarios([scenario]);
+    await manager.executeScenario(scenario.id);
+
+    // The scenario must not have released the explicit override: a default
+    // propagation afterwards still no-ops.
+    connector.applyDefaultEvSettings({ ...defaultEVSettings, targetSoc: 80 });
+    expect(connector.evSettings.targetSoc).toBe(50);
+  });
+
+  it("releases the override when a scenario WITH evSettings completes naturally", async () => {
+    const connector = makeConnector();
+    const chargePoint = makeChargePointStub();
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint,
+      connector,
+    });
+    const manager = new ScenarioManager(connector, chargePoint, callbacks);
+
+    const scenario = completingScenario("sc-with-ev", { targetSoc: 50 });
+    manager.loadScenarios([scenario]);
+    await manager.executeScenario(scenario.id);
+
+    expect(connector.evSettings.targetSoc).toBe(50);
+
+    // The scenario owned the override and completed — the next default
+    // propagation applies again.
     connector.applyDefaultEvSettings({ ...defaultEVSettings, targetSoc: 80 });
     expect(connector.evSettings.targetSoc).toBe(80);
   });

--- a/src/cp/domain/connector/Connector.ts
+++ b/src/cp/domain/connector/Connector.ts
@@ -169,6 +169,12 @@ export class Connector {
   private _scenarioManager?: ScenarioManager;
   private _autoResetToAvailable = true;
   private _evSettings: EVSettings = getDefaultEVSettings();
+  // True while an explicit/scenario override is active (#105): a running
+  // scenario's evSettings must win over any later Default EV Settings
+  // propagation (e.g. a browser reload in remote mode re-pushing the
+  // default onto every connector while a scenario is mid-flight on the
+  // daemon). Cleared when the scenario that set it stops/completes.
+  private _evSettingsOverridden = false;
   private _chargingProfiles: ActiveChargingProfile[] = [];
 
   /**
@@ -492,6 +498,36 @@ export class Connector {
   set evSettings(settings: EVSettings) {
     this._evSettings = { ...settings };
     this.eventsEmitter.emit("evSettingsChange", { settings: this._evSettings });
+  }
+
+  /**
+   * Explicit/scenario set (#105): merges `partial` into the current EV
+   * settings and marks the connector as overridden, so a later Default EV
+   * Settings propagation (`applyDefaultEvSettings`) no-ops until
+   * {@link clearEvSettingsOverride} runs.
+   */
+  applyEvSettingsOverride(partial: Partial<EVSettings>): void {
+    this._evSettingsOverridden = true;
+    this.evSettings = { ...this._evSettings, ...partial };
+  }
+
+  /**
+   * Default-EV-settings propagation (#105): replaces the settings wholesale,
+   * same as the `evSettings` setter, but only when no override is active —
+   * a running scenario/explicit override wins over this until cleared.
+   */
+  applyDefaultEvSettings(settings: EVSettings): void {
+    if (this._evSettingsOverridden) return;
+    this.evSettings = { ...settings };
+  }
+
+  /**
+   * Unmark the override (current values are kept as-is) so the next
+   * `applyDefaultEvSettings` call can take effect. Called when the scenario
+   * that set the override stops or completes.
+   */
+  clearEvSettingsOverride(): void {
+    this._evSettingsOverridden = false;
   }
 
   /**

--- a/src/cp/domain/connector/__tests__/Connector.evSettingsOverride.test.ts
+++ b/src/cp/domain/connector/__tests__/Connector.evSettingsOverride.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { Connector } from "../Connector";
+import { Logger, LogLevel } from "../../../shared/Logger";
+import { defaultEVSettings, type EVSettings } from "../EVSettings";
+
+function makeConnector(): Connector {
+  // ERROR-level logger so tests stay quiet without overriding stdout.
+  return new Connector(1, new Logger(LogLevel.ERROR));
+}
+
+const nextDefault: EVSettings = {
+  ...defaultEVSettings,
+  targetSoc: 80,
+};
+
+describe("Connector EV settings override tracking (#105)", () => {
+  it("applyEvSettingsOverride merges a partial into the current settings", () => {
+    const connector = makeConnector();
+
+    connector.applyEvSettingsOverride({ targetSoc: 50 });
+
+    expect(connector.evSettings.targetSoc).toBe(50);
+    // Everything else keeps its previous (default) value — this is a
+    // merge, not a replace.
+    expect(connector.evSettings.modelName).toBe(defaultEVSettings.modelName);
+    expect(connector.evSettings.batteryCapacityKwh).toBe(
+      defaultEVSettings.batteryCapacityKwh,
+    );
+  });
+
+  it("applyDefaultEvSettings is a no-op while an override is active", () => {
+    const connector = makeConnector();
+
+    connector.applyEvSettingsOverride({ targetSoc: 50 });
+    connector.applyDefaultEvSettings(nextDefault);
+
+    expect(connector.evSettings.targetSoc).toBe(50);
+  });
+
+  it("clearEvSettingsOverride keeps the current values but lets the next default propagation apply", () => {
+    const connector = makeConnector();
+
+    connector.applyEvSettingsOverride({ targetSoc: 50 });
+    connector.clearEvSettingsOverride();
+
+    // Values survive the clear itself...
+    expect(connector.evSettings.targetSoc).toBe(50);
+
+    // ...but the next default propagation is no longer blocked.
+    connector.applyDefaultEvSettings(nextDefault);
+    expect(connector.evSettings.targetSoc).toBe(80);
+  });
+
+  it("applyDefaultEvSettings replaces settings wholesale when there is no override", () => {
+    const connector = makeConnector();
+
+    connector.applyDefaultEvSettings(nextDefault);
+
+    expect(connector.evSettings).toEqual(nextDefault);
+  });
+});

--- a/src/data/local/LocalChargePointService.evDefaults.test.ts
+++ b/src/data/local/LocalChargePointService.evDefaults.test.ts
@@ -86,4 +86,42 @@ describe("LocalChargePointService.applyDefaultEVSettings (#107)", () => {
       );
     }
   });
+
+  it("keeps a scenario/explicit override across a default propagation, and applies the default again once cleared (#105)", async () => {
+    service = new LocalChargePointService();
+    await service.syncLocalChargePoints([
+      localDefinition({ connectorNumber: 1 }),
+    ]);
+
+    const chargePoint = service.getLocalChargePoint("CP-EV");
+    const connector = chargePoint?.getConnector(1);
+    expect(connector).toBeDefined();
+
+    connector?.applyEvSettingsOverride({ targetSoc: 50 });
+
+    await service.applyDefaultEVSettings({
+      ...defaultEVSettings,
+      targetSoc: 80,
+    });
+
+    // A browser reload re-pushing the default (#107) must not stomp the
+    // active override (#105) — the target SoC set via the scenario/explicit
+    // override stays at 50.
+    await expect(service.getEVSettings("CP-EV", 1)).resolves.toMatchObject({
+      targetSoc: 50,
+    });
+
+    connector?.clearEvSettingsOverride();
+
+    await service.applyDefaultEVSettings({
+      ...defaultEVSettings,
+      targetSoc: 80,
+    });
+
+    // Once the override clears (e.g. the scenario stopped), the next
+    // default propagation is free to apply.
+    await expect(service.getEVSettings("CP-EV", 1)).resolves.toMatchObject({
+      targetSoc: 80,
+    });
+  });
 });

--- a/src/data/local/LocalChargePointService.ts
+++ b/src/data/local/LocalChargePointService.ts
@@ -425,8 +425,10 @@ export class LocalChargePointService implements ChargePointService {
     connectorId: number,
     settings: EVSettings,
   ): Promise<void> {
+    // Explicit set (#105): marks the connector overridden so a later
+    // Default EV Settings propagation doesn't clobber it.
     const connector = this.requireConnector(id, connectorId);
-    connector.evSettings = settings;
+    connector.applyEvSettingsOverride(settings);
   }
 
   async getEVSettings(
@@ -442,9 +444,11 @@ export class LocalChargePointService implements ChargePointService {
     // Push it onto every connector (per-connector EV settings aren't a
     // user-editable, persisted concept — they only come from the default or a
     // running scenario) so the editor reflects the new default immediately (#107).
+    // Connectors with an active explicit/scenario override skip this (#105) —
+    // see Connector.applyDefaultEvSettings.
     this.chargePoints.forEach((chargePoint) => {
       chargePoint.connectors.forEach((connector) => {
-        connector.evSettings = { ...settings };
+        connector.applyDefaultEvSettings(settings);
       });
     });
   }

--- a/src/data/remote/RemoteChargePointService.socket.test.ts
+++ b/src/data/remote/RemoteChargePointService.socket.test.ts
@@ -680,14 +680,12 @@ describe("RemoteChargePointService socket.io rpc", () => {
         name: "applyDefaultEVSettings",
         invoke: (service) => service.applyDefaultEVSettings(ev),
         expected: [
-          { method: "cp.list", params: {} },
           {
-            cpId: "cp-1",
-            method: "set_ev_settings",
-            params: { connector: 1, settings: ev },
+            method: "ev_settings.apply_default",
+            params: { settings: ev },
           },
         ],
-        results: [[cpItem("cp-1")], undefined],
+        results: [undefined],
       },
       {
         name: "setAutoMeterValueConfig",

--- a/src/data/remote/RemoteChargePointService.ts
+++ b/src/data/remote/RemoteChargePointService.ts
@@ -879,20 +879,15 @@ export class RemoteChargePointService implements ChargePointService {
 
   async applyDefaultEVSettings(settings: EVSettings): Promise<void> {
     // The daemon's connectors never see the browser-only Default EV Settings,
-    // so push it onto every connector of every known charge point (#107).
-    const cps = await this.listChargePoints().catch(() => []);
-    await Promise.all(
-      cps.flatMap((cp) =>
-        cp.connectors.map((connector) =>
-          this.setEVSettings(cp.id, connector.id, settings).catch((err) =>
-            console.warn(
-              `Failed to apply default EV settings to ${cp.id}/${connector.id}`,
-              err,
-            ),
-          ),
-        ),
-      ),
-    );
+    // so push it onto every connector of every known charge point (#107) via
+    // a single daemon-level RPC. This must NOT go through setEVSettings
+    // (per-connector, marks an explicit override, #105) — the daemon-side
+    // RegistryChargePointService.applyDefaultEVSettings routes it through
+    // each connector's default-propagation path instead, so an active
+    // scenario/explicit override isn't clobbered.
+    await this.rpc("ev_settings.apply_default", {
+      settings: settings as unknown as Record<string, unknown>,
+    });
   }
 
   async setAutoMeterValueConfig(

--- a/src/protocol/__tests__/methods.test.ts
+++ b/src/protocol/__tests__/methods.test.ts
@@ -66,7 +66,7 @@ describe("method table coverage (Step 3c)", () => {
     for (const id of EXPLICIT_METHODS) {
       expect(METHODS[id]).toBeDefined();
     }
-    expect(EXPLICIT_METHODS).toHaveLength(21);
+    expect(EXPLICIT_METHODS).toHaveLength(22);
   });
 
   it("contains exactly the jsonMode ids + the explicit ops (no drift)", () => {
@@ -101,6 +101,16 @@ describe("method table coverage (Step 3c)", () => {
     expect(METHODS["connector_settings.soc_meter_sync.get"]).toBeDefined();
     expect(METHODS["connector_settings.soc_meter_sync.save"]).toBeDefined();
     expect(isRpcMethod("connector_settings.auto_meter.get")).toBe(true);
+  });
+
+  it("includes the daemon-wide default EV settings op (#105)", () => {
+    expect(METHODS["ev_settings.apply_default"]).toBeDefined();
+    expect(isRpcMethod("ev_settings.apply_default")).toBe(true);
+    expect(
+      METHODS["ev_settings.apply_default"].params.safeParse({
+        settings: { targetSoc: 80 },
+      }).success,
+    ).toBe(true);
   });
 });
 

--- a/src/protocol/methods.ts
+++ b/src/protocol/methods.ts
@@ -323,6 +323,14 @@ export const METHODS = {
     params: connectorSettingsParamsSchema.extend({ enabled: z.boolean() }),
     result: z.object({ ok: z.literal(true) }),
   },
+  // Daemon-wide (not per-CP): pushes Default EV Settings onto every
+  // connector of every registered CP, unless a connector currently has an
+  // explicit/scenario override active (#105). Distinct from the per-CP
+  // `set_ev_settings`, which always marks an override.
+  "ev_settings.apply_default": {
+    params: z.object({ settings: OBJ() }),
+    result: ANY,
+  },
   "server.shutdown": { params: EMPTY, result: ANY },
   "events.subscribe": {
     params: z.object({ scope: STR_64K }),
@@ -351,6 +359,7 @@ export const EXPLICIT_METHODS = [
   "connector_settings.auto_meter.save",
   "connector_settings.soc_meter_sync.get",
   "connector_settings.soc_meter_sync.save",
+  "ev_settings.apply_default",
   "server.shutdown",
   "events.subscribe",
   "events.unsubscribe",


### PR DESCRIPTION
Fixes #105.

## Problem

After #109, `applyDefaultEVSettings` replaces every connector's EV settings wholesale, and the web console re-pushes the default on every mount and on every default change. Any targetSoc applied by a scenario (or an explicit `set_ev_settings`) gets silently reset to the default (80%) — e.g. a browser reload in remote mode while a scenario runs on the daemon. That matches the follow-up report on #105: target set to 50%, charging still stops at 80%.

## Fix

Per-connector EV settings now have two explicit sources with a precedence rule: **an active scenario/explicit override wins over default propagation**.

- `Connector` gains override tracking: `applyEvSettingsOverride(partial)` (merge + mark), `applyDefaultEvSettings(settings)` (no-op while overridden), `clearEvSettingsOverride()` (unmark, keep values).
- Scenario `onSetEVSettings` and explicit `set_ev_settings` route through the override path; default propagation routes through the default path in all three services (local, daemon registry, remote).
- Remote default propagation uses a new daemon-level RPC `ev_settings.apply_default` instead of per-connector `set_ev_settings` fan-out — one round trip, and it can no longer masquerade as an explicit override.
- The override is released when the scenario that declared `evSettings` stops or completes — scenarios that never touch EV settings can't wipe an explicit override (guarded at all five stop/completion sites). Concurrent evSettings-declaring scenarios on one connector remain a documented edge.

## Tests

- Connector unit tests for the three new methods (merge/no-op/clear semantics).
- ScenarioManager + real `CLIChargePointService` (via registry harness) regression tests: override survives a no-evSettings scenario's full lifecycle and a default push; an evSettings-declaring scenario still releases on stop and natural completion; RED verified before each guard.
- Remote RPC contract tests updated for `ev_settings.apply_default`.
- Gates: eslint clean, vitest 411 passed, bun test 108 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)