### PR TITLE
fix(web): keep daemon-only SOAP XML libs out of the browser bundle (#127)

### DIFF
--- a/src/build/__tests__/browserBundleNoDaemonXml.bun.test.ts
+++ b/src/build/__tests__/browserBundleNoDaemonXml.bun.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Regression guard for issue #127 (Docker 0.6.1 web console blank page).
+//
+// The OCPP 1.5 SOAP transport is daemon-only, but ChargePoint statically
+// imports it, so without the browser-build stub in vite.config.ts the
+// production bundle drags in xmlbuilder2's CommonJS DOM stack (@oozcitak/*).
+// That CJS<->ESM interop crashes browser startup under some production
+// module-init orderings with "Object.defineProperty called on non-object",
+// blanking the whole SPA. The daemon-only unit tests never exercise the
+// browser bundle, and PR CI never runs `vite build`, so nothing caught it.
+// This test builds the real browser bundle and asserts that stack is absent.
+//
+// Runs under `bun test` (the `test:bun` npm script), NOT vitest: the vite stub
+// is skipped when process.env.VITEST is set, so the assertion is only
+// meaningful outside vitest.
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+
+// Identifiers unique to xmlbuilder2's @oozcitak DOM stack that survive
+// minification. If any reaches a browser chunk, the daemon-only SOAP XML
+// libraries leaked back into the web bundle and #127 can recur.
+const FORBIDDEN = ["@oozcitak", "XMLBuilderCBImpl", "oozcitak/dom"];
+
+describe("browser bundle (issue #127)", () => {
+  it(
+    "does not bundle the daemon-only xmlbuilder2 DOM stack",
+    () => {
+      const outDir = mkdtempSync(join(tmpdir(), "ocpp-bundle-check-"));
+      try {
+        // The vite stub keys off VITEST being unset; bun test doesn't set it,
+        // but strip it defensively in case a parent runner did.
+        const env = { ...process.env };
+        delete env.VITEST;
+
+        const proc = Bun.spawnSync(
+          ["bunx", "vite", "build", "--outDir", outDir],
+          { cwd: repoRoot, env, stdout: "pipe", stderr: "pipe" },
+        );
+
+        if (proc.exitCode !== 0) {
+          console.error(proc.stderr.toString());
+        }
+        expect(proc.exitCode).toBe(0);
+
+        const assetsDir = join(outDir, "assets");
+        const jsFiles = readdirSync(assetsDir).filter((f) =>
+          f.endsWith(".js"),
+        );
+        expect(jsFiles.length).toBeGreaterThan(0);
+
+        const offenders: string[] = [];
+        for (const file of jsFiles) {
+          const code = readFileSync(join(assetsDir, file), "utf-8");
+          for (const marker of FORBIDDEN) {
+            if (code.includes(marker)) offenders.push(`${file}: ${marker}`);
+          }
+        }
+
+        if (offenders.length > 0) {
+          console.error(
+            "Daemon-only SOAP XML code leaked into the browser bundle:\n" +
+              offenders.join("\n"),
+          );
+        }
+        expect(offenders).toEqual([]);
+      } finally {
+        rmSync(outDir, { recursive: true, force: true });
+      }
+    },
+    120_000,
+  );
+});

--- a/src/build/soapXmlBrowserStub.ts
+++ b/src/build/soapXmlBrowserStub.ts
@@ -1,0 +1,35 @@
+// Browser-build stub for the daemon-only OCPP 1.5 SOAP XML libraries
+// (`xmlbuilder2` + `fast-xml-parser`). `vite.config.ts` aliases both packages
+// to this module for the browser build and dev server — never for vitest,
+// which runs the real SOAP code in Node.
+//
+// Why this exists: `ChargePoint` statically imports the SOAP transport, so
+// `soapEnvelope.ts` — and with it xmlbuilder2's CommonJS DOM stack
+// (`@oozcitak/dom`, whose classes do `extends require("events").EventEmitter`
+// and rely on CJS<->ESM interop wrappers) — is pulled into the browser
+// bundle's static module graph. That happens even though OCPP 1.5 SOAP is
+// daemon-only: it needs `--soap-callback-url` and an inbound SOAP server the
+// web console can't run, so the browser never instantiates `OCPPSoapHandler`.
+// Under some production module-init orderings (observed in the Alpine Docker
+// build) that CJS interop calls `Object.defineProperty` on a not-yet-
+// initialized export and throws "Object.defineProperty called on non-object",
+// blanking the whole SPA (issue #127). Stubbing the libraries out of the
+// browser build removes that entire code path — and supersedes the older
+// `events` polyfill workaround, which only papered over the same root cause.
+//
+// These symbols are never reached in the browser; if they ever are, fail loud.
+const daemonOnly = (): never => {
+  throw new Error(
+    "OCPP 1.5 SOAP XML tooling is daemon-only and unavailable in the browser web console",
+  );
+};
+
+// Stands in for `import { create } from "xmlbuilder2"`.
+export const create = (): never => daemonOnly();
+
+// Stands in for `import { XMLParser } from "fast-xml-parser"`.
+export class XMLParser {
+  parse(): never {
+    return daemonOnly();
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,18 +42,31 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
-      // The OCPP 1.5 SOAP transport (daemon-only) pulls in xmlbuilder2, whose
-      // streaming builder declares `class XMLBuilderCBImpl extends
-      // require("events").EventEmitter` at module load. That code is never
-      // executed in the browser web console, but it is statically reachable
-      // from the shared ChargePoint domain class and therefore bundled. Vite
-      // externalizes Node's `events` for the browser, leaving EventEmitter
-      // undefined, so the class declaration throws "Class extends value
-      // undefined" while the bundle initializes — blanking the whole console.
-      // Resolve `events` to its browser polyfill (the `events` npm package) so
-      // the otherwise-unused module evaluates cleanly. Keep the `events`
-      // devDependency in sync; it has no direct import and exists only for this.
-      events: path.resolve(__dirname, "node_modules/events/events.js"),
+      // The OCPP 1.5 SOAP transport is daemon-only: it needs
+      // `--soap-callback-url` and an inbound SOAP server the web console can't
+      // run, so the browser never instantiates OCPPSoapHandler. But
+      // ChargePoint statically imports it, so soapEnvelope.ts — and with it
+      // xmlbuilder2's CommonJS DOM stack (@oozcitak/*, plus fast-xml-parser) —
+      // lands in the browser bundle's static init graph anyway. That CJS<->ESM
+      // interop crashes browser startup under some production module-init
+      // orderings with "Object.defineProperty called on non-object", blanking
+      // the whole SPA (issue #127; the earlier `events` polyfill only papered
+      // over an earlier symptom of the same root cause). Alias both XML
+      // libraries to a tiny stub for the browser build/dev server so that code
+      // path is never bundled. Skipped under vitest (process.env.VITEST), where
+      // the real SOAP code runs in Node.
+      ...(process.env.VITEST
+        ? {}
+        : {
+            xmlbuilder2: path.resolve(
+              __dirname,
+              "./src/build/soapXmlBrowserStub.ts",
+            ),
+            "fast-xml-parser": path.resolve(
+              __dirname,
+              "./src/build/soapXmlBrowserStub.ts",
+            ),
+          }),
     },
     // Force a single React instance across every chunk. The Scenario Editor is
     // a lazy chunk built around @xyflow/react, which leans heavily on React


### PR DESCRIPTION
Fixes #127 — the Docker `0.6.1` web console renders a **blank page**, with `Uncaught TypeError: Object.defineProperty called on non-object` thrown during bundle init. `0.6.0` works.

## Root cause

The OCPP 1.5 SOAP transport is **daemon-only** — it needs `--soap-callback-url` and an inbound SOAP server the browser web console can't run, so the browser never instantiates `OCPPSoapHandler`. But `ChargePoint` statically imports it:

```
ChargePoint.ts  →  soap/index.ts  →  soapEnvelope.ts  →  import { create } from "xmlbuilder2"
```

so `xmlbuilder2`'s CommonJS DOM stack (`@oozcitak/dom`, `@oozcitak/util`, `@oozcitak/url`) lands in the **browser** bundle's static init graph anyway. Its CJS↔ESM interop wrappers run at bundle init and, under some production module-init orderings, call `Object.defineProperty` on a not-yet-initialized (non-object) export → throw → the whole SPA blanks.

The ordering is build-environment dependent, which is why it slipped through:

| Build | index chunk | Result |
|---|---|---|
| Local `npm`/Node (rollup 4.24) | 2,620 kB | renders (chunks happen to init in a safe order) |
| Alpine Docker `bun` (rollup 4.62) | 2,620 kB | **blank + the error** |

Reproduced by building the Docker `ui` stage from both `v0.6.1` and current `main` and loading the emitted bundle in a browser — both throw the reported error; the fixed build renders clean.

The existing `events` polyfill in `vite.config.ts` was an earlier band-aid for the **same** root cause (a different symptom: `Class extends value undefined`). Rather than add another polyfill, this removes the code path from the browser entirely.

## Fix

Alias `xmlbuilder2` and `fast-xml-parser` to a tiny browser-build stub (`src/build/soapXmlBrowserStub.ts`) in `vite.config.ts`, **skipped under vitest** (`process.env.VITEST`) so tests keep exercising the real SOAP code in Node. The daemon (Bun runtime, not Vite) is unaffected and uses the real libraries.

Result: the `@oozcitak` DOM stack is gone from the browser bundle and the `index` chunk drops **~384 kB** (2,620 → 2,236 kB).

## Regression guard

PR CI never runs `vite build` — the browser bundle is only built for release-tag Docker images, which is why this shipped uncaught. Added `src/build/__tests__/browserBundleNoDaemonXml.bun.test.ts`: it builds the real browser bundle and fails if the daemon-only XML stack leaks back in. It runs on every PR via `test:bun` (no CI-YAML change). Verified it **fails on `main` without the fix** and **passes with it**.

## Verification

- Docker/Alpine build (the environment that reproduced the crash): blank + error → **renders clean, 0 console errors** after the fix
- `test:vitest` (SOAP suite 6/6) and `test:bun` (SOAP handler 6/6) pass — real libraries under test
- Full vitest suite: 85 files / 524 tests pass
- `vite dev` loads clean; lint + prettier clean; no new `tsc` errors

## Follow-up (not in this PR)

The `events` devDependency is now unused (its only consumer, the old alias, is gone). Removing it touches both lockfiles, so it's left for a separate cleanup.