### PR TITLE
feat(ocpp): implement the remaining OCPP 1.6 Security Whitepaper message set

### DIFF
--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -682,6 +682,43 @@ export class ChargePoint {
     this._outbox.sendFirmwareStatusNotification(status);
   }
 
+  /** Send LogStatusNotification.req — see OCPPMessageHandler doc. */
+  sendLogStatusNotification(
+    status:
+      | "BadMessage"
+      | "Idle"
+      | "NotSupportedOperation"
+      | "PermissionDenied"
+      | "Uploaded"
+      | "UploadFailure"
+      | "Uploading",
+    requestId?: number,
+  ): void {
+    this._outbox.sendLogStatusNotification(status, requestId);
+  }
+
+  /** Send SignedFirmwareStatusNotification.req — see OCPPMessageHandler doc. */
+  sendSignedFirmwareStatusNotification(
+    status:
+      | "Downloaded"
+      | "DownloadFailed"
+      | "Downloading"
+      | "DownloadScheduled"
+      | "DownloadPaused"
+      | "Idle"
+      | "InstallationFailed"
+      | "Installing"
+      | "Installed"
+      | "InstallRebooting"
+      | "InstallScheduled"
+      | "InstallVerificationFailed"
+      | "InvalidSignature"
+      | "SignatureVerified",
+    requestId?: number,
+  ): void {
+    this._outbox.sendSignedFirmwareStatusNotification(status, requestId);
+  }
+
   /** Set while a simulated firmware update is in flight, so a second
    *  UpdateFirmware.req (the spec allows the CSMS to re-issue) doesn't
    *  fork a parallel status train. */
@@ -730,6 +767,66 @@ export class ChargePoint {
 
     const startTimer = setTimeout(() => fireStep(0), startDelay);
     this._firmwareUpdateTimers.push(startTimer);
+  }
+
+  /** Mirrors `_firmwareUpdateInFlight` / `_firmwareUpdateTimers` for the
+   *  signed variant — kept separate so a SignedUpdateFirmware.req can't
+   *  collide with (or be blocked by) a plain UpdateFirmware.req train. */
+  private _signedFirmwareUpdateInFlight = false;
+  private _signedFirmwareUpdateTimers: NodeJS.Timeout[] = [];
+
+  /**
+   * OCPP 1.6 Security Whitepaper SignedUpdateFirmware.req: schedules a
+   * simulated signed firmware update progression. After `retrieveDate` is
+   * reached, fires SignedFirmwareStatusNotification.req in sequence —
+   * Downloading → Downloaded → SignatureVerified → Installing → Installed
+   * — with `intervalMs` between each transition, carrying `requestId` on
+   * every notification. Same "no real binary, just walk the status
+   * machine" approach as `simulateFirmwareUpdate` — no signature is
+   * actually verified.
+   */
+  simulateSignedFirmwareUpdate(
+    retrieveDate: Date,
+    requestId: number,
+    intervalMs = 2000,
+  ): void {
+    if (this._signedFirmwareUpdateInFlight) {
+      this._logger.warn(
+        "SignedUpdateFirmware: a previous simulated update is still in flight; ignoring",
+        LogType.OCPP,
+      );
+      return;
+    }
+    this._signedFirmwareUpdateInFlight = true;
+
+    const startDelay = Math.max(0, retrieveDate.getTime() - Date.now());
+    const sequence: Array<
+      | "Downloading"
+      | "Downloaded"
+      | "SignatureVerified"
+      | "Installing"
+      | "Installed"
+    > = [
+      "Downloading",
+      "Downloaded",
+      "SignatureVerified",
+      "Installing",
+      "Installed",
+    ];
+
+    const fireStep = (index: number) => {
+      if (index >= sequence.length) {
+        this._signedFirmwareUpdateInFlight = false;
+        this._signedFirmwareUpdateTimers = [];
+        return;
+      }
+      this.sendSignedFirmwareStatusNotification(sequence[index], requestId);
+      const t = setTimeout(() => fireStep(index + 1), intervalMs);
+      this._signedFirmwareUpdateTimers.push(t);
+    };
+
+    const startTimer = setTimeout(() => fireStep(0), startDelay);
+    this._signedFirmwareUpdateTimers.push(startTimer);
   }
 
   /** Boot-notification gate accessors used by BootNotificationResultHandler. */
