### PR TITLE
fix(scenario): never drop sql.js writes made during an in-flight flush (#101)

### DIFF
--- a/src/data/sqlite/SqlJsDatabase.ts
+++ b/src/data/sqlite/SqlJsDatabase.ts
@@ -11,6 +11,7 @@ import type {
   SqlRow,
 } from "../../cp/domain/persistence/Database";
 import { runMigrations } from "../../cp/domain/persistence/schema";
+import { createDurableFlusher } from "./durableFlush";
 import { loadBlob, saveBlob } from "./IndexedDbBlobStore";
 
 /**
@@ -37,7 +38,13 @@ import { loadBlob, saveBlob } from "./IndexedDbBlobStore";
  */
 export class SqlJsDatabase implements Database {
   private flushHandle: ReturnType<typeof setTimeout> | null = null;
-  private flushPending: Promise<void> | null = null;
+  // Never drops writes that land while an earlier save is still in flight
+  // (#101). The arrow reads `this.db` lazily (at flush time), so it's safe to
+  // build during field init before the constructor assigns `db`.
+  private readonly durableFlush = createDurableFlusher(
+    () => this.db.export(),
+    saveBlob,
+  );
   private static readonly FLUSH_DEBOUNCE_MS = 200;
 
   private constructor(private db: SqlJsBackingDb) {}
@@ -95,20 +102,19 @@ export class SqlJsDatabase implements Database {
   }
 
   /**
-   * Export the in-memory DB to IndexedDB. Coalesces with any pending
-   * debounced flush so callers never see stale data on the next page load.
+   * Export the in-memory DB to IndexedDB. Delegates to {@link createDurableFlusher},
+   * which guarantees the current state reaches storage even when a previous
+   * save is still in flight — so an awaited `flush()` never resolves while the
+   * newest writes are still only in memory (#101).
    */
   flush(): Promise<void> {
+    // The durable flusher always persists the current state, so any pending
+    // debounce timer is redundant once we're flushing explicitly.
     if (this.flushHandle) {
       clearTimeout(this.flushHandle);
       this.flushHandle = null;
     }
-    if (this.flushPending) return this.flushPending;
-    const dump = this.db.export();
-    this.flushPending = saveBlob(dump).finally(() => {
-      this.flushPending = null;
-    });
-    return this.flushPending;
+    return this.durableFlush();
   }
 
   private scheduleFlush(): void {

--- a/src/data/sqlite/__tests__/durableFlush.test.ts
+++ b/src/data/sqlite/__tests__/durableFlush.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { createDurableFlusher } from "../durableFlush";
+
+/**
+ * A `save()` whose completion we drive by hand, so tests can deterministically
+ * reproduce "a write lands while an earlier save is still in flight".
+ */
+function controllableSaver() {
+  const completed: string[] = []; // snapshots that finished saving, in order
+  const queue: Array<{ snapshot: string; resolve: () => void }> = [];
+  const save = (snapshot: Uint8Array): Promise<void> =>
+    new Promise<void>((resolve) => {
+      queue.push({ snapshot: new TextDecoder().decode(snapshot), resolve });
+    });
+  const inFlight = (): string[] => queue.map((q) => q.snapshot);
+  const completeOldest = async (): Promise<void> => {
+    const next = queue.shift();
+    if (!next) throw new Error("no in-flight save to complete");
+    completed.push(next.snapshot);
+    next.resolve();
+    // Drain all microtasks so chained follow-ups run before we assert.
+    await new Promise((r) => setTimeout(r, 0));
+  };
+  return { save, completed, inFlight, completeOldest };
+}
+
+describe("createDurableFlusher", () => {
+  it("persists writes made while an earlier save is in flight (#101 regression)", async () => {
+    let snapshot = "empty";
+    const saver = controllableSaver();
+    const flush = createDurableFlusher(
+      () => new TextEncoder().encode(snapshot),
+      saver.save,
+    );
+
+    // Write A, flush -> save of "A" starts and stays in flight.
+    snapshot = "A";
+    const f1 = flush();
+    expect(saver.inFlight()).toEqual(["A"]);
+
+    // Write B arrives WHILE the "A" save is in flight, then flush again.
+    snapshot = "B";
+    const f2 = flush();
+
+    // Complete the in-flight "A" save; the follow-up must re-export the latest.
+    await saver.completeOldest();
+    expect(saver.inFlight()).toEqual(["B"]); // <-- old code left this empty
+    await saver.completeOldest();
+
+    await Promise.all([f1, f2]);
+
+    // The newest write reached durable storage — it was NOT dropped.
+    expect(saver.completed).toEqual(["A", "B"]);
+  });
+
+  it("coalesces a burst of flushes during one in-flight save into a single follow-up", async () => {
+    let snapshot = "empty";
+    const saver = controllableSaver();
+    const flush = createDurableFlusher(
+      () => new TextEncoder().encode(snapshot),
+      saver.save,
+    );
+
+    snapshot = "A";
+    void flush(); // starts save "A"
+    snapshot = "B";
+    void flush(); // queues follow-up
+    snapshot = "C";
+    void flush(); // coalesces onto the same follow-up
+
+    await saver.completeOldest(); // finish "A"
+    // Exactly one follow-up, exporting the latest snapshot ("C").
+    expect(saver.inFlight()).toEqual(["C"]);
+    await saver.completeOldest();
+    expect(saver.completed).toEqual(["A", "C"]);
+  });
+
+  it("reproduces the OLD bug: return-the-in-flight-promise dropped the write (#101)", async () => {
+    // Faithful replica of the previous SqlJsDatabase.flush() coalescing, kept
+    // as executable documentation of the regression this module fixes.
+    let snapshot = "empty";
+    const saver = controllableSaver();
+    let pending: Promise<void> | null = null;
+    const buggyFlush = (): Promise<void> => {
+      if (pending) return pending; // returns a promise whose export predates B
+      const dump = new TextEncoder().encode(snapshot);
+      pending = saver.save(dump).finally(() => {
+        pending = null;
+      });
+      return pending;
+    };
+
+    snapshot = "A";
+    const f1 = buggyFlush();
+    snapshot = "B";
+    const f2 = buggyFlush(); // hands back the "A" save; "B" is never exported
+
+    await saver.completeOldest();
+    await Promise.all([f1, f2]);
+
+    expect(saver.completed).toEqual(["A"]);
+    expect(saver.completed).not.toContain("B"); // the lost write
+  });
+});

--- a/src/data/sqlite/durableFlush.ts
+++ b/src/data/sqlite/durableFlush.ts
@@ -1,0 +1,48 @@
+/**
+ * Write-back coalescer for a single durable snapshot — used to persist the
+ * sql.js in-memory database to IndexedDB (see {@link ./SqlJsDatabase}).
+ *
+ * Guarantee: every write made *before* a `flush()` call is included in some
+ * completed `save`, even writes made while an earlier save is still in flight.
+ *
+ * The previous "return the in-flight promise" approach silently dropped those
+ * writes (#101): the in-flight save had already captured its snapshot before
+ * the new write, and the explicit flush both cancelled the pending debounce and
+ * returned that stale promise — so `await flush()` resolved while the newest
+ * data never reached storage. On the next page load the pre-write blob was
+ * restored, so an uploaded/saved scenario appeared to "not save" after refresh.
+ *
+ * Here, a flush that arrives while a save is in flight queues exactly one
+ * follow-up that re-exports the latest snapshot once the in-flight save settles.
+ * Concurrent callers coalesce onto that single follow-up, so a burst of writes
+ * costs at most one extra save rather than one per write.
+ */
+export function createDurableFlusher(
+  exportSnapshot: () => Uint8Array,
+  save: (snapshot: Uint8Array) => Promise<void>,
+): () => Promise<void> {
+  let pending: Promise<void> | null = null;
+  let queued: Promise<void> | null = null;
+
+  const startSave = (): Promise<void> => {
+    const snapshot = exportSnapshot();
+    const p = save(snapshot).finally(() => {
+      if (pending === p) pending = null;
+    });
+    pending = p;
+    return p;
+  };
+
+  return function flush(): Promise<void> {
+    if (!pending) return startSave();
+    // A save is mid-flight with a snapshot that may predate recent writes.
+    // Queue one follow-up that re-exports after it settles; coalesce callers.
+    queued ??= pending
+      .catch(() => undefined)
+      .then(() => {
+        queued = null;
+        return startSave();
+      });
+    return queued;
+  };
+}


### PR DESCRIPTION
Reopens/fixes the #101 regression: after uploading a scenario JSON and Saving, a page refresh reverts to the **old** scenario (web console / local mode).

## Root cause
`SqlJsDatabase.flush()` (browser sql.js → IndexedDB) dropped writes made while a previous save was in flight:

```js
flush() {
  if (this.flushHandle) { clearTimeout(this.flushHandle); this.flushHandle = null; } // cancels the pending debounce
  if (this.flushPending) return this.flushPending;  // returns a promise whose db.export() predates the new writes
  ...
}
```

When an IndexedDB `saveBlob` is in flight, an explicit `flush()` (which the upload/Save path `await`s) both **cancels the freshly-scheduled debounce** and **returns the stale in-flight promise without re-exporting**. So the upload's `DELETE`+`INSERT` never reaches IndexedDB, yet `await flush()` resolves as if it did — on refresh the pre-write blob is restored → old scenario. Local/sql.js only (matches "refresh the Web"), and timing-dependent because the `logs` table writes on nearly every message/tick, so a save is frequently in flight. The old docstring even claimed it "coalesces … so callers never see stale data" — the code did the opposite.

## Fix
Extract the write-back coalescing into `createDurableFlusher(exportSnapshot, save)` (mirrors the existing `createLatestWinsSaver` pattern). While a save is in flight, it queues **exactly one** follow-up that re-exports the latest snapshot once the in-flight save settles; concurrent callers coalesce onto it. So every write made before a `flush()` is guaranteed to reach storage.

## Tests
`src/data/sqlite/__tests__/durableFlush.test.ts` — deterministic, no WASM/IndexedDB needed:
- regression: a write landing during an in-flight save is persisted (not dropped)
- a burst of flushes coalesces into a single follow-up exporting the latest state
- a faithful replica of the **old** logic, asserting it dropped the write (executable documentation of the bug)

Full suite green (85 files / 524 tests), type-check + lint clean.

Fixes #101