### PR TITLE
fix(ci): resolve v0.6.0 release-pipeline failures (#121, #122, #123)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,27 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+# Least-privilege token scopes required by the official Pages deployment.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Serialise Pages deployments. #121: the previous setup ran two deployment
+# mechanisms at once — peaceiris/actions-gh-pages pushing to the `gh-pages`
+# branch AND GitHub's branch-based Pages build — which left deployments stuck
+# in `deployment_queued` until the 10-minute timeout. A single serialised
+# `pages` group prevents a new push from racing an in-flight deploy. Don't
+# cancel an in-progress production deploy midway.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -22,8 +38,22 @@ jobs:
         run: VITE_BASE_URL="/ocpp-cp-simulator" npm run build
       - name: Copy index.html to 404.html for SPA routing
         run: cp dist/index.html dist/404.html
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    # The official single-mechanism Pages deployment (replaces the
+    # peaceiris push to `gh-pages`). Requires the repo Pages source to be
+    # set to "GitHub Actions": Settings → Pages → Build and deployment →
+    # Source → GitHub Actions.
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -48,8 +48,11 @@ jobs:
           - platform: "macos-latest"
             args: "--target x86_64-apple-darwin"
             target: "x86_64-apple-darwin"
+          # Linux ships .deb + .rpm only; AppImage bundling via linuxdeploy
+          # fails on GitHub runners (#122). See release.yml for the full
+          # rationale. Re-add "appimage" once the upstream bug is fixed.
           - platform: "ubuntu-22.04"
-            args: ""
+            args: "--bundles deb,rpm"
             target: "x86_64-unknown-linux-gnu"
           - platform: "windows-latest"
             args: ""
@@ -120,10 +123,6 @@ jobs:
           # fails on the Windows MINGW runner, and would pick the wrong arch
           # for the cross-compiled x86_64 macOS build).
           TAURI_TARGET: ${{ matrix.target }}
-          # linuxdeploy and its plugins are AppImages; GitHub runners lack FUSE,
-          # so extract-and-run instead of mounting. Fixes the Linux AppImage
-          # bundle dying with "failed to run linuxdeploy". No-op off Linux.
-          APPIMAGE_EXTRACT_AND_RUN: "1"
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           args: ${{ matrix.args }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,15 @@ jobs:
           - platform: "macos-latest"
             args: "--target x86_64-apple-darwin"
             target: "x86_64-apple-darwin"
+          # Linux ships .deb + .rpm only. AppImage bundling via linuxdeploy
+          # fails on GitHub runners ("failed to run linuxdeploy", #122) — an
+          # unresolved upstream Tauri issue that even APPIMAGE_EXTRACT_AND_RUN
+          # doesn't fix, aggravated by our Bun-compiled sidecar (externalBin)
+          # tripping linuxdeploy's strip step. Leaving AppImage in the target
+          # list fails the whole Linux job, so no .deb/.rpm get uploaded either.
+          # Re-add "appimage" here once the upstream bug is fixed.
           - platform: "ubuntu-22.04"
-            args: ""
+            args: "--bundles deb,rpm"
             target: "x86_64-unknown-linux-gnu"
           - platform: "windows-latest"
             args: ""
@@ -109,10 +116,6 @@ jobs:
           # fails on the Windows MINGW runner, and would pick the wrong arch
           # for the cross-compiled x86_64 macOS build).
           TAURI_TARGET: ${{ matrix.target }}
-          # linuxdeploy and its plugins are AppImages; GitHub runners lack FUSE,
-          # so extract-and-run instead of mounting. Fixes the Linux AppImage
-          # bundle dying with "failed to run linuxdeploy". No-op off Linux.
-          APPIMAGE_EXTRACT_AND_RUN: "1"
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "OCPP CP Simulator ${{ github.ref_name }}"
@@ -125,7 +128,8 @@ jobs:
             - **macOS (Apple Silicon)**: `OCPP.CP.Simulator_*_aarch64.dmg`
             - **macOS (Intel)**: `OCPP.CP.Simulator_*_x64.dmg`
             - **Windows**: `OCPP.CP.Simulator_*_x64-setup.exe` or `.msi`
-            - **Linux**: `ocpp-cp-simulator_*_amd64.AppImage` or `.deb`
+            - **Linux (Debian/Ubuntu)**: `OCPP.CP.Simulator_*_amd64.deb`
+            - **Linux (Fedora/RHEL)**: `OCPP.CP.Simulator-*.x86_64.rpm`
 
             ### Web Version
             The web version is available at: https://shiv3.github.io/ocpp-cp-simulator/

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -40,8 +40,8 @@ Available for:
   - Intel: `OCPP.CP.Simulator_*_x64.dmg`
 - **Windows**: `OCPP.CP.Simulator_*_x64-setup.exe` or `.msi`
 - **Linux**:
-  - AppImage: `ocpp-cp-simulator_*_amd64.AppImage` (recommended)
-  - Debian/Ubuntu: `ocpp-cp-simulator_*_amd64.deb`
+  - Debian/Ubuntu: `OCPP.CP.Simulator_*_amd64.deb`
+  - Fedora/RHEL: `OCPP.CP.Simulator-*.x86_64.rpm`
 
 ### Installation
 
@@ -62,16 +62,15 @@ Available for:
 
 #### Linux
 
-**AppImage (Recommended)**
-
-1. Download the `.AppImage` file
-2. Make it executable: `chmod +x ocpp-cp-simulator_*.AppImage`
-3. Run: `./ocpp-cp-simulator_*.AppImage`
-
 **Debian/Ubuntu**
 
 1. Download the `.deb` file
-2. Install: `sudo dpkg -i ocpp-cp-simulator_*.deb`
+2. Install: `sudo dpkg -i OCPP.CP.Simulator_*.deb`
+
+**Fedora/RHEL**
+
+1. Download the `.rpm` file
+2. Install: `sudo rpm -i OCPP.CP.Simulator-*.rpm`
 
 ## Development
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OCPP CP Simulator",
-  "version": "0.1.0",
+  "version": "../package.json",
   "identifier": "com.ocpp.cp-simulator",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Fixes the three v0.6.0 release-pipeline failures reported in #121, #122, #123.

## #123 — Consistent release versions
`src-tauri/tauri.conf.json` hardcoded `version: "0.1.0"`, so the release-tag stamp (which runs `npm version` on `package.json`) never reached the desktop bundle filenames/metadata — `.deb`/`.rpm`/`.dmg`/`.msi` shipped as `0.1.0` while the tag was `v0.6.0`.

- Point `tauri.conf.json` `version` at `../package.json` (a Tauri v2-supported form), making **`package.json` the single source of truth** already stamped by `release.yml`, `docker-publish.yml`, and `cli-release.yml`.
- Web footer, Docker image, desktop bundles, and CLI tarball now all expose the same version on tagged builds; dev/branch builds stay `0.0.0`.

## #122 — Ubuntu AppImage build failure
The AppImage step (`linuxdeploy`) fails on GitHub runners with `failed to run linuxdeploy`, even though `.deb`/`.rpm` build fine. `APPIMAGE_EXTRACT_AND_RUN=1` was already present at v0.6.0 and didn't help — it's an unresolved upstream Tauri/linuxdeploy issue, aggravated here by our Bun-compiled sidecar (`externalBin`) tripping linuxdeploy's strip step. Leaving AppImage in the target list fails the **whole** Linux job, so no `.deb`/`.rpm` get uploaded either.

- Restrict Linux to `--bundles deb,rpm` in `release.yml` and `manual-release.yml` (both formats already build reliably).
- Drop the now-moot `APPIMAGE_EXTRACT_AND_RUN` env; document the rationale + how to re-enable once fixed upstream.
- Update `docs/browser.md` download/install instructions to `.deb` (Debian/Ubuntu) + `.rpm` (Fedora/RHEL).

## #121 — GitHub Pages deployment stuck
Two deployment mechanisms ran at once — `peaceiris/actions-gh-pages` pushing to the `gh-pages` branch **and** GitHub's branch-based Pages build — leaving deployments stuck in `deployment_queued` until the 10-minute timeout.

- Replace with the single official flow: `actions/upload-pages-artifact` + `actions/deploy-pages`, split into `build`/`deploy` jobs with least-privilege `pages: write` / `id-token: write` scopes and serialised `concurrency`.
- Build steps are unchanged (the artifact itself was always valid); only the deployment mechanism changed.

> [!IMPORTANT]
> **Manual step required for #121 (after this reaches `main`):** set the repo Pages source to **GitHub Actions** — *Settings → Pages → Build and deployment → Source → GitHub Actions*. It is currently `legacy` (deploy-from-`gh-pages`-branch). Do **not** flip it before the new `deploy.yml` is on `main`, or the current peaceiris-based deploy on `main` will stop updating the site.

## Notes
- Base is `feat/issues-batch-integration` because #123 builds on the version-stamp steps that live on this branch and are not yet on `main`.
- CI (release/pages) only runs on real pushes/tags, so these were validated by YAML/JSON syntax checks and the Tauri v2 config schema (which documents the `../package.json` version form) rather than a live release.