@@ -864,6 +961,10 @@ export class ChargePoint {
     this._firmwareUpdateTimers.forEach((t) => clearTimeout(t));
     this._firmwareUpdateTimers = [];
     this._firmwareUpdateInFlight = false;
+    // ...and the signed variant's simulation too.
+    this._signedFirmwareUpdateTimers.forEach((t) => clearTimeout(t));
+    this._signedFirmwareUpdateTimers = [];
+    this._signedFirmwareUpdateInFlight = false;
     this._scenarioHandledConnectors.clear();
     this._scenarioStopHandledConnectors.clear();
     // Cancel all ConnectionTimeOut watchdogs so the timer doesn't fire

--- a/src/cp/domain/charge-point/ConfigurationStore.ts
+++ b/src/cp/domain/charge-point/ConfigurationStore.ts
@@ -201,6 +201,11 @@ export class ConfigurationStore {
     return this.getInteger("ConnectionTimeOut") ?? 60;
   }
 
+  /** Canonical key `CertificateStoreMaxLength`; default `10`. */
+  certificateStoreMaxLength(): number {
+    return this.getInteger("CertificateStoreMaxLength") ?? 10;
+  }
+
   /**
    * Apply a ChangeConfiguration.req: parses the string value into the key's
    * declared type, persists, fires listeners, and returns the spec-defined

--- a/src/cp/domain/security/CertificateStore.ts
+++ b/src/cp/domain/security/CertificateStore.ts
@@ -45,6 +45,22 @@ export class CertificateStore {
     return this.#rootCerts.map((cert) => ({ ...cert }));
   }
 
+  /**
+   * Removes the first stored root certificate matching `predicate`
+   * (DeleteCertificate.req matches by `certificateHashData`, computed by
+   * the caller via `certificateHash.ts` — this store stays decoupled from
+   * the hashing/crypto concern). Returns `true` when a certificate was
+   * removed, `false` when nothing matched.
+   */
+  deleteRootCert(
+    predicate: (cert: InstalledRootCertificate) => boolean,
+  ): boolean {
+    const index = this.#rootCerts.findIndex(predicate);
+    if (index === -1) return false;
+    this.#rootCerts.splice(index, 1);
+    return true;
+  }
+
   clearAll(): void {
     this.#keyPair = undefined;
     this.#pendingCsrPem = undefined;

--- a/src/cp/domain/security/__tests__/certificateHash.test.ts
+++ b/src/cp/domain/security/__tests__/certificateHash.test.ts
@@ -28,21 +28,44 @@ async function selfSignedRootCert(serialNumber: string, cn: string) {
   return { cert, pem: cert.toString("pem") };
 }
 
+/**
+ * Fixed known-answer fixture, generated and hashed entirely OUTSIDE the
+ * library under test (OpenSSL 3.6.2):
+ *
+ *   openssl ecparam -name prime256v1 -genkey -noout -out key.pem
+ *   openssl req -new -x509 -key key.pem -days 7300 -sha256 \
+ *     -subj "/CN=OCPP KAT Root CA/O=Example CPO" -set_serial 0x0aa2b3
+ *
+ * Expected hashes derived from the DER via `openssl asn1parse` offsets and
+ * `openssl dgst -sha256`: issuerNameHash over the issuer Name SEQUENCE
+ * (51 bytes at offset 30); issuerKeyHash over the subjectPublicKey BIT
+ * STRING content minus the leading unused-bits octet (65 bytes at offset
+ * 190 — the 0x04-prefixed uncompressed EC point).
+ */
+const KAT_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIBpjCCAUygAwIBAgIDCqKzMAoGCCqGSM49BAMCMDExGTAXBgNVBAMMEE9DUFAg
+S0FUIFJvb3QgQ0ExFDASBgNVBAoMC0V4YW1wbGUgQ1BPMB4XDTI2MDcwNzExNDQw
+NloXDTQ2MDcwMjExNDQwNlowMTEZMBcGA1UEAwwQT0NQUCBLQVQgUm9vdCBDQTEU
+MBIGA1UECgwLRXhhbXBsZSBDUE8wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATF
+sHwsmYjqvegLgl3oDlAHvalUN6+rj99NXr2TgkSFzfIe7fBNb2fzLeV8zLFXJ7if
+z5JXpaljzbIaVkr9N5FIo1MwUTAdBgNVHQ4EFgQU2hS5MJMuHrIOcgETuqpDbQkC
+2gUwHwYDVR0jBBgwFoAU2hS5MJMuHrIOcgETuqpDbQkC2gUwDwYDVR0TAQH/BAUw
+AwEB/zAKBggqhkjOPQQDAgNIADBFAiEAgNy7JC9GKPvwAr0H18p/x78OAlUHPeg9
+8UGq9LUH7SQCICG3tEVQJC6tLIZOar+KzwF3dGbOHRk6kK4tuI+pq1kw
+-----END CERTIFICATE-----`;
+
 describe("computeCertificateHashData", () => {
-  it("computes issuerNameHash as SHA-256 over the DER-encoded issuer Name", async () => {
-    const { cert, pem } = await selfSignedRootCert("01a2b3", "Test Root CA");
-    const result = await computeCertificateHashData(pem);
+  it("matches OpenSSL-derived known-answer hashes for a fixed certificate", async () => {
+    const result = await computeCertificateHashData(KAT_CERT_PEM);
 
-    const expected = await crypto.subtle.digest(
-      "SHA-256",
-      cert.issuerName.toArrayBuffer(),
-    );
-    const expectedHex = Array.from(new Uint8Array(expected))
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
-
-    expect(result.issuerNameHash).toBe(expectedHex);
-    expect(result.issuerNameHash).toHaveLength(64);
+    expect(result).toEqual({
+      hashAlgorithm: "SHA256",
+      issuerNameHash:
+        "2f1e564ddbf440fc551bf9d5284e6700c64a42fb685d5c9db91f606a721c0fa4",
+      issuerKeyHash:
+        "e5330c333975c58e5d299572140e2663337dfc1714ea5c85f581151b5eae8059",
+      serialNumber: "0aa2b3",
+    });
   });
 
   /**

--- a/src/cp/domain/security/__tests__/certificateHash.test.ts
+++ b/src/cp/domain/security/__tests__/certificateHash.test.ts
@@ -1,0 +1,121 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import * as x509 from "@peculiar/x509";
+import {
+  certificateHashDataEquals,
+  computeCertificateHashData,
+} from "../certificateHash";
+
+x509.cryptoProvider.set(globalThis.crypto as Crypto);
+
+const EC_ALG = { name: "ECDSA", namedCurve: "P-256", hash: "SHA-256" } as const;
+
+async function selfSignedRootCert(serialNumber: string, cn: string) {
+  const keys = await crypto.subtle.generateKey(EC_ALG, true, [
+    "sign",
+    "verify",
+  ]);
+  const now = Date.now();
+  const cert = await x509.X509CertificateGenerator.createSelfSigned({
+    serialNumber,
+    name: `CN=${cn},O=Example`,
+    notBefore: new Date(now - 60_000),
+    notAfter: new Date(now + 86_400_000),
+    signingAlgorithm: EC_ALG,
+    keys,
+    extensions: [new x509.BasicConstraintsExtension(true, undefined, true)],
+  });
+  return { cert, pem: cert.toString("pem") };
+}
+
+describe("computeCertificateHashData", () => {
+  it("computes issuerNameHash as SHA-256 over the DER-encoded issuer Name", async () => {
+    const { cert, pem } = await selfSignedRootCert("01a2b3", "Test Root CA");
+    const result = await computeCertificateHashData(pem);
+
+    const expected = await crypto.subtle.digest(
+      "SHA-256",
+      cert.issuerName.toArrayBuffer(),
+    );
+    const expectedHex = Array.from(new Uint8Array(expected))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    expect(result.issuerNameHash).toBe(expectedHex);
+    expect(result.issuerNameHash).toHaveLength(64);
+  });
+
+  /**
+   * Independent cross-check that does NOT reuse @peculiar/x509's
+   * `getKeyIdentifier` internals: export the certificate's public key as a
+   * raw EC point via WebCrypto (`exportKey("raw", ...)` — the uncompressed
+   * point, with no ASN.1 framing at all) and hash that directly. For an EC
+   * key the BIT STRING content (minus the always-zero "unused bits" byte)
+   * *is* the raw point, so this independently confirms issuerKeyHash is
+   * "SHA-256 over the subjectPublicKey bits, no tag/length/unused-bits
+   * byte" rather than e.g. a hash of the whole SubjectPublicKeyInfo DER.
+   */
+  it("computes issuerKeyHash matching an independent WebCrypto raw-point hash", async () => {
+    const { cert, pem } = await selfSignedRootCert("01", "Test Root CA 2");
+    const result = await computeCertificateHashData(pem);
+
+    const cryptoKey = await cert.publicKey.export(EC_ALG, ["verify"]);
+    const rawPoint = await crypto.subtle.exportKey("raw", cryptoKey);
+    const expected = await crypto.subtle.digest("SHA-256", rawPoint);
+    const expectedHex = Array.from(new Uint8Array(expected))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    expect(result.issuerKeyHash).toBe(expectedHex);
+    expect(result.issuerKeyHash).toHaveLength(64);
+  });
+
+  it("reports hashAlgorithm SHA256 and a sign-padding-stripped hex serialNumber", async () => {
+    const { pem } = await selfSignedRootCert("ff0102", "Serial Test");
+    const result = await computeCertificateHashData(pem);
+
+    expect(result.hashAlgorithm).toBe("SHA256");
+    // DER requires a leading 0x00 pad byte when the high bit of the first
+    // declared byte is set (0xff here) to keep the INTEGER non-negative;
+    // the reported serial must not carry that padding.
+    expect(result.serialNumber).toBe("ff0102");
+  });
+
+  it("produces different hashes for different keys/issuers", async () => {
+    const a = await selfSignedRootCert("01", "Root A");
+    const b = await selfSignedRootCert("01", "Root B");
+    const hashA = await computeCertificateHashData(a.pem);
+    const hashB = await computeCertificateHashData(b.pem);
+
+    expect(hashA.issuerNameHash).not.toBe(hashB.issuerNameHash);
+    expect(hashA.issuerKeyHash).not.toBe(hashB.issuerKeyHash);
+  });
+});
+
+describe("certificateHashDataEquals", () => {
+  it("compares case-insensitively across all fields", async () => {
+    const { pem } = await selfSignedRootCert("0a", "Case Test");
+    const hash = await computeCertificateHashData(pem);
+
+    expect(
+      certificateHashDataEquals(hash, {
+        hashAlgorithm: hash.hashAlgorithm,
+        issuerNameHash: hash.issuerNameHash.toUpperCase(),
+        issuerKeyHash: hash.issuerKeyHash.toUpperCase(),
+        serialNumber: hash.serialNumber.toUpperCase(),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when any field differs", async () => {
+    const { pem } = await selfSignedRootCert("0b", "Mismatch Test");
+    const hash = await computeCertificateHashData(pem);
+
+    expect(
+      certificateHashDataEquals(hash, {
+        ...hash,
+        serialNumber: "ffffff",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/cp/domain/security/certificateHash.ts
+++ b/src/cp/domain/security/certificateHash.ts
@@ -1,0 +1,73 @@
+import "reflect-metadata";
+import * as x509 from "@peculiar/x509";
+
+x509.cryptoProvider.set(globalThis.crypto as Crypto);
+
+export type HashAlgorithm = "SHA256";
+
+/** OCPP 1.6 Security Whitepaper `CertificateHashDataType`. */
+export interface CertificateHashData {
+  hashAlgorithm: HashAlgorithm;
+  issuerNameHash: string;
+  issuerKeyHash: string;
+  serialNumber: string;
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Computes the OCPP 1.6 Security Whitepaper `certificateHashData` for a
+ * stored root certificate (GetInstalledCertificateIds / DeleteCertificate).
+ * Root certificates are self-signed, so the "issuer" fields — which
+ * normally identify the CA that signed the certificate under inspection —
+ * resolve to the certificate's own subject name and public key.
+ *
+ * - issuerNameHash: SHA-256 over the DER encoding of the issuer Name.
+ * - issuerKeyHash: SHA-256 over the subjectPublicKey BIT STRING content,
+ *   excluding the tag, length, and leading "unused bits" octet — the RFC
+ *   5280 §4.2.1.2 Subject Key Identifier method (1) formula, and the same
+ *   value produced by OpenSSL's X509_pubkey_digest (the de facto
+ *   reference implementation behind RFC 6960 issuerKeyHash in real-world
+ *   CSMS stacks). Verified against an independent asn1js BIT STRING parse
+ *   in certificateHash.test.ts.
+ * - serialNumber: hex string, sign-padding byte stripped by @peculiar/x509.
+ */
+export async function computeCertificateHashData(
+  pem: string,
+): Promise<CertificateHashData> {
+  const cert = new x509.X509Certificate(pem);
+  const issuerNameHash = await crypto.subtle.digest(
+    "SHA-256",
+    cert.issuerName.toArrayBuffer(),
+  );
+  const issuerKeyHash = await cert.publicKey.getKeyIdentifier("SHA-256");
+
+  return {
+    hashAlgorithm: "SHA256",
+    issuerNameHash: toHex(issuerNameHash),
+    issuerKeyHash: toHex(issuerKeyHash),
+    serialNumber: cert.serialNumber,
+  };
+}
+
+/** Case-insensitive field comparison — CSMS implementations vary on hex casing. */
+export function certificateHashDataEquals(
+  a: CertificateHashData,
+  b: {
+    hashAlgorithm: string;
+    issuerNameHash: string;
+    issuerKeyHash: string;
+    serialNumber: string;
+  },
+): boolean {
+  return (
+    a.hashAlgorithm === b.hashAlgorithm &&
+    a.issuerNameHash.toLowerCase() === b.issuerNameHash.toLowerCase() &&
+    a.issuerKeyHash.toLowerCase() === b.issuerKeyHash.toLowerCase() &&
+    a.serialNumber.toLowerCase() === b.serialNumber.toLowerCase()
+  );
+}

--- a/src/cp/domain/security/certificateHash.ts
+++ b/src/cp/domain/security/certificateHash.ts
@@ -32,8 +32,12 @@ function toHex(buffer: ArrayBuffer): string {
  *   5280 §4.2.1.2 Subject Key Identifier method (1) formula, and the same
  *   value produced by OpenSSL's X509_pubkey_digest (the de facto
  *   reference implementation behind RFC 6960 issuerKeyHash in real-world
- *   CSMS stacks). Verified against an independent asn1js BIT STRING parse
- *   in certificateHash.test.ts.
+ *   CSMS stacks). Verified in certificateHash.test.ts two independent
+ *   ways: against SHA-256 over the raw EC point exported via WebCrypto
+ *   (`exportKey("raw", ...)` — for EC keys, exactly the BIT STRING
+ *   content with no ASN.1 framing), and against known-answer hashes
+ *   precomputed with `openssl asn1parse` + `openssl dgst -sha256` for a
+ *   fixed certificate.
  * - serialNumber: hex string, sign-padding byte stripped by @peculiar/x509.
  */
 export async function computeCertificateHashData(

--- a/src/cp/domain/transport/Outbox.ts
+++ b/src/cp/domain/transport/Outbox.ts
@@ -92,6 +92,30 @@ export class Outbox implements IChargePointMessageHandler {
     return this.handler.sendFirmwareStatusNotification(status);
   }
 
+  sendLogStatusNotification(
+    status: Parameters<
+      IChargePointMessageHandler["sendLogStatusNotification"]
+    >[0],
+    requestId?: Parameters<
+      IChargePointMessageHandler["sendLogStatusNotification"]
+    >[1],
+  ): ReturnType<IChargePointMessageHandler["sendLogStatusNotification"]> {
+    return this.handler.sendLogStatusNotification(status, requestId);
+  }
+
+  sendSignedFirmwareStatusNotification(
+    status: Parameters<
+      IChargePointMessageHandler["sendSignedFirmwareStatusNotification"]
+    >[0],
+    requestId?: Parameters<
+      IChargePointMessageHandler["sendSignedFirmwareStatusNotification"]
+    >[1],
+  ): ReturnType<
+    IChargePointMessageHandler["sendSignedFirmwareStatusNotification"]
+  > {
+    return this.handler.sendSignedFirmwareStatusNotification(status, requestId);
+  }
+
   setBootStatus(
     status: Parameters<IChargePointMessageHandler["setBootStatus"]>[0],
   ): ReturnType<IChargePointMessageHandler["setBootStatus"]> {

--- a/src/cp/domain/transport/__tests__/Outbox.test.ts
+++ b/src/cp/domain/transport/__tests__/Outbox.test.ts
@@ -95,6 +95,22 @@ class FakeMessageHandler implements IChargePointMessageHandler {
     this.record("sendFirmwareStatusNotification", args);
   }
 
+  sendLogStatusNotification(
+    ...args: Parameters<IChargePointMessageHandler["sendLogStatusNotification"]>
+  ): ReturnType<IChargePointMessageHandler["sendLogStatusNotification"]> {
+    this.record("sendLogStatusNotification", args);
+  }
+
+  sendSignedFirmwareStatusNotification(
+    ...args: Parameters<
+      IChargePointMessageHandler["sendSignedFirmwareStatusNotification"]
+    >
+  ): ReturnType<
+    IChargePointMessageHandler["sendSignedFirmwareStatusNotification"]
+  > {
+    this.record("sendSignedFirmwareStatusNotification", args);
+  }
+
   setBootStatus(
     ...args: Parameters<IChargePointMessageHandler["setBootStatus"]>
   ): ReturnType<IChargePointMessageHandler["setBootStatus"]> {
@@ -212,6 +228,15 @@ describe("Outbox", () => {
 
     outbox.sendFirmwareStatusNotification("Downloaded");
     expectCall(handler, "sendFirmwareStatusNotification", ["Downloaded"]);
+
+    outbox.sendLogStatusNotification("Uploading", 7);
+    expectCall(handler, "sendLogStatusNotification", ["Uploading", 7]);
+
+    outbox.sendSignedFirmwareStatusNotification("Downloading", 9);
+    expectCall(handler, "sendSignedFirmwareStatusNotification", [
+      "Downloading",
+      9,
+    ]);
 
     outbox.setBootStatus(bootStatus);
     expectCall(handler, "setBootStatus", [bootStatus]);

--- a/src/cp/infrastructure/transport/IChargePointMessageHandler.ts
+++ b/src/cp/infrastructure/transport/IChargePointMessageHandler.ts
@@ -34,6 +34,11 @@ export interface IChargePointMessageHandler {
   sendSignCertificate(csr?: string): Promise<void>;
   sendDiagnosticsStatusNotification(status: string): void;
   sendFirmwareStatusNotification(status: string): void;
+  sendLogStatusNotification(status: string, requestId?: number): void;
+  sendSignedFirmwareStatusNotification(
+    status: string,
+    requestId?: number,
+  ): void;
   setBootStatus(
     status:
       | { status: "Idle" }

--- a/src/cp/infrastructure/transport/OCPPMessageHandler.ts
+++ b/src/cp/infrastructure/transport/OCPPMessageHandler.ts
@@ -11,16 +11,23 @@ import type {
   ClearChargingProfileRequestV16,
   DataTransferRequestV16,
   DataTransferResponseV16,
+  DeleteCertificateRequestV16,
   DiagnosticsStatusNotificationRequestV16,
   DiagnosticsStatusNotificationResponseV16,
+  ExtendedTriggerMessageRequestV16,
   FirmwareStatusNotificationRequestV16,
   FirmwareStatusNotificationResponseV16,
   GetCompositeScheduleRequestV16,
   GetConfigurationRequestV16,
   GetDiagnosticsRequestV16,
+  GetInstalledCertificateIdsRequestV16,
   GetLocalListVersionRequestV16,
+  GetLogRequestV16,
   HeartbeatRequestV16,
   HeartbeatResponseV16,
+  InstallCertificateRequestV16,
+  LogStatusNotificationRequestV16,
+  LogStatusNotificationResponseV16,
   MeterValuesRequestV16,
   MeterValuesResponseV16,
   RemoteStartTransactionRequestV16,
@@ -33,6 +40,9 @@ import type {
   SecurityEventNotificationResponseV16,
   SignCertificateRequestV16,
   SignCertificateResponseV16,
+  SignedFirmwareStatusNotificationRequestV16,
+  SignedFirmwareStatusNotificationResponseV16,
+  SignedUpdateFirmwareRequestV16,
   StartTransactionRequestV16,
   StartTransactionResponseV16,
   StatusNotificationRequestV16,
@@ -101,6 +111,12 @@ import {
   SendLocalListHandler,
   UpdateFirmwareHandler,
   CertificateSignedHandler,
+  ExtendedTriggerMessageHandler,
+  InstallCertificateHandler,
+  GetInstalledCertificateIdsHandler,
+  DeleteCertificateHandler,
+  GetLogHandler,
+  SignedUpdateFirmwareHandler,
 } from "./handlers";
 
 type CoreOcppMessagePayloadCall =
@@ -115,7 +131,8 @@ type CoreOcppMessagePayloadCall =
 
 type FirmwareManagementOcppMessagePayloadCall =
   | GetDiagnosticsRequestV16
-  | UpdateFirmwareRequestV16;
+  | UpdateFirmwareRequestV16
+  | SignedUpdateFirmwareRequestV16;
 
 type LocalAuthListManagementOcppMessagePayloadCall =
   | GetLocalListVersionRequestV16
@@ -130,9 +147,16 @@ type SmartChargingOcppMessagePayloadCall =
   | GetCompositeScheduleRequestV16
   | SetChargingProfileRequestV16;
 
-type RemoteTriggerOcppMessagePayloadCall = TriggerMessageRequestV16;
+type RemoteTriggerOcppMessagePayloadCall =
+  | TriggerMessageRequestV16
+  | ExtendedTriggerMessageRequestV16;
 
-type SecurityExtensionOcppMessagePayloadCall = CertificateSignedRequestV16;
+type SecurityExtensionOcppMessagePayloadCall =
+  | CertificateSignedRequestV16
+  | InstallCertificateRequestV16
+  | GetInstalledCertificateIdsRequestV16
+  | DeleteCertificateRequestV16
+  | GetLogRequestV16;
 
 type OcppMessagePayloadCall =
   | CoreOcppMessagePayloadCall
@@ -156,11 +180,13 @@ type CoreOcppMessagePayloadCallResult =
 
 type FirmwareManagementOcppMessagePayloadCallResult =
   | DiagnosticsStatusNotificationResponseV16
-  | FirmwareStatusNotificationResponseV16;
+  | FirmwareStatusNotificationResponseV16
+  | SignedFirmwareStatusNotificationResponseV16;
 
 type SecurityExtensionOcppMessagePayloadCallResult =
   | SecurityEventNotificationResponseV16
-  | SignCertificateResponseV16;
+  | SignCertificateResponseV16
+  | LogStatusNotificationResponseV16;
 
 type OcppMessagePayloadCallResult =
   | CoreOcppMessagePayloadCallResult
@@ -368,6 +394,33 @@ export class OCPPMessageHandler {
     this._registry.registerCallHandler(
       OCPPAction.CertificateSigned,
       new CertificateSignedHandler(),
+    );
+    // OCPP 1.6 Security Whitepaper (ed. 4): remaining message set —
+    // ExtendedTriggerMessage/InstallCertificate/GetInstalledCertificateIds/
+    // DeleteCertificate/GetLog/SignedUpdateFirmware. Matching outbound
+    // status notifications fire from inside the handlers themselves (or,
+    // for SignedUpdateFirmware, ChargePoint.simulateSignedFirmwareUpdate) —
+    // there is no CALLRESULT counterpart to register for any of these.
+    this._registry.registerCallHandler(
+      OCPPAction.ExtendedTriggerMessage,
+      new ExtendedTriggerMessageHandler(),
+    );
+    this._registry.registerCallHandler(
+      OCPPAction.InstallCertificate,
+      new InstallCertificateHandler(),
+    );
+    this._registry.registerCallHandler(
+      OCPPAction.GetInstalledCertificateIds,
+      new GetInstalledCertificateIdsHandler(),
+    );
+    this._registry.registerCallHandler(
+      OCPPAction.DeleteCertificate,
+      new DeleteCertificateHandler(),
+    );
+    this._registry.registerCallHandler(OCPPAction.GetLog, new GetLogHandler());
+    this._registry.registerCallHandler(
+      OCPPAction.SignedUpdateFirmware,
+      new SignedUpdateFirmwareHandler(),
     );
 
     // Register CALLRESULT handlers (incoming responses from central system)
@@ -594,6 +647,65 @@ export class OCPPMessageHandler {
     const messageId = this.generateMessageId();
     const payload: FirmwareStatusNotificationRequestV16 = { status };
     this.sendRequest(OCPPAction.FirmwareStatusNotification, messageId, payload);
+  }
+
+  /**
+   * OCPP 1.6 Security Whitepaper LogStatusNotification.req. `requestId`
+   * carries the id from the triggering GetLog.req (TriggerMessage-driven
+   * `Idle` sends have none).
+   */
+  public sendLogStatusNotification(
+    status:
+      | "BadMessage"
+      | "Idle"
+      | "NotSupportedOperation"
+      | "PermissionDenied"
+      | "Uploaded"
+      | "UploadFailure"
+      | "Uploading",
+    requestId?: number,
+  ): void {
+    const messageId = this.generateMessageId();
+    const payload: LogStatusNotificationRequestV16 = {
+      status,
+      ...(requestId !== undefined ? { requestId } : {}),
+    };
+    this.sendRequest(OCPPAction.LogStatusNotification, messageId, payload);
+  }
+
+  /**
+   * OCPP 1.6 Security Whitepaper SignedFirmwareStatusNotification.req —
+   * the signed counterpart to FirmwareStatusNotification, carrying the
+   * `requestId` from the triggering SignedUpdateFirmware.req.
+   */
+  public sendSignedFirmwareStatusNotification(
+    status:
+      | "Downloaded"
+      | "DownloadFailed"
+      | "Downloading"
+      | "DownloadScheduled"
+      | "DownloadPaused"
+      | "Idle"
+      | "InstallationFailed"
+      | "Installing"
+      | "Installed"
+      | "InstallRebooting"
+      | "InstallScheduled"
+      | "InstallVerificationFailed"
+      | "InvalidSignature"
+      | "SignatureVerified",
+    requestId?: number,
+  ): void {
+    const messageId = this.generateMessageId();
+    const payload: SignedFirmwareStatusNotificationRequestV16 = {
+      status,
+      ...(requestId !== undefined ? { requestId } : {}),
+    };
+    this.sendRequest(
+      OCPPAction.SignedFirmwareStatusNotification,
+      messageId,
+      payload,
+    );
   }
 
   /**
@@ -849,7 +961,16 @@ export class OCPPMessageHandler {
     );
     switch (messageType) {
       case OCPPMessageType.CALL:
-        this.handleCall(messageId, action, payload as OcppMessagePayloadCall);
+        // Some handlers (e.g. GetInstalledCertificateIds/DeleteCertificate)
+        // compute certificate hashes via WebCrypto and are `async`; handleCall
+        // awaits `handler.handle()` internally. Not awaited here — CALL
+        // handling is fire-and-forget, matching the rest of this dispatch
+        // loop (nothing downstream depends on completion order).
+        void this.handleCall(
+          messageId,
+          action,
+          payload as OcppMessagePayloadCall,
+        );
         break;
       case OCPPMessageType.CALLRESULT:
         this.handleCallResult(
@@ -868,11 +989,11 @@ export class OCPPMessageHandler {
     }
   }
 
-  private handleCall(
+  private async handleCall(
     messageId: string,
     action: OCPPAction,
     payload: OcppMessagePayloadCall,
-  ): void {
+  ): Promise<void> {
     // Use registry to get handler
     const handler = this._registry.getCallHandler(action);
 
@@ -891,7 +1012,10 @@ export class OCPPMessageHandler {
         chargePoint: this._chargePoint,
         logger: this._logger,
       };
-      const response = handler.handle(payload, context);
+      // `handle()` may return its response synchronously or as a Promise
+      // (see `CallHandler` in MessageHandlerRegistry.ts) — `await` resolves
+      // a plain value immediately, so this is a no-op for sync handlers.
+      const response = await handler.handle(payload, context);
       this.sendCallResult(messageId, response);
     } catch (error) {
       this._logger.error(`Error handling ${action}: ${error}`, LogType.OCPP);

--- a/src/cp/infrastructure/transport/OCPPMessageHandlerV201.ts
+++ b/src/cp/infrastructure/transport/OCPPMessageHandlerV201.ts
@@ -531,6 +531,23 @@ export class OCPPMessageHandlerV201 implements IChargePointMessageHandler {
     );
   }
 
+  public sendLogStatusNotification(_status: string, _requestId?: number): void {
+    this._logger.warn(
+      "[v2.0.1] LogStatusNotification is a 1.6 Security Whitepaper message; not wired through this handler",
+      LogType.OCPP,
+    );
+  }
+
+  public sendSignedFirmwareStatusNotification(
+    _status: string,
+    _requestId?: number,
+  ): void {
+    this._logger.warn(
+      "[v2.0.1] SignedFirmwareStatusNotification is a 1.6 Security Whitepaper message; not wired through this handler",
+      LogType.OCPP,
+    );
+  }
+
   public setBootStatus(
     status:
       | { status: "Idle" }

--- a/src/cp/infrastructure/transport/__tests__/v16SecurityWhitepaperExtras.bun.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/v16SecurityWhitepaperExtras.bun.test.ts
@@ -1,0 +1,316 @@
+import "reflect-metadata";
+import { describe, expect, it } from "bun:test";
+import * as x509 from "@peculiar/x509";
+
+import type {
+  DeleteCertificateResponseV16,
+  GetInstalledCertificateIdsResponseV16,
+  InstallCertificateResponseV16,
+} from "../../../../ocpp";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+import { startMockCsms } from "./mockCsms";
+
+x509.cryptoProvider.set(globalThis.crypto as Crypto);
+
+const EC_ALG = { name: "ECDSA", namedCurve: "P-256", hash: "SHA-256" } as const;
+
+function canBindBunServe(): boolean {
+  try {
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("ok");
+      },
+    });
+    void server.stop(true);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function selfSignedRootCertPem(): Promise<string> {
+  const keys = await crypto.subtle.generateKey(EC_ALG, true, [
+    "sign",
+    "verify",
+  ]);
+  const now = Date.now();
+  const cert = await x509.X509CertificateGenerator.createSelfSigned({
+    serialNumber: "01",
+    name: "CN=Extras Root CA,O=Example",
+    notBefore: new Date(now - 60_000),
+    notAfter: new Date(now + 86_400_000),
+    signingAlgorithm: EC_ALG,
+    keys,
+    extensions: [new x509.BasicConstraintsExtension(true, undefined, true)],
+  });
+  return cert.toString("pem");
+}
+
+/** Boots the CP and drains the post-boot StatusNotification fan-out
+ *  (connector 0 + connector 1) so it doesn't interfere with later
+ *  `waitForCall` assertions. No SecurityProfile is set, so no
+ *  SecurityEventNotification(StartupOfTheDevice) is expected. */
+async function bootAndDrain(
+  csms: ReturnType<typeof startMockCsms>,
+): Promise<void> {
+  const boot = await csms.waitForCall("BootNotification");
+  csms.replyCallResult(boot.messageId, {
+    status: "Accepted",
+    currentTime: "2026-06-30T00:00:00.000Z",
+    interval: 300,
+  });
+  for (const connectorId of [0, 1]) {
+    const frame = await csms.waitForFrame(
+      (candidate) =>
+        candidate[0] === 2 &&
+        candidate[2] === "StatusNotification" &&
+        (candidate[3] as { connectorId?: number }).connectorId === connectorId,
+    );
+    csms.replyCallResult(frame[1] as string, {});
+  }
+}
+
+describe.skipIf(!canBindBunServe())(
+  "OCPP 1.6 Security Whitepaper — remaining message set (#94b) wiring",
+  () => {
+    it("ExtendedTriggerMessage(Heartbeat) is accepted and fires a Heartbeat", async () => {
+      const csms = startMockCsms();
+      const cp = new ChargePoint(
+        "CP016-XTM",
+        DefaultBootNotification,
+        1,
+        csms.url,
+        null,
+        null,
+        null,
+        {},
+        [],
+        "OCPP-1.6J",
+        {},
+      );
+      cp.events.on("error", () => undefined);
+      try {
+        cp.connect();
+        await bootAndDrain(csms);
+
+        const messageId = crypto.randomUUID();
+        csms.send([
+          2,
+          messageId,
+          "ExtendedTriggerMessage",
+          {
+            requestedMessage: "Heartbeat",
+          },
+        ]);
+
+        const response = await csms.waitForFrame(
+          (frame) => frame[0] === 3 && frame[1] === messageId,
+        );
+        expect(response[2]).toEqual({ status: "Accepted" });
+
+        await csms.waitForCall("Heartbeat");
+      } finally {
+        cp.disconnect();
+        await csms.stop();
+      }
+    });
+
+    it("install → get → delete round-trips a root certificate over the wire", async () => {
+      const csms = startMockCsms();
+      const cp = new ChargePoint(
+        "CP016-CERTMGMT",
+        DefaultBootNotification,
+        1,
+        csms.url,
+        null,
+        null,
+        null,
+        {},
+        [],
+        "OCPP-1.6J",
+        {},
+      );
+      cp.events.on("error", () => undefined);
+      try {
+        cp.connect();
+        await bootAndDrain(csms);
+
+        const pem = await selfSignedRootCertPem();
+
+        const installId = crypto.randomUUID();
+        csms.send([
+          2,
+          installId,
+          "InstallCertificate",
+          {
+            certificateType: "ManufacturerRootCertificate",
+            certificate: pem,
+          },
+        ]);
+        const installResponse = await csms.waitForFrame(
+          (frame) => frame[0] === 3 && frame[1] === installId,
+        );
+        expect(installResponse[2] as InstallCertificateResponseV16).toEqual({
+          status: "Accepted",
+        });
+
+        const getId = crypto.randomUUID();
+        csms.send([
+          2,
+          getId,
+          "GetInstalledCertificateIds",
+          {
+            certificateType: "ManufacturerRootCertificate",
+          },
+        ]);
+        const getResponse = await csms.waitForFrame(
+          (frame) => frame[0] === 3 && frame[1] === getId,
+        );
+        const getPayload =
+          getResponse[2] as GetInstalledCertificateIdsResponseV16;
+        expect(getPayload.status).toBe("Accepted");
+        expect(getPayload.certificateHashData).toHaveLength(1);
+
+        const deleteId = crypto.randomUUID();
+        csms.send([
+          2,
+          deleteId,
+          "DeleteCertificate",
+          {
+            certificateHashData: getPayload.certificateHashData![0],
+          },
+        ]);
+        const deleteResponse = await csms.waitForFrame(
+          (frame) => frame[0] === 3 && frame[1] === deleteId,
+        );
+        expect(deleteResponse[2] as DeleteCertificateResponseV16).toEqual({
+          status: "Accepted",
+        });
+
+        expect(cp.certificateStore.listRootCerts()).toEqual([]);
+      } finally {
+        cp.disconnect();
+        await csms.stop();
+      }
+    });
+
+    it("GetLog is accepted and reports Uploading then Uploaded with requestId", async () => {
+      const csms = startMockCsms();
+      const cp = new ChargePoint(
+        "CP016-GETLOG",
+        DefaultBootNotification,
+        1,
+        csms.url,
+        null,
+        null,
+        null,
+        {},
+        [],
+        "OCPP-1.6J",
+        {},
+      );
+      cp.events.on("error", () => undefined);
+      try {
+        cp.connect();
+        await bootAndDrain(csms);
+
+        const messageId = crypto.randomUUID();
+        csms.send([
+          2,
+          messageId,
+          "GetLog",
+          {
+            logType: "DiagnosticsLog",
+            requestId: 77,
+            log: { remoteLocation: "http://example.invalid/upload" },
+          },
+        ]);
+
+        const response = await csms.waitForFrame(
+          (frame) => frame[0] === 3 && frame[1] === messageId,
+        );
+        expect(response[2]).toEqual({
+          status: "Accepted",
+          filename: "CP016-GETLOG-DiagnosticsLog-77.log",
+        });
+
+        const uploading = await csms.waitForCall("LogStatusNotification", 4000);
+        expect(uploading.payload).toEqual({
+          status: "Uploading",
+          requestId: 77,
+        });
+        csms.replyCallResult(uploading.messageId, {});
+
+        const uploaded = await csms.waitForFrame(
+          (frame) =>
+            frame[0] === 2 &&
+            frame[2] === "LogStatusNotification" &&
+            (frame[3] as { status?: string }).status === "Uploaded",
+          4000,
+        );
+        expect(uploaded[3]).toEqual({ status: "Uploaded", requestId: 77 });
+      } finally {
+        cp.disconnect();
+        await csms.stop();
+      }
+    });
+
+    it("SignedUpdateFirmware is accepted and starts the Downloading train with requestId", async () => {
+      const csms = startMockCsms();
+      const cp = new ChargePoint(
+        "CP016-SIGNEDFW",
+        DefaultBootNotification,
+        1,
+        csms.url,
+        null,
+        null,
+        null,
+        {},
+        [],
+        "OCPP-1.6J",
+        {},
+      );
+      cp.events.on("error", () => undefined);
+      try {
+        cp.connect();
+        await bootAndDrain(csms);
+
+        const messageId = crypto.randomUUID();
+        csms.send([
+          2,
+          messageId,
+          "SignedUpdateFirmware",
+          {
+            requestId: 55,
+            firmware: {
+              location: "http://example.invalid/firmware.bin",
+              retrieveDateTime: new Date().toISOString(),
+              signingCertificate:
+                "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
+              signature: "deadbeef",
+            },
+          },
+        ]);
+
+        const response = await csms.waitForFrame(
+          (frame) => frame[0] === 3 && frame[1] === messageId,
+        );
+        expect(response[2]).toEqual({ status: "Accepted" });
+
+        const downloading = await csms.waitForCall(
+          "SignedFirmwareStatusNotification",
+          4000,
+        );
+        expect(downloading.payload).toEqual({
+          status: "Downloading",
+          requestId: 55,
+        });
+      } finally {
+        cp.disconnect();
+        await csms.stop();
+      }
+    });
+  },
+);

--- a/src/cp/infrastructure/transport/handlers/MessageHandlerRegistry.ts
+++ b/src/cp/infrastructure/transport/handlers/MessageHandlerRegistry.ts
@@ -10,13 +10,23 @@ import type {
   ClearCacheRequestV16,
   ClearCacheResponseV16,
   DataTransferResponseV16,
+  DeleteCertificateRequestV16,
+  DeleteCertificateResponseV16,
+  ExtendedTriggerMessageRequestV16,
+  ExtendedTriggerMessageResponseV16,
   GetConfigurationRequestV16,
   GetConfigurationResponseV16,
   GetDiagnosticsRequestV16,
   GetDiagnosticsResponseV16,
+  GetInstalledCertificateIdsRequestV16,
+  GetInstalledCertificateIdsResponseV16,
   GetLocalListVersionRequestV16,
   GetLocalListVersionResponseV16,
+  GetLogRequestV16,
+  GetLogResponseV16,
   HeartbeatResponseV16,
+  InstallCertificateRequestV16,
+  InstallCertificateResponseV16,
   MeterValuesResponseV16,
   RemoteStartTransactionRequestV16,
   RemoteStartTransactionResponseV16,
@@ -28,6 +38,8 @@ import type {
   ResetResponseV16,
   SendLocalListRequestV16,
   SendLocalListResponseV16,
+  SignedUpdateFirmwareRequestV16,
+  SignedUpdateFirmwareResponseV16,
   StartTransactionResponseV16,
   StatusNotificationResponseV16,
   StopTransactionResponseV16,
@@ -51,10 +63,18 @@ export interface HandlerContext {
 }
 
 /**
- * Interface for handling CALL messages (requests from central system to charge point)
+ * Interface for handling CALL messages (requests from central system to charge point).
+ *
+ * `handle()` may return its response synchronously or as a `Promise` — the
+ * latter is needed by handlers that compute certificate hashes via
+ * WebCrypto (GetInstalledCertificateIds/DeleteCertificate). The dispatch
+ * loop (`OCPPMessageHandler.handleCall`) awaits the result either way.
  */
 export interface CallHandler<TRequest = unknown, TResponse = unknown> {
-  handle(payload: TRequest, context: HandlerContext): TResponse;
+  handle(
+    payload: TRequest,
+    context: HandlerContext,
+  ): TResponse | Promise<TResponse>;
 }
 
 /**
@@ -185,6 +205,27 @@ export type CallHandlerMap = {
   [OCPPAction.CertificateSigned]: CallHandler<
     CertificateSignedRequestV16,
     CertificateSignedResponseV16
+  >;
+  [OCPPAction.ExtendedTriggerMessage]: CallHandler<
+    ExtendedTriggerMessageRequestV16,
+    ExtendedTriggerMessageResponseV16
+  >;
+  [OCPPAction.InstallCertificate]: CallHandler<
+    InstallCertificateRequestV16,
+    InstallCertificateResponseV16
+  >;
+  [OCPPAction.GetInstalledCertificateIds]: CallHandler<
+    GetInstalledCertificateIdsRequestV16,
+    GetInstalledCertificateIdsResponseV16
+  >;
+  [OCPPAction.DeleteCertificate]: CallHandler<
+    DeleteCertificateRequestV16,
+    DeleteCertificateResponseV16
+  >;
+  [OCPPAction.GetLog]: CallHandler<GetLogRequestV16, GetLogResponseV16>;
+  [OCPPAction.SignedUpdateFirmware]: CallHandler<
+    SignedUpdateFirmwareRequestV16,
+    SignedUpdateFirmwareResponseV16
   >;
 };
 

--- a/src/cp/infrastructure/transport/handlers/call/CertificateManagementHandlers.ts
+++ b/src/cp/infrastructure/transport/handlers/call/CertificateManagementHandlers.ts
@@ -1,0 +1,173 @@
+import "reflect-metadata";
+import * as x509 from "@peculiar/x509";
+
+import type {
+  DeleteCertificateRequestV16,
+  DeleteCertificateResponseV16,
+  GetInstalledCertificateIdsRequestV16,
+  GetInstalledCertificateIdsResponseV16,
+  InstallCertificateRequestV16,
+  InstallCertificateResponseV16,
+} from "../../../../../ocpp";
+import {
+  isValidDeleteCertificateRequestV16,
+  isValidGetInstalledCertificateIdsRequestV16,
+  isValidInstallCertificateRequestV16,
+} from "../../../../../ocpp";
+import {
+  certificateHashDataEquals,
+  computeCertificateHashData,
+  type CertificateHashData,
+} from "../../../../domain/security/certificateHash";
+import { LogType } from "../../../../shared/Logger";
+import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
+
+x509.cryptoProvider.set(globalThis.crypto as Crypto);
+
+/**
+ * §2 InstallCertificate.req (OCPP 1.6 Security Whitepaper): stores a root
+ * certificate (CentralSystemRootCertificate / ManufacturerRootCertificate)
+ * for later use validating the CSMS or a firmware signer. `Rejected`
+ * covers both a malformed/unparseable PEM and a full certificate store —
+ * there is no dedicated status for the latter in the 1.6 whitepaper.
+ */
+export class InstallCertificateHandler
+  implements
+    CallHandler<InstallCertificateRequestV16, InstallCertificateResponseV16>
+{
+  handle(
+    payload: InstallCertificateRequestV16,
+    context: HandlerContext,
+  ): InstallCertificateResponseV16 {
+    if (!isValidInstallCertificateRequestV16(payload)) {
+      context.logger.warn(
+        "InstallCertificate rejected: invalid request payload",
+        LogType.OCPP,
+      );
+      return { status: "Rejected" };
+    }
+
+    try {
+      // Structural validation only; throws on malformed PEM.
+      new x509.X509Certificate(payload.certificate);
+    } catch {
+      context.logger.warn(
+        "InstallCertificate rejected: malformed certificate",
+        LogType.OCPP,
+      );
+      return { status: "Rejected" };
+    }
+
+    const store = context.chargePoint.certificateStore;
+    const maxLength =
+      context.chargePoint.configuration.certificateStoreMaxLength();
+    if (store.listRootCerts().length >= maxLength) {
+      context.logger.warn(
+        `InstallCertificate rejected: store at CertificateStoreMaxLength (${maxLength})`,
+        LogType.OCPP,
+      );
+      return { status: "Rejected" };
+    }
+
+    store.installRootCert(payload.certificateType, payload.certificate.trim());
+    context.logger.info(
+      `InstallCertificate accepted: type=${payload.certificateType}`,
+      LogType.OCPP,
+    );
+    return { status: "Accepted" };
+  }
+}
+
+/**
+ * §2 GetInstalledCertificateIds.req: reports `certificateHashData` for
+ * every stored root cert matching the requested `certificateType`. Hash
+ * computation is async (WebCrypto digest), so the registry's dispatch
+ * loop awaits `handle()` — see `MessageHandlerRegistry.CallHandler`.
+ */
+export class GetInstalledCertificateIdsHandler
+  implements
+    CallHandler<
+      GetInstalledCertificateIdsRequestV16,
+      GetInstalledCertificateIdsResponseV16
+    >
+{
+  async handle(
+    payload: GetInstalledCertificateIdsRequestV16,
+    context: HandlerContext,
+  ): Promise<GetInstalledCertificateIdsResponseV16> {
+    if (!isValidGetInstalledCertificateIdsRequestV16(payload)) {
+      context.logger.warn(
+        "GetInstalledCertificateIds: invalid request payload",
+        LogType.OCPP,
+      );
+      return { status: "NotFound" };
+    }
+
+    const matches = context.chargePoint.certificateStore
+      .listRootCerts()
+      .filter((cert) => cert.type === payload.certificateType);
+
+    if (matches.length === 0) {
+      context.logger.info(
+        `GetInstalledCertificateIds: no stored certs of type=${payload.certificateType}`,
+        LogType.OCPP,
+      );
+      return { status: "NotFound" };
+    }
+
+    const certificateHashData = (await Promise.all(
+      matches.map((cert) => computeCertificateHashData(cert.pem)),
+    )) as [CertificateHashData, ...CertificateHashData[]];
+
+    context.logger.info(
+      `GetInstalledCertificateIds: returning ${certificateHashData.length} entr${
+        certificateHashData.length === 1 ? "y" : "ies"
+      } for type=${payload.certificateType}`,
+      LogType.OCPP,
+    );
+    return { status: "Accepted", certificateHashData };
+  }
+}
+
+/**
+ * §2 DeleteCertificate.req: matches the request's `certificateHashData`
+ * against every stored root cert (across both types — the request itself
+ * carries no `certificateType`) and deletes on the first match.
+ */
+export class DeleteCertificateHandler
+  implements
+    CallHandler<DeleteCertificateRequestV16, DeleteCertificateResponseV16>
+{
+  async handle(
+    payload: DeleteCertificateRequestV16,
+    context: HandlerContext,
+  ): Promise<DeleteCertificateResponseV16> {
+    if (!isValidDeleteCertificateRequestV16(payload)) {
+      context.logger.warn(
+        "DeleteCertificate: invalid request payload",
+        LogType.OCPP,
+      );
+      return { status: "Failed" };
+    }
+
+    const store = context.chargePoint.certificateStore;
+    const target = payload.certificateHashData;
+    for (const cert of store.listRootCerts()) {
+      const hash = await computeCertificateHashData(cert.pem);
+      if (certificateHashDataEquals(hash, target)) {
+        store.deleteRootCert((c) => c.type === cert.type && c.pem === cert.pem);
+        context.logger.info(
+          `DeleteCertificate accepted: removed type=${cert.type}`,
+          LogType.OCPP,
+        );
+        return { status: "Accepted" };
+      }
+    }
+
+    context.logger.info(
+      "DeleteCertificate: no stored cert matched the given hash data",
+      LogType.OCPP,
+    );
+    return { status: "NotFound" };
+  }
+}

--- a/src/cp/infrastructure/transport/handlers/call/ExtendedTriggerMessageHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/ExtendedTriggerMessageHandler.ts
@@ -1,0 +1,99 @@
+import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
+import type {
+  ExtendedTriggerMessageRequestV16,
+  ExtendedTriggerMessageResponseV16,
+} from "../../../../../ocpp";
+import { LogType } from "../../../../shared/Logger";
+
+/**
+ * §2 ExtendedTriggerMessage.req (OCPP 1.6 Security Whitepaper): a superset
+ * of TriggerMessage.req (see `OtherCallHandlers.TriggerMessageHandler`)
+ * covering the three Security messages plus the original Core set. Same
+ * §6.51-style contract — respond Accepted/NotImplemented first, then fire
+ * the requested message via `queueMicrotask` so the CALLRESULT is on the
+ * wire before the new CALL.
+ */
+export class ExtendedTriggerMessageHandler
+  implements
+    CallHandler<
+      ExtendedTriggerMessageRequestV16,
+      ExtendedTriggerMessageResponseV16
+    >
+{
+  handle(
+    payload: ExtendedTriggerMessageRequestV16,
+    context: HandlerContext,
+  ): ExtendedTriggerMessageResponseV16 {
+    context.logger.info(
+      `Extended trigger message request received: ${payload.requestedMessage}` +
+        (payload.connectorId !== undefined
+          ? ` (connectorId=${payload.connectorId})`
+          : ""),
+      LogType.OCPP,
+    );
+
+    switch (payload.requestedMessage) {
+      case "StatusNotification":
+        queueMicrotask(() =>
+          context.chargePoint.sendCurrentStatusNotification(
+            payload.connectorId,
+          ),
+        );
+        return { status: "Accepted" };
+
+      case "Heartbeat":
+        queueMicrotask(() => context.chargePoint.sendHeartbeat());
+        return { status: "Accepted" };
+
+      case "MeterValues": {
+        const targetConnectorId = payload.connectorId;
+        queueMicrotask(() => {
+          if (targetConnectorId === undefined || targetConnectorId === 0) {
+            for (const id of context.chargePoint.connectors.keys()) {
+              context.chargePoint.sendMeterValue(id);
+            }
+            return;
+          }
+          context.chargePoint.sendMeterValue(targetConnectorId);
+        });
+        return { status: "Accepted" };
+      }
+
+      case "BootNotification":
+        // §5.17 + §4.2: permitted even while the boot gate is
+        // Pending/Rejected — same escape hatch as plain TriggerMessage.
+        queueMicrotask(() => context.chargePoint.boot());
+        return { status: "Accepted" };
+
+      case "SignChargePointCertificate":
+        queueMicrotask(() => {
+          context.chargePoint.sendSignCertificate().catch((err) => {
+            context.logger.warn(
+              `SignChargePointCertificate trigger failed: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+              LogType.OCPP,
+            );
+          });
+        });
+        return { status: "Accepted" };
+
+      case "LogStatusNotification":
+        // Not currently uploading a log — Idle, mirroring the
+        // DiagnosticsStatusNotification trigger contract.
+        queueMicrotask(() =>
+          context.chargePoint.sendLogStatusNotification("Idle"),
+        );
+        return { status: "Accepted" };
+
+      case "FirmwareStatusNotification":
+        queueMicrotask(() =>
+          context.chargePoint.sendSignedFirmwareStatusNotification("Idle"),
+        );
+        return { status: "Accepted" };
+
+      default:
+        return { status: "NotImplemented" };
+    }
+  }
+}

--- a/src/cp/infrastructure/transport/handlers/call/GetLogHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/GetLogHandler.ts
@@ -1,0 +1,46 @@
+import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
+import type { GetLogRequestV16, GetLogResponseV16 } from "../../../../../ocpp";
+import { LogType } from "../../../../shared/Logger";
+
+/**
+ * §2 GetLog.req (OCPP 1.6 Security Whitepaper): the CALLRESULT returns the
+ * log's target filename, then the CP follows up with a
+ * LogStatusNotification train — `Uploading` while the (simulated) upload
+ * is in progress, then `Uploaded`. There is no real diagnostics/security
+ * log to upload here, so — unlike GetDiagnostics's real `UploadFile` POST
+ * — the sequence is purely timer-driven, mirroring
+ * `ChargePoint.simulateFirmwareUpdate`'s fixed-interval status train.
+ */
+export class GetLogHandler
+  implements CallHandler<GetLogRequestV16, GetLogResponseV16>
+{
+  handle(
+    payload: GetLogRequestV16,
+    context: HandlerContext,
+  ): GetLogResponseV16 {
+    context.logger.info(
+      `GetLog request received: logType=${payload.logType} requestId=${payload.requestId}`,
+      LogType.DIAGNOSTICS,
+    );
+
+    const filename = `${context.chargePoint.id}-${payload.logType}-${payload.requestId}.log`;
+
+    // §4.4-style contract: status notifications follow the CALLRESULT, not
+    // precede it. queueMicrotask defers Uploading until the response has
+    // been serialized onto the wire (same pattern as GetDiagnostics).
+    queueMicrotask(() => {
+      context.chargePoint.sendLogStatusNotification(
+        "Uploading",
+        payload.requestId,
+      );
+      setTimeout(() => {
+        context.chargePoint.sendLogStatusNotification(
+          "Uploaded",
+          payload.requestId,
+        );
+      }, 2000);
+    });
+
+    return { status: "Accepted", filename };
+  }
+}

--- a/src/cp/infrastructure/transport/handlers/call/SignedUpdateFirmwareHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/SignedUpdateFirmwareHandler.ts
@@ -1,0 +1,61 @@
+import { CallHandler, HandlerContext } from "../MessageHandlerRegistry";
+import type {
+  SignedUpdateFirmwareRequestV16,
+  SignedUpdateFirmwareResponseV16,
+} from "../../../../../ocpp";
+import { LogType } from "../../../../shared/Logger";
+
+/**
+ * §2 SignedUpdateFirmware.req (OCPP 1.6 Security Whitepaper): the signed
+ * counterpart to UpdateFirmware.req (see `UpdateFirmwareHandler`). The
+ * response is sent immediately; the simulated download/verify/install
+ * train — Downloading → Downloaded → SignatureVerified → Installing →
+ * Installed — progresses asynchronously via
+ * `ChargePoint.simulateSignedFirmwareUpdate`, carrying the request's
+ * `requestId` on every SignedFirmwareStatusNotification. No real
+ * signature verification is performed — the simulator has no binary to
+ * fetch or signature to check, so `SignatureVerified` always fires on the
+ * happy path. `retries` / `retryInterval` are logged but not exercised.
+ */
+export class SignedUpdateFirmwareHandler
+  implements
+    CallHandler<
+      SignedUpdateFirmwareRequestV16,
+      SignedUpdateFirmwareResponseV16
+    >
+{
+  handle(
+    payload: SignedUpdateFirmwareRequestV16,
+    context: HandlerContext,
+  ): SignedUpdateFirmwareResponseV16 {
+    const retrieveDate = new Date(payload.firmware.retrieveDateTime);
+    if (Number.isNaN(retrieveDate.getTime())) {
+      context.logger.warn(
+        `SignedUpdateFirmware: invalid retrieveDateTime '${payload.firmware.retrieveDateTime}', starting immediately`,
+        LogType.OCPP,
+      );
+    }
+    context.logger.info(
+      `SignedUpdateFirmware received: requestId=${payload.requestId}, location=${payload.firmware.location}, retrieveDateTime=${payload.firmware.retrieveDateTime}` +
+        (payload.retries != null ? `, retries=${payload.retries}` : "") +
+        (payload.retryInterval != null
+          ? `, retryInterval=${payload.retryInterval}s`
+          : ""),
+      LogType.OCPP,
+    );
+
+    // §6.19-style contract: response is empty/immediate; defer the
+    // simulated train so the CALLRESULT goes out first.
+    const startAt = Number.isNaN(retrieveDate.getTime())
+      ? new Date()
+      : retrieveDate;
+    queueMicrotask(() =>
+      context.chargePoint.simulateSignedFirmwareUpdate(
+        startAt,
+        payload.requestId,
+      ),
+    );
+
+    return { status: "Accepted" };
+  }
+}

--- a/src/cp/infrastructure/transport/handlers/call/__tests__/CertificateManagementHandlers.test.ts
+++ b/src/cp/infrastructure/transport/handlers/call/__tests__/CertificateManagementHandlers.test.ts
@@ -1,0 +1,211 @@
+import "reflect-metadata";
+import { describe, it, expect } from "vitest";
+import * as x509 from "@peculiar/x509";
+import {
+  DeleteCertificateHandler,
+  GetInstalledCertificateIdsHandler,
+  InstallCertificateHandler,
+} from "../CertificateManagementHandlers";
+import { Logger } from "../../../../../shared/Logger";
+import { CertificateStore } from "../../../../../domain/security/CertificateStore";
+import type { HandlerContext } from "../../MessageHandlerRegistry";
+import type { ChargePoint } from "../../../../../domain/charge-point/ChargePoint";
+
+x509.cryptoProvider.set(globalThis.crypto as Crypto);
+
+const EC_ALG = { name: "ECDSA", namedCurve: "P-256", hash: "SHA-256" } as const;
+
+async function selfSignedRootCert(serialNumber: string, cn: string) {
+  const keys = await crypto.subtle.generateKey(EC_ALG, true, [
+    "sign",
+    "verify",
+  ]);
+  const now = Date.now();
+  const cert = await x509.X509CertificateGenerator.createSelfSigned({
+    serialNumber,
+    name: `CN=${cn},O=Example`,
+    notBefore: new Date(now - 60_000),
+    notAfter: new Date(now + 86_400_000),
+    signingAlgorithm: EC_ALG,
+    keys,
+    extensions: [new x509.BasicConstraintsExtension(true, undefined, true)],
+  });
+  return cert.toString("pem");
+}
+
+function buildContext(maxLength = 10) {
+  const certificateStore = new CertificateStore();
+  const chargePoint = {
+    id: "CP-CERT-TEST",
+    certificateStore,
+    configuration: {
+      certificateStoreMaxLength: () => maxLength,
+    },
+  };
+  const ctx: HandlerContext = {
+    chargePoint: chargePoint as unknown as ChargePoint,
+    logger: new Logger(),
+  };
+  return { ctx, certificateStore };
+}
+
+describe("InstallCertificateHandler", () => {
+  it("accepts a well-formed certificate and stores it", async () => {
+    const { ctx, certificateStore } = buildContext();
+    const pem = await selfSignedRootCert("01", "Root A");
+    const handler = new InstallCertificateHandler();
+
+    const res = handler.handle(
+      { certificateType: "CentralSystemRootCertificate", certificate: pem },
+      ctx,
+    );
+
+    expect(res).toEqual({ status: "Accepted" });
+    expect(certificateStore.listRootCerts()).toEqual([
+      { type: "CentralSystemRootCertificate", pem: pem.trim() },
+    ]);
+  });
+
+  it("rejects malformed PEM", () => {
+    const { ctx, certificateStore } = buildContext();
+    const handler = new InstallCertificateHandler();
+
+    const res = handler.handle(
+      {
+        certificateType: "ManufacturerRootCertificate",
+        certificate: "not a certificate",
+      },
+      ctx,
+    );
+
+    expect(res).toEqual({ status: "Rejected" });
+    expect(certificateStore.listRootCerts()).toEqual([]);
+  });
+
+  it("rejects when the store is at CertificateStoreMaxLength", async () => {
+    const { ctx, certificateStore } = buildContext(1);
+    const first = await selfSignedRootCert("01", "Root A");
+    certificateStore.installRootCert("CentralSystemRootCertificate", first);
+
+    const handler = new InstallCertificateHandler();
+    const second = await selfSignedRootCert("02", "Root B");
+    const res = handler.handle(
+      { certificateType: "CentralSystemRootCertificate", certificate: second },
+      ctx,
+    );
+
+    expect(res).toEqual({ status: "Rejected" });
+    expect(certificateStore.listRootCerts()).toHaveLength(1);
+  });
+});
+
+describe("GetInstalledCertificateIdsHandler", () => {
+  it("returns NotFound when no root certs of the requested type are stored", async () => {
+    const { ctx } = buildContext();
+    const handler = new GetInstalledCertificateIdsHandler();
+
+    const res = await handler.handle(
+      { certificateType: "CentralSystemRootCertificate" },
+      ctx,
+    );
+
+    expect(res).toEqual({ status: "NotFound" });
+  });
+
+  it("returns certificateHashData for stored certs of the requested type only", async () => {
+    const { ctx, certificateStore } = buildContext();
+    const centralPem = await selfSignedRootCert("01", "Central Root");
+    const mfgPem = await selfSignedRootCert("02", "Mfg Root");
+    certificateStore.installRootCert(
+      "CentralSystemRootCertificate",
+      centralPem,
+    );
+    certificateStore.installRootCert("ManufacturerRootCertificate", mfgPem);
+
+    const handler = new GetInstalledCertificateIdsHandler();
+    const res = await handler.handle(
+      { certificateType: "CentralSystemRootCertificate" },
+      ctx,
+    );
+
+    expect(res.status).toBe("Accepted");
+    expect(res.certificateHashData).toHaveLength(1);
+    expect(res.certificateHashData?.[0]).toMatchObject({
+      hashAlgorithm: "SHA256",
+      serialNumber: "01",
+    });
+    expect(res.certificateHashData?.[0].issuerNameHash).toHaveLength(64);
+    expect(res.certificateHashData?.[0].issuerKeyHash).toHaveLength(64);
+  });
+});
+
+describe("DeleteCertificateHandler", () => {
+  it("returns NotFound when no stored cert matches the hash data", async () => {
+    const { ctx } = buildContext();
+    const handler = new DeleteCertificateHandler();
+
+    const res = await handler.handle(
+      {
+        certificateHashData: {
+          hashAlgorithm: "SHA256",
+          issuerNameHash: "a".repeat(64),
+          issuerKeyHash: "b".repeat(64),
+          serialNumber: "ff",
+        },
+      },
+      ctx,
+    );
+
+    expect(res).toEqual({ status: "NotFound" });
+  });
+
+  it("deletes the matching stored root cert and returns Accepted", async () => {
+    const { ctx, certificateStore } = buildContext();
+    const pem = await selfSignedRootCert("01", "Root To Delete");
+    certificateStore.installRootCert("CentralSystemRootCertificate", pem);
+
+    const getHandler = new GetInstalledCertificateIdsHandler();
+    const listed = await getHandler.handle(
+      { certificateType: "CentralSystemRootCertificate" },
+      ctx,
+    );
+    const hashData = listed.certificateHashData?.[0];
+    expect(hashData).toBeDefined();
+
+    const deleteHandler = new DeleteCertificateHandler();
+    const res = await deleteHandler.handle(
+      { certificateHashData: hashData! },
+      ctx,
+    );
+
+    expect(res).toEqual({ status: "Accepted" });
+    expect(certificateStore.listRootCerts()).toEqual([]);
+  });
+
+  it("does not delete non-matching certs when multiple are installed", async () => {
+    const { ctx, certificateStore } = buildContext();
+    const keepPem = await selfSignedRootCert("01", "Keep Me");
+    const deletePem = await selfSignedRootCert("02", "Delete Me");
+    certificateStore.installRootCert("CentralSystemRootCertificate", keepPem);
+    certificateStore.installRootCert("ManufacturerRootCertificate", deletePem);
+
+    const getHandler = new GetInstalledCertificateIdsHandler();
+    const listed = await getHandler.handle(
+      { certificateType: "ManufacturerRootCertificate" },
+      ctx,
+    );
+    expect(listed.certificateHashData).toBeDefined();
+    const hashData = listed.certificateHashData![0];
+
+    const deleteHandler = new DeleteCertificateHandler();
+    const res = await deleteHandler.handle(
+      { certificateHashData: hashData },
+      ctx,
+    );
+
+    expect(res).toEqual({ status: "Accepted" });
+    const remaining = certificateStore.listRootCerts();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].pem).toBe(keepPem.trim());
+  });
+});

--- a/src/cp/infrastructure/transport/handlers/call/__tests__/ExtendedTriggerMessageHandler.test.ts
+++ b/src/cp/infrastructure/transport/handlers/call/__tests__/ExtendedTriggerMessageHandler.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import { ExtendedTriggerMessageHandler } from "../ExtendedTriggerMessageHandler";
+import { Logger } from "../../../../../shared/Logger";
+import type { HandlerContext } from "../../MessageHandlerRegistry";
+import type { ChargePoint } from "../../../../../domain/charge-point/ChargePoint";
+
+function buildContext() {
+  const calls: Record<string, unknown[][]> = {};
+  const record =
+    (name: string) =>
+    (...args: unknown[]) => {
+      (calls[name] ??= []).push(args);
+    };
+
+  const chargePoint = {
+    sendCurrentStatusNotification: record("sendCurrentStatusNotification"),
+    sendHeartbeat: record("sendHeartbeat"),
+    sendMeterValue: record("sendMeterValue"),
+    boot: record("boot"),
+    sendSignCertificate: vi.fn(() => Promise.resolve()),
+    sendLogStatusNotification: record("sendLogStatusNotification"),
+    sendSignedFirmwareStatusNotification: record(
+      "sendSignedFirmwareStatusNotification",
+    ),
+    connectors: new Map([
+      [1, { id: 1 }],
+      [2, { id: 2 }],
+    ]),
+  };
+
+  const ctx: HandlerContext = {
+    chargePoint: chargePoint as unknown as ChargePoint,
+    logger: new Logger(),
+  };
+  return { ctx, calls, chargePoint };
+}
+
+describe("ExtendedTriggerMessageHandler", () => {
+  it("returns NotImplemented for an unsupported requestedMessage", () => {
+    const { ctx } = buildContext();
+    const handler = new ExtendedTriggerMessageHandler();
+    const res = handler.handle(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { requestedMessage: "Unsupported" as any },
+      ctx,
+    );
+    expect(res).toEqual({ status: "NotImplemented" });
+  });
+
+  it("Accepted + fires StatusNotification after the microtask queue drains", async () => {
+    const { ctx, calls } = buildContext();
+    const handler = new ExtendedTriggerMessageHandler();
+    const res = handler.handle(
+      { requestedMessage: "StatusNotification", connectorId: 1 },
+      ctx,
+    );
+    expect(res).toEqual({ status: "Accepted" });
+    expect(calls.sendCurrentStatusNotification).toBeUndefined();
+    await Promise.resolve();
+    expect(calls.sendCurrentStatusNotification).toEqual([[1]]);
+  });
+
+  it("Accepted + fires Heartbeat", async () => {
+    const { ctx, calls } = buildContext();
+    const handler = new ExtendedTriggerMessageHandler();
+    const res = handler.handle({ requestedMessage: "Heartbeat" }, ctx);
+    expect(res).toEqual({ status: "Accepted" });
+    await Promise.resolve();
+    expect(calls.sendHeartbeat).toHaveLength(1);
+  });
+
+  it("Accepted + fans out MeterValues to every connector when connectorId is omitted", async () => {
+    const { ctx, calls } = buildContext();
+    const handler = new ExtendedTriggerMessageHandler();
+    const res = handler.handle({ requestedMessage: "MeterValues" }, ctx);
+    expect(res).toEqual({ status: "Accepted" });
+    await Promise.resolve();
+    expect(calls.sendMeterValue).toEqual([[1], [2]]);
+  });
+
+  it("Accepted + sends MeterValues for a single connectorId", async () => {
+    const { ctx, calls } = buildContext();
+    const handler = new ExtendedTriggerMessageHandler();
+    handler.handle({ requestedMessage: "MeterValues", connectorId: 2 }, ctx);
+    await Promise.resolve();
+    expect(calls.sendMeterValue).toEqual([[2]]);
+  });
+
+  it("Accepted + re-sends BootNotification", async () => {
+    const { ctx, calls } = buildContext();
+    const handler = new ExtendedTriggerMessageHandler();
+    const res = handler.handle({ requestedMessage: "BootNotification" }, ctx);
+    expect(res).toEqual({ status: "Accepted" });
+    await Promise.resolve();
+    expect(calls.boot).toHaveLength(1);
+  });
+
+  it("Accepted + triggers SignChargePointCertificate via sendSignCertificate", async () => {
+    const { ctx, chargePoint } = buildContext();
+    const handler = new ExtendedTriggerMessageHandler();
+    const res = handler.handle(
+      { requestedMessage: "SignChargePointCertificate" },
+      ctx,
+    );
+    expect(res).toEqual({ status: "Accepted" });
+    await Promise.resolve();
+    expect(chargePoint.sendSignCertificate).toHaveBeenCalledTimes(1);
+  });
+
+  it("Accepted + sends LogStatusNotification Idle", async () => {
+    const { ctx, calls } = buildContext();
+    const handler = new ExtendedTriggerMessageHandler();
+    const res = handler.handle(
+      { requestedMessage: "LogStatusNotification" },
+      ctx,
+    );
+    expect(res).toEqual({ status: "Accepted" });
+    await Promise.resolve();
+    expect(calls.sendLogStatusNotification).toEqual([["Idle"]]);
+  });
+
+  it("Accepted + sends SignedFirmwareStatusNotification Idle", async () => {
+    const { ctx, calls } = buildContext();
+    const handler = new ExtendedTriggerMessageHandler();
+    const res = handler.handle(
+      { requestedMessage: "FirmwareStatusNotification" },
+      ctx,
+    );
+    expect(res).toEqual({ status: "Accepted" });
+    await Promise.resolve();
+    expect(calls.sendSignedFirmwareStatusNotification).toEqual([["Idle"]]);
+  });
+});

--- a/src/cp/infrastructure/transport/handlers/call/__tests__/GetLogHandler.test.ts
+++ b/src/cp/infrastructure/transport/handlers/call/__tests__/GetLogHandler.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { GetLogHandler } from "../GetLogHandler";
+import { Logger } from "../../../../../shared/Logger";
+import type { HandlerContext } from "../../MessageHandlerRegistry";
+import type { ChargePoint } from "../../../../../domain/charge-point/ChargePoint";
+
+type LogStatus =
+  | "BadMessage"
+  | "Idle"
+  | "NotSupportedOperation"
+  | "PermissionDenied"
+  | "Uploaded"
+  | "UploadFailure"
+  | "Uploading";
+
+function buildContext() {
+  const sent: Array<{ status: LogStatus; requestId?: number }> = [];
+  const chargePoint = {
+    id: "CP-LOG-TEST",
+    sendLogStatusNotification: (status: LogStatus, requestId?: number) => {
+      sent.push({ status, requestId });
+    },
+  };
+  const ctx: HandlerContext = {
+    chargePoint: chargePoint as unknown as ChargePoint,
+    logger: new Logger(),
+  };
+  return { ctx, sent };
+}
+
+describe("GetLogHandler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns Accepted with a derived filename immediately", () => {
+    const { ctx } = buildContext();
+    const handler = new GetLogHandler();
+    const res = handler.handle(
+      {
+        logType: "DiagnosticsLog",
+        requestId: 7,
+        log: { remoteLocation: "http://example.invalid/upload" },
+      },
+      ctx,
+    );
+    expect(res).toEqual({
+      status: "Accepted",
+      filename: "CP-LOG-TEST-DiagnosticsLog-7.log",
+    });
+  });
+
+  it("emits Uploading then Uploaded carrying requestId, after the CALLRESULT microtask", async () => {
+    const { ctx, sent } = buildContext();
+    const handler = new GetLogHandler();
+    handler.handle(
+      {
+        logType: "SecurityLog",
+        requestId: 42,
+        log: { remoteLocation: "http://example.invalid/upload" },
+      },
+      ctx,
+    );
+
+    expect(sent).toEqual([]);
+    await Promise.resolve();
+    expect(sent).toEqual([{ status: "Uploading", requestId: 42 }]);
+
+    vi.advanceTimersByTime(2000);
+    expect(sent).toEqual([
+      { status: "Uploading", requestId: 42 },
+      { status: "Uploaded", requestId: 42 },
+    ]);
+  });
+});

--- a/src/cp/infrastructure/transport/handlers/call/__tests__/SignedUpdateFirmwareHandler.test.ts
+++ b/src/cp/infrastructure/transport/handlers/call/__tests__/SignedUpdateFirmwareHandler.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { SignedUpdateFirmwareHandler } from "../SignedUpdateFirmwareHandler";
+import { Logger } from "../../../../../shared/Logger";
+import type { HandlerContext } from "../../MessageHandlerRegistry";
+import type { ChargePoint } from "../../../../../domain/charge-point/ChargePoint";
+
+type FirmwareStatus =
+  | "Downloading"
+  | "Downloaded"
+  | "SignatureVerified"
+  | "Installing"
+  | "Installed";
+
+/**
+ * Spies on `sendSignedFirmwareStatusNotification` and replicates the
+ * scheduling half of `ChargePoint.simulateSignedFirmwareUpdate` — the
+ * schedule itself is what's under test here — same duck-typing approach
+ * as `UpdateFirmwareHandler.test.ts` (no WebSocket / Database needed).
+ */
+function buildContext() {
+  const logger = new Logger();
+  const sent: Array<{ status: FirmwareStatus; requestId?: number }> = [];
+  const timers: NodeJS.Timeout[] = [];
+  let inFlight = false;
+
+  const chargePoint = {
+    sendSignedFirmwareStatusNotification: (
+      status: FirmwareStatus,
+      requestId?: number,
+    ) => {
+      sent.push({ status, requestId });
+    },
+    simulateSignedFirmwareUpdate(
+      retrieveDate: Date,
+      requestId: number,
+      intervalMs = 2000,
+    ): void {
+      if (inFlight) return;
+      inFlight = true;
+      const sequence: FirmwareStatus[] = [
+        "Downloading",
+        "Downloaded",
+        "SignatureVerified",
+        "Installing",
+        "Installed",
+      ];
+      const startDelay = Math.max(0, retrieveDate.getTime() - Date.now());
+      const fireStep = (i: number) => {
+        if (i >= sequence.length) {
+          inFlight = false;
+          return;
+        }
+        this.sendSignedFirmwareStatusNotification(sequence[i], requestId);
+        timers.push(setTimeout(() => fireStep(i + 1), intervalMs));
+      };
+      timers.push(setTimeout(() => fireStep(0), startDelay));
+    },
+  };
+
+  const ctx: HandlerContext = {
+    chargePoint: chargePoint as unknown as ChargePoint,
+    logger,
+  };
+  return { ctx, sent };
+}
+
+function firmwarePayload(
+  overrides: Partial<{ retrieveDateTime: string; requestId: number }> = {},
+) {
+  return {
+    requestId: overrides.requestId ?? 5,
+    firmware: {
+      location: "http://example.invalid/firmware.bin",
+      retrieveDateTime:
+        overrides.retrieveDateTime ?? new Date(Date.now() + 1000).toISOString(),
+      signingCertificate:
+        "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
+      signature: "deadbeef",
+    },
+  };
+}
+
+describe("SignedUpdateFirmwareHandler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns Accepted immediately", () => {
+    const { ctx } = buildContext();
+    const handler = new SignedUpdateFirmwareHandler();
+    const res = handler.handle(firmwarePayload(), ctx);
+    expect(res).toEqual({ status: "Accepted" });
+  });
+
+  it("fires Downloading → Downloaded → SignatureVerified → Installing → Installed carrying requestId", async () => {
+    const { ctx, sent } = buildContext();
+    const handler = new SignedUpdateFirmwareHandler();
+    handler.handle(firmwarePayload({ requestId: 9 }), ctx);
+
+    await Promise.resolve();
+    expect(sent).toEqual([]);
+
+    vi.advanceTimersByTime(999);
+    expect(sent).toEqual([]);
+
+    vi.advanceTimersByTime(1);
+    expect(sent).toEqual([{ status: "Downloading", requestId: 9 }]);
+
+    vi.advanceTimersByTime(2000);
+    vi.advanceTimersByTime(2000);
+    vi.advanceTimersByTime(2000);
+    vi.advanceTimersByTime(2000);
+    expect(sent).toEqual([
+      { status: "Downloading", requestId: 9 },
+      { status: "Downloaded", requestId: 9 },
+      { status: "SignatureVerified", requestId: 9 },
+      { status: "Installing", requestId: 9 },
+      { status: "Installed", requestId: 9 },
+    ]);
+  });
+
+  it("starts immediately when retrieveDateTime is invalid", async () => {
+    const { ctx, sent } = buildContext();
+    const handler = new SignedUpdateFirmwareHandler();
+    handler.handle(
+      firmwarePayload({ retrieveDateTime: "not-a-date", requestId: 1 }),
+      ctx,
+    );
+    await Promise.resolve();
+    vi.advanceTimersByTime(0);
+    expect(sent[0]).toEqual({ status: "Downloading", requestId: 1 });
+  });
+});

--- a/src/cp/infrastructure/transport/handlers/index.ts
+++ b/src/cp/infrastructure/transport/handlers/index.ts
@@ -15,6 +15,10 @@ export * from "./call/ChangeAvailabilityHandler";
 export * from "./call/LocalAuthListHandlers";
 export * from "./call/UpdateFirmwareHandler";
 export * from "./call/CertificateSignedHandler";
+export * from "./call/ExtendedTriggerMessageHandler";
+export * from "./call/CertificateManagementHandlers";
+export * from "./call/GetLogHandler";
+export * from "./call/SignedUpdateFirmwareHandler";
 
 // Export CALLRESULT handlers
 export * from "./callresult/BootNotificationResultHandler";

--- a/src/cp/infrastructure/transport/soap/OCPPSoapHandler.ts
+++ b/src/cp/infrastructure/transport/soap/OCPPSoapHandler.ts
@@ -570,6 +570,23 @@ export class OCPPSoapHandler implements IChargePointMessageHandler {
     );
   }
 
+  public sendLogStatusNotification(status: string, requestId?: number): void {
+    this._logger.warn(
+      `OCPP 1.5 SOAP has no security extension; ignoring LogStatusNotification ${JSON.stringify({ status, requestId })}`,
+      LogType.OCPP,
+    );
+  }
+
+  public sendSignedFirmwareStatusNotification(
+    status: string,
+    requestId?: number,
+  ): void {
+    this._logger.warn(
+      `OCPP 1.5 SOAP has no security extension; ignoring SignedFirmwareStatusNotification ${JSON.stringify({ status, requestId })}`,
+      LogType.OCPP,
+    );
+  }
+
   public sendSignCertificate(_csr?: string): Promise<void> {
     this._logger.warn(
       "OCPP 1.5 SOAP has no security extension; ignoring SignCertificate",


### PR DESCRIPTION
Implements the rest of the OCPP 1.6 Security Whitepaper (ed. 4) message set requested in #94, so a CSMS can exercise the full set against the simulator: every message is accepted with a well-formed response and, where the spec defines one, the matching status-notification flow.

## New CSMS→CP handlers (1.6 registry only)

- **ExtendedTriggerMessage** — mirrors TriggerMessage (incl. per-connector fan-out): `BootNotification`, `Heartbeat`, `MeterValues`, `StatusNotification`, plus `SignChargePointCertificate` (fires the existing CSR flow), `LogStatusNotification`, `FirmwareStatusNotification` (signed variant). Unknown → `NotImplemented`.
- **InstallCertificate** — validates PEM, stores via the certificate store, enforces `CertificateStoreMaxLength` (→ `Rejected` when full).
- **GetInstalledCertificateIds** — returns `certificateHashData` (SHA-256 issuerNameHash / issuerKeyHash / serialNumber) for stored roots of the requested type; `NotFound` when none.
- **DeleteCertificate** — matches by the same hash helper; `Accepted` / `NotFound`.
- **GetLog** — `Accepted` + filename, then a simulated `LogStatusNotification` `Uploading → Uploaded` sequence carrying `requestId`.
- **SignedUpdateFirmware** — `Accepted`, then `SignedFirmwareStatusNotification` `Downloading → Downloaded → SignatureVerified → Installing → Installed` with `requestId`, mirroring the existing simulated firmware flow (no real signature verification — stub semantics).

## Notes

- Certificate hashing follows RFC 5280 conventions (SHA-256 over the DER issuer Name; over the subjectPublicKey BIT STRING content), verified two independent ways in tests: WebCrypto raw EC-point export cross-check and OpenSSL-precomputed known-answer hashes for a fixed certificate.
- `CallHandler.handle` was widened to allow async handlers; existing sync handlers are unaffected.
- 2.0.1/2.1 registries untouched.

## Tests

Per-handler unit tests (response shapes for every status path, sequence ordering + requestId propagation, store round-trips with real certs) plus an end-to-end bun test driving a real ChargePoint over a WebSocket. Gates: eslint clean, vitest 427 passed, bun test 112 passed.

With #118 (security-profile UI), this covers the remaining requests in #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)