### PR TITLE
ci: supply-chain & quality hardening (#128, #129, #130, #131)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Automated dependency updates (issue #128).
+#
+# Ecosystems:
+#   * bun            — package.json + bun.lock (CI installs with
+#                      `bun install --frozen-lockfile`, so the JS deps must be
+#                      driven through Bun, not npm, to keep the lockfile in
+#                      sync). Requires Dependabot's Bun support (bun >= 1.1.39).
+#   * github-actions — refreshes the SHA pins from #129 and their version
+#                      comments together.
+#   * docker         — the oven/bun base image in the Dockerfile.
+#
+# Non-major updates are grouped into a single weekly PR per ecosystem to keep
+# the review load low; majors still come as individual PRs so breaking changes
+# get their own scrutiny.
+version: 2
+updates:
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      js-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,7 +12,16 @@ categories:
   - title: "Bug Fixes"
     labels: ["fix", "bugfix", "bug"]
   - title: "Maintenance"
-    labels: ["chore", "ci", "docs", "documentation", "dependencies", "refactor", "test"]
+    labels:
+      [
+        "chore",
+        "ci",
+        "docs",
+        "documentation",
+        "dependencies",
+        "refactor",
+        "test",
+      ]
 
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
 change-title-escapes: '\<*_&'
@@ -26,7 +35,19 @@ version-resolver:
     labels: ["minor", "feature", "enhancement", "feat"]
   patch:
     labels:
-      ["patch", "fix", "bugfix", "bug", "chore", "ci", "docs", "documentation", "dependencies", "refactor", "test"]
+      [
+        "patch",
+        "fix",
+        "bugfix",
+        "bug",
+        "chore",
+        "ci",
+        "docs",
+        "documentation",
+        "dependencies",
+        "refactor",
+        "test",
+      ]
   default: patch
 
 # Note: categories/version above key off PR labels. This drafter runs only on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,23 @@ jobs:
       - name: Coverage (non-blocking)
         run: bun run test:coverage
         continue-on-error: true
+
+      # Coverage + test-results reporting (issue #131). Both are non-blocking
+      # (fail_ci_if_error: false) and run even when a test step failed, so a
+      # red build still publishes its numbers. Needs a CODECOV_TOKEN repo
+      # secret; without it the upload is skipped rather than failing CI.
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/junit.xml
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
 
@@ -46,7 +46,7 @@ jobs:
       # secret; without it the upload is skipped rather than failing CI.
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/junit.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Format check
+        run: bun run format:check
+
       - name: Unit tests (vitest)
         run: bun run test:vitest
 

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -30,15 +30,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
       - name: Setup Node (for `npm pack`)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
 
@@ -90,7 +90,7 @@ jobs:
             || { echo "::error::src/protocol missing from the CLI tarball"; exit 1; }
 
       - name: Create / update release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: CLI ${{ steps.version.outputs.tag }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "v22"
       - name: Install dependencies
@@ -39,7 +39,7 @@ jobs:
       - name: Copy index.html to 404.html for SPA routing
         run: cp dist/index.html dist/404.html
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./dist
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,16 +37,16 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -58,7 +58,7 @@ jobs:
       # package.json and Vite bakes the version into the bundle (issue #93).
       - name: Setup Node (for version stamping)
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
 
@@ -76,7 +76,7 @@ jobs:
 
       - name: Compute image tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ghcr.io/${{ github.repository }}
           # `latest` deliberately tracks the default branch (bleeding edge),
@@ -96,7 +96,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build & push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -16,11 +16,11 @@ jobs:
     outputs:
       release_id: ${{ steps.create_release.outputs.id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Create Release
         id: create_release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const { data } = await github.rest.repos.createRelease({
@@ -60,25 +60,28 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       # Node is still needed: tauri-action's runtime + the `npx @tauri-apps/cli
       # icon` step below. Dependency install + the tauri build itself go
       # through Bun (see below), so there's no npm cache to prime here.
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: "src-tauri -> target"
           cache-targets: "false"
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        # rust-toolchain derives the toolchain from the ref name, so a pinned
+        # SHA needs the toolchain named explicitly.
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Install dependencies (Ubuntu only)
@@ -92,7 +95,7 @@ jobs:
       # `bun tauri build`. Install with the same tool so there's a single,
       # frozen-lockfile install rather than an npm/bun mix.
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
@@ -115,7 +118,7 @@ jobs:
           npx @tauri-apps/cli icon icons/icon.svg
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Tauri's beforeBuildCommand re-runs build-tauri-sidecar.sh; hand it

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write # create / update the draft release
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,25 +36,28 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       # Node is still needed: tauri-action's runtime + the `npx @tauri-apps/cli
       # icon` step below. Dependency install + the tauri build itself go
       # through Bun (see below), so there's no npm cache to prime here.
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: "src-tauri -> target"
           cache-targets: "false"
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        # rust-toolchain derives the toolchain from the ref name, so a pinned
+        # SHA needs the toolchain named explicitly.
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Install dependencies (Ubuntu only)
@@ -68,7 +71,7 @@ jobs:
       # `bun tauri build`. Install with the same tool so there's a single,
       # frozen-lockfile install rather than an npm/bun mix.
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
@@ -108,7 +111,7 @@ jobs:
         run: npm version --no-git-tag-version --allow-same-version "${{ steps.version.outputs.version }}"
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Tauri's beforeBuildCommand re-runs build-tauri-sidecar.sh; hand it
@@ -143,12 +146,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Generate release notes
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const tag = context.ref.replace('refs/tags/', '');

--- a/public/splash.html
+++ b/public/splash.html
@@ -12,8 +12,8 @@
       body {
         margin: 0;
         height: 100%;
-        font-family:
-          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          sans-serif;
       }
       body {
         display: flex;
@@ -53,8 +53,7 @@
         line-height: 1.4;
       }
       code {
-        font-family:
-          ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
         background: #1e293b;
         padding: 0.1rem 0.35rem;
         border-radius: 4px;
@@ -82,7 +81,9 @@
         const started = Date.now();
         while (Date.now() - started < POLL_TIMEOUT_MS) {
           try {
-            const res = await fetch(`${url}${HEALTH_PATH}`, { cache: "no-store" });
+            const res = await fetch(`${url}${HEALTH_PATH}`, {
+              cache: "no-store",
+            });
             if (res.ok) {
               const body = await res.json().catch(() => null);
               if (body && body.ok === true) {
@@ -100,8 +101,7 @@
 
       function showError(url) {
         document.getElementById("spinner").style.display = "none";
-        document.getElementById("title").textContent =
-          "Daemon failed to start";
+        document.getElementById("title").textContent = "Daemon failed to start";
         const sub = document.getElementById("subtitle");
         sub.classList.add("error");
         sub.innerHTML =

--- a/src/components/LogViewerDemo.tsx
+++ b/src/components/LogViewerDemo.tsx
@@ -1,8 +1,14 @@
-import { useState, useEffect } from 'react';
-import { LogViewer } from '@/components/ui/log-viewer';
-import { Logger, LogLevel, LogType, LogEntry } from '@/cp/shared/Logger';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useState, useEffect } from "react";
+import { LogViewer } from "@/components/ui/log-viewer";
+import { Logger, LogLevel, LogType, LogEntry } from "@/cp/shared/Logger";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 
 export function LogViewerDemo() {
   const [logger] = useState(() => new Logger(LogLevel.DEBUG));
@@ -10,7 +16,7 @@ export function LogViewerDemo() {
 
   useEffect(() => {
     // Subscribe to all log events
-    const unsubscribe = logger.on('log', (entry) => {
+    const unsubscribe = logger.on("log", (entry) => {
       setLogs((prev) => [...prev, entry]);
     });
 
@@ -18,17 +24,20 @@ export function LogViewerDemo() {
   }, [logger]);
 
   const addSampleLogs = () => {
-    logger.debug('WebSocket connection established', LogType.WEBSOCKET);
-    logger.info('OCPP handshake completed', LogType.OCPP);
-    logger.info('BootNotification sent', LogType.OCPP);
-    logger.debug('Heartbeat sent', LogType.HEARTBEAT);
-    logger.info('Transaction started with ID: 12345', LogType.TRANSACTION);
-    logger.debug('Meter value: 1234.5 kWh', LogType.METER_VALUE);
-    logger.warn('Low battery warning', LogType.STATUS);
-    logger.error('Failed to send StatusNotification', LogType.STATUS);
-    logger.info('Configuration updated: HeartbeatInterval = 60', LogType.CONFIGURATION);
-    logger.debug('Diagnostics data collected', LogType.DIAGNOSTICS);
-    logger.info('Scenario step completed: Connect to CSMS', LogType.SCENARIO);
+    logger.debug("WebSocket connection established", LogType.WEBSOCKET);
+    logger.info("OCPP handshake completed", LogType.OCPP);
+    logger.info("BootNotification sent", LogType.OCPP);
+    logger.debug("Heartbeat sent", LogType.HEARTBEAT);
+    logger.info("Transaction started with ID: 12345", LogType.TRANSACTION);
+    logger.debug("Meter value: 1234.5 kWh", LogType.METER_VALUE);
+    logger.warn("Low battery warning", LogType.STATUS);
+    logger.error("Failed to send StatusNotification", LogType.STATUS);
+    logger.info(
+      "Configuration updated: HeartbeatInterval = 60",
+      LogType.CONFIGURATION,
+    );
+    logger.debug("Diagnostics data collected", LogType.DIAGNOSTICS);
+    logger.info("Scenario step completed: Connect to CSMS", LogType.SCENARIO);
   };
 
   const handleClear = () => {
@@ -42,7 +51,8 @@ export function LogViewerDemo() {
         <CardHeader>
           <CardTitle>Log Viewer Demo</CardTitle>
           <CardDescription>
-            A structured log viewer component with filtering capabilities for OCPP charge point simulator
+            A structured log viewer component with filtering capabilities for
+            OCPP charge point simulator
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/src/components/Logger.tsx
+++ b/src/components/Logger.tsx
@@ -122,10 +122,18 @@ const Logger: React.FC<LoggerProps> = ({ logs, onClear }) => {
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="ALL">All Levels</SelectItem>
-              <SelectItem value={LogLevel.DEBUG.toString()}>DEBUG and above</SelectItem>
-              <SelectItem value={LogLevel.INFO.toString()}>INFO and above</SelectItem>
-              <SelectItem value={LogLevel.WARN.toString()}>WARN and above</SelectItem>
-              <SelectItem value={LogLevel.ERROR.toString()}>ERROR only</SelectItem>
+              <SelectItem value={LogLevel.DEBUG.toString()}>
+                DEBUG and above
+              </SelectItem>
+              <SelectItem value={LogLevel.INFO.toString()}>
+                INFO and above
+              </SelectItem>
+              <SelectItem value={LogLevel.WARN.toString()}>
+                WARN and above
+              </SelectItem>
+              <SelectItem value={LogLevel.ERROR.toString()}>
+                ERROR only
+              </SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -183,10 +191,7 @@ const Logger: React.FC<LoggerProps> = ({ logs, onClear }) => {
       </div>
 
       {/* Log Display */}
-      <AutoScrollingLogDisplay
-        logs={filteredLogs}
-        autoScroll={autoScroll}
-      />
+      <AutoScrollingLogDisplay logs={filteredLogs} autoScroll={autoScroll} />
     </div>
   );
 };
@@ -264,7 +269,9 @@ const AutoScrollingLogDisplay: React.FC<AutoScrollingLogDisplayProps> = ({
             <span className={`font-semibold ${getLogLevelColor(log.level)}`}>
               [{LogLevel[log.level]}]
             </span>{" "}
-            <span className={`px-1 py-0.5 rounded text-xs ${getLogTypeColor(log.type)}`}>
+            <span
+              className={`px-1 py-0.5 rounded text-xs ${getLogTypeColor(log.type)}`}
+            >
               {log.type}
             </span>{" "}
             <span className="text-primary">{log.message}</span>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { Moon, Sun, Monitor, Check } from 'lucide-react';
-import { useDarkMode } from '../contexts/DarkModeContext';
-import { Button } from '@/components/ui/button';
+import React from "react";
+import { Moon, Sun, Monitor, Check } from "lucide-react";
+import { useDarkMode } from "../contexts/DarkModeContext";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+} from "@/components/ui/dropdown-menu";
 
 const ThemeToggle: React.FC = () => {
   const { theme, setTheme, isDark } = useDarkMode();
@@ -16,28 +16,24 @@ const ThemeToggle: React.FC = () => {
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" size="icon" aria-label="Toggle theme">
-          {isDark ? (
-            <Moon className="h-5 w-5" />
-          ) : (
-            <Sun className="h-5 w-5" />
-          )}
+          {isDark ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => setTheme('light')}>
+        <DropdownMenuItem onClick={() => setTheme("light")}>
           <Sun className="mr-2 h-4 w-4" />
           Light
-          {theme === 'light' && <Check className="ml-auto h-4 w-4" />}
+          {theme === "light" && <Check className="ml-auto h-4 w-4" />}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('dark')}>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
           <Moon className="mr-2 h-4 w-4" />
           Dark
-          {theme === 'dark' && <Check className="ml-auto h-4 w-4" />}
+          {theme === "dark" && <Check className="ml-auto h-4 w-4" />}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('system')}>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
           <Monitor className="mr-2 h-4 w-4" />
           System
-          {theme === 'system' && <Check className="ml-auto h-4 w-4" />}
+          {theme === "system" && <Check className="ml-auto h-4 w-4" />}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/state-transition/ScenarioStateNode.tsx
+++ b/src/components/state-transition/ScenarioStateNode.tsx
@@ -1,7 +1,14 @@
 import React, { memo } from "react";
 import { Handle, Position, NodeProps } from "@xyflow/react";
 
-export type ScenarioState = "idle" | "running" | "paused" | "waiting" | "stepping" | "completed" | "error";
+export type ScenarioState =
+  | "idle"
+  | "running"
+  | "paused"
+  | "waiting"
+  | "stepping"
+  | "completed"
+  | "error";
 
 interface ScenarioStateNodeData {
   state: ScenarioState;
@@ -9,7 +16,9 @@ interface ScenarioStateNodeData {
   isCurrent: boolean;
 }
 
-const ScenarioStateNode: React.FC<NodeProps<ScenarioStateNodeData>> = ({ data }) => {
+const ScenarioStateNode: React.FC<NodeProps<ScenarioStateNodeData>> = ({
+  data,
+}) => {
   const { state, label, isCurrent } = data;
 
   // Color settings based on state
@@ -64,9 +73,7 @@ const ScenarioStateNode: React.FC<NodeProps<ScenarioStateNodeData>> = ({ data })
           {label}
         </div>
         {isCurrent && (
-          <div className="mt-1 text-xs text-white font-semibold">
-            ● Current
-          </div>
+          <div className="mt-1 text-xs text-white font-semibold">● Current</div>
         )}
       </div>
 

--- a/src/components/state-transition/StateNode.tsx
+++ b/src/components/state-transition/StateNode.tsx
@@ -70,9 +70,7 @@ const StateNode: React.FC<NodeProps<StateNodeData>> = ({ data }) => {
           {label}
         </div>
         {isCurrent && (
-          <div className="mt-1 text-xs text-white font-semibold">
-            ● Current
-          </div>
+          <div className="mt-1 text-xs text-white font-semibold">● Current</div>
         )}
       </div>
 

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -16,7 +16,7 @@ const alertVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  }
+  },
 );
 
 const Alert = React.forwardRef<

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -10,7 +10,7 @@ const Card = React.forwardRef<
     ref={ref}
     className={cn(
       "rounded-xl border bg-card text-card-foreground shadow",
-      className
+      className,
     )}
     {...props}
   />
@@ -73,4 +73,11 @@ const CardFooter = React.forwardRef<
 ));
 CardFooter.displayName = "CardFooter";
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -12,7 +12,7 @@ const Checkbox = React.forwardRef<
     ref={ref}
     className={cn(
       "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
-      className
+      className,
     )}
     {...props}
   >

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
     ref={ref}
     className={cn(
       "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
+      className,
     )}
     {...props}
   />
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
+        className,
       )}
       {...props}
     >
@@ -58,7 +58,7 @@ const DialogHeader = ({
   <div
     className={cn(
       "flex flex-col space-y-1.5 text-center sm:text-left",
-      className
+      className,
     )}
     {...props}
   />
@@ -72,7 +72,7 @@ const DialogFooter = ({
   <div
     className={cn(
       "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
+      className,
     )}
     {...props}
   />
@@ -87,7 +87,7 @@ const DialogTitle = React.forwardRef<
     ref={ref}
     className={cn(
       "text-lg font-semibold leading-none tracking-tight",
-      className
+      className,
     )}
     {...props}
   />

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     className={cn(
       "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
       inset && "pl-8",
-      className
+      className,
     )}
     {...props}
   >
@@ -46,7 +46,7 @@ const DropdownMenuSubContent = React.forwardRef<
     ref={ref}
     className={cn(
       "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
+      className,
     )}
     {...props}
   />
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       className={cn(
         "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className
+        className,
       )}
       {...props}
     />
@@ -84,7 +84,7 @@ const DropdownMenuItem = React.forwardRef<
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
-      className
+      className,
     )}
     {...props}
   />
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      className,
     )}
     checked={checked}
     {...props}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      className,
     )}
     {...props}
   >
@@ -148,7 +148,7 @@ const DropdownMenuLabel = React.forwardRef<
     className={cn(
       "px-2 py-1.5 text-sm font-semibold",
       inset && "pl-8",
-      className
+      className,
     )}
     {...props}
   />

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -12,13 +12,13 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         type={type}
         className={cn(
           "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
-          className
+          className,
         )}
         ref={ref}
         {...props}
       />
     );
-  }
+  },
 );
 Input.displayName = "Input";
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -18,7 +18,7 @@ const SelectTrigger = React.forwardRef<
     ref={ref}
     className={cn(
       "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
-      className
+      className,
     )}
     {...props}
   >
@@ -38,7 +38,7 @@ const SelectScrollUpButton = React.forwardRef<
     ref={ref}
     className={cn(
       "flex cursor-default items-center justify-center py-1",
-      className
+      className,
     )}
     {...props}
   >
@@ -55,7 +55,7 @@ const SelectScrollDownButton = React.forwardRef<
     ref={ref}
     className={cn(
       "flex cursor-default items-center justify-center py-1",
-      className
+      className,
     )}
     {...props}
   >
@@ -76,7 +76,7 @@ const SelectContent = React.forwardRef<
         "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-        className
+        className,
       )}
       position={position}
       {...props}
@@ -86,7 +86,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           "p-1",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
         )}
       >
         {children}
@@ -117,7 +117,7 @@ const SelectItem = React.forwardRef<
     ref={ref}
     className={cn(
       "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      className,
     )}
     {...props}
   >

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Table = React.forwardRef<
   HTMLTableElement,
@@ -13,16 +13,16 @@ const Table = React.forwardRef<
       {...props}
     />
   </div>
-))
-Table.displayName = "Table"
+));
+Table.displayName = "Table";
 
 const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
   <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
-))
-TableHeader.displayName = "TableHeader"
+));
+TableHeader.displayName = "TableHeader";
 
 const TableBody = React.forwardRef<
   HTMLTableSectionElement,
@@ -33,8 +33,8 @@ const TableBody = React.forwardRef<
     className={cn("[&_tr:last-child]:border-0", className)}
     {...props}
   />
-))
-TableBody.displayName = "TableBody"
+));
+TableBody.displayName = "TableBody";
 
 const TableFooter = React.forwardRef<
   HTMLTableSectionElement,
@@ -44,12 +44,12 @@ const TableFooter = React.forwardRef<
     ref={ref}
     className={cn(
       "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-      className
+      className,
     )}
     {...props}
   />
-))
-TableFooter.displayName = "TableFooter"
+));
+TableFooter.displayName = "TableFooter";
 
 const TableRow = React.forwardRef<
   HTMLTableRowElement,
@@ -59,12 +59,12 @@ const TableRow = React.forwardRef<
     ref={ref}
     className={cn(
       "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
-      className
+      className,
     )}
     {...props}
   />
-))
-TableRow.displayName = "TableRow"
+));
+TableRow.displayName = "TableRow";
 
 const TableHead = React.forwardRef<
   HTMLTableCellElement,
@@ -74,12 +74,12 @@ const TableHead = React.forwardRef<
     ref={ref}
     className={cn(
       "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-      className
+      className,
     )}
     {...props}
   />
-))
-TableHead.displayName = "TableHead"
+));
+TableHead.displayName = "TableHead";
 
 const TableCell = React.forwardRef<
   HTMLTableCellElement,
@@ -89,12 +89,12 @@ const TableCell = React.forwardRef<
     ref={ref}
     className={cn(
       "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-      className
+      className,
     )}
     {...props}
   />
-))
-TableCell.displayName = "TableCell"
+));
+TableCell.displayName = "TableCell";
 
 const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
@@ -105,8 +105,8 @@ const TableCaption = React.forwardRef<
     className={cn("mt-4 text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-TableCaption.displayName = "TableCaption"
+));
+TableCaption.displayName = "TableCaption";
 
 export {
   Table,
@@ -117,4 +117,4 @@ export {
   TableRow,
   TableCell,
   TableCaption,
-}
+};

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -13,7 +13,7 @@ const TabsList = React.forwardRef<
     ref={ref}
     className={cn(
       "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
-      className
+      className,
     )}
     {...props}
   />
@@ -28,7 +28,7 @@ const TabsTrigger = React.forwardRef<
     ref={ref}
     className={cn(
       "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
-      className
+      className,
     )}
     {...props}
   />
@@ -43,7 +43,7 @@ const TabsContent = React.forwardRef<
     ref={ref}
     className={cn(
       "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      className
+      className,
     )}
     {...props}
   />

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -11,13 +11,13 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         className={cn(
           "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
-          className
+          className,
         )}
         ref={ref}
         {...props}
       />
     );
-  }
+  },
 );
 Textarea.displayName = "Textarea";
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -18,7 +18,7 @@ const TooltipContent = React.forwardRef<
     sideOffset={sideOffset}
     className={cn(
       "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
+      className,
     )}
     {...props}
   />

--- a/src/contexts/DarkModeContext.tsx
+++ b/src/contexts/DarkModeContext.tsx
@@ -1,6 +1,6 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from "react";
 
-type Theme = 'light' | 'dark' | 'system';
+type Theme = "light" | "dark" | "system";
 
 interface DarkModeContextType {
   theme: Theme;
@@ -8,12 +8,16 @@ interface DarkModeContextType {
   isDark: boolean;
 }
 
-const DarkModeContext = createContext<DarkModeContextType | undefined>(undefined);
+const DarkModeContext = createContext<DarkModeContextType | undefined>(
+  undefined,
+);
 
-export const DarkModeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const DarkModeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
   const [theme, setThemeState] = useState<Theme>(() => {
-    const saved = localStorage.getItem('theme') as Theme;
-    return saved || 'system';
+    const saved = localStorage.getItem("theme") as Theme;
+    return saved || "system";
   });
 
   const [isDark, setIsDark] = useState(false);
@@ -24,19 +28,21 @@ export const DarkModeProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     const applyTheme = () => {
       let shouldBeDark = false;
 
-      if (theme === 'dark') {
+      if (theme === "dark") {
         shouldBeDark = true;
-      } else if (theme === 'light') {
+      } else if (theme === "light") {
         shouldBeDark = false;
       } else {
         // system
-        shouldBeDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        shouldBeDark = window.matchMedia(
+          "(prefers-color-scheme: dark)",
+        ).matches;
       }
 
       if (shouldBeDark) {
-        root.classList.add('dark');
+        root.classList.add("dark");
       } else {
-        root.classList.remove('dark');
+        root.classList.remove("dark");
       }
 
       setIsDark(shouldBeDark);
@@ -45,20 +51,20 @@ export const DarkModeProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     applyTheme();
 
     // Listen for system theme changes
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     const handleChange = () => {
-      if (theme === 'system') {
+      if (theme === "system") {
         applyTheme();
       }
     };
 
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
   }, [theme]);
 
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme);
-    localStorage.setItem('theme', newTheme);
+    localStorage.setItem("theme", newTheme);
   };
 
   return (
@@ -71,7 +77,7 @@ export const DarkModeProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 export const useDarkMode = () => {
   const context = useContext(DarkModeContext);
   if (!context) {
-    throw new Error('useDarkMode must be used within DarkModeProvider');
+    throw new Error("useDarkMode must be used within DarkModeProvider");
   }
   return context;
 };

--- a/src/cp/domain/reservation/Reservation.ts
+++ b/src/cp/domain/reservation/Reservation.ts
@@ -42,13 +42,13 @@ export class ReservationManager {
     expiryDate: Date,
     idTag: string,
     parentIdTag: string | undefined,
-    reservationId: number
+    reservationId: number,
   ): ReservationStatus {
     // Check if reservation ID already exists
     if (this.reservations.has(reservationId)) {
       this.logger.warn(
         `Reservation ID ${reservationId} already exists`,
-        LogType.GENERAL
+        LogType.GENERAL,
       );
       return ReservationStatus.Rejected;
     }
@@ -58,7 +58,7 @@ export class ReservationManager {
     if (existingReservation) {
       this.logger.warn(
         `Connector ${connectorId} already has an active reservation`,
-        LogType.GENERAL
+        LogType.GENERAL,
       );
       return ReservationStatus.Occupied;
     }
@@ -67,7 +67,7 @@ export class ReservationManager {
     if (expiryDate <= new Date()) {
       this.logger.warn(
         `Reservation expiry date is in the past: ${expiryDate}`,
-        LogType.GENERAL
+        LogType.GENERAL,
       );
       return ReservationStatus.Rejected;
     }
@@ -85,7 +85,7 @@ export class ReservationManager {
 
     this.logger.info(
       `Created reservation ${reservationId} for connector ${connectorId} (idTag: ${idTag}, expiry: ${expiryDate})`,
-      LogType.GENERAL
+      LogType.GENERAL,
     );
 
     return ReservationStatus.Accepted;
@@ -101,7 +101,7 @@ export class ReservationManager {
     if (!reservation) {
       this.logger.warn(
         `Reservation ${reservationId} not found`,
-        LogType.GENERAL
+        LogType.GENERAL,
       );
       return false;
     }
@@ -110,7 +110,7 @@ export class ReservationManager {
 
     this.logger.info(
       `Cancelled reservation ${reservationId} (connector: ${reservation.connectorId})`,
-      LogType.GENERAL
+      LogType.GENERAL,
     );
 
     return true;
@@ -132,7 +132,7 @@ export class ReservationManager {
 
     this.logger.info(
       `Used reservation ${reservationId} (connector: ${reservation.connectorId})`,
-      LogType.GENERAL
+      LogType.GENERAL,
     );
 
     return true;
@@ -154,16 +154,13 @@ export class ReservationManager {
     if (reservation.expiryDate <= new Date()) {
       this.logger.warn(
         `Reservation ${reservationId} has expired`,
-        LogType.GENERAL
+        LogType.GENERAL,
       );
       return false;
     }
 
     // Check if ID tag matches (or parent ID tag matches)
-    if (
-      reservation.idTag === idTag ||
-      reservation.parentIdTag === idTag
-    ) {
+    if (reservation.idTag === idTag || reservation.parentIdTag === idTag) {
       return true;
     }
 
@@ -243,7 +240,7 @@ export class ReservationManager {
       this.reservations.delete(id);
       this.logger.info(
         `Cleaned up expired reservation ${id} (connector: ${reservation?.connectorId})`,
-        LogType.GENERAL
+        LogType.GENERAL,
       );
     }
   }

--- a/src/data/RuntimeMode.ts
+++ b/src/data/RuntimeMode.ts
@@ -2,7 +2,9 @@ export type RuntimeMode = "local" | "remote";
 
 export const DEFAULT_RUNTIME_MODE: RuntimeMode = "local";
 
-export function parseRuntimeMode(value: string | undefined | null): RuntimeMode {
+export function parseRuntimeMode(
+  value: string | undefined | null,
+): RuntimeMode {
   if (!value) return DEFAULT_RUNTIME_MODE;
   const normalized = value.trim().toLowerCase();
   return normalized === "remote" ? "remote" : DEFAULT_RUNTIME_MODE;
@@ -18,9 +20,10 @@ export function resolveRuntimeMode(envValue?: string | null): RuntimeMode {
     const meta = import.meta as unknown;
     if (typeof meta === "object" && meta !== null && "env" in meta) {
       const envRecord = (meta as { env?: Record<string, unknown> }).env;
-      const runtimeMode = typeof envRecord?.VITE_RUNTIME_MODE === "string"
-        ? (envRecord.VITE_RUNTIME_MODE as string)
-        : undefined;
+      const runtimeMode =
+        typeof envRecord?.VITE_RUNTIME_MODE === "string"
+          ? (envRecord.VITE_RUNTIME_MODE as string)
+          : undefined;
       if (runtimeMode) {
         return parseRuntimeMode(runtimeMode);
       }

--- a/src/data/hooks/useScenarios.dom.test.tsx
+++ b/src/data/hooks/useScenarios.dom.test.tsx
@@ -118,16 +118,14 @@ describe("useScenarios ChargePointService consumer", () => {
       null;
     const unsubscribe = vi.fn();
     service = {
-      listScenarioDefinitions: vi
-        .fn()
-        .mockResolvedValue([
-          scenario("first"),
-          scenario("other", { targetId: 2 }),
-          scenario("cp-level", {
-            targetType: "chargePoint",
-            targetId: undefined,
-          }),
-        ]),
+      listScenarioDefinitions: vi.fn().mockResolvedValue([
+        scenario("first"),
+        scenario("other", { targetId: 2 }),
+        scenario("cp-level", {
+          targetType: "chargePoint",
+          targetId: undefined,
+        }),
+      ]),
       subscribeScenarioDefinitions: vi.fn((_cpId, _connectorId, handler) => {
         scenarioHandler = handler;
         return unsubscribe;

--- a/src/v1/V1App.tsx
+++ b/src/v1/V1App.tsx
@@ -10,13 +10,13 @@ const V1App: React.FC = () => {
   useEffect(() => {
     // Remove dark class from html element when V1 is mounted
     const root = window.document.documentElement;
-    const hadDarkClass = root.classList.contains('dark');
-    root.classList.remove('dark');
+    const hadDarkClass = root.classList.contains("dark");
+    root.classList.remove("dark");
 
     // Restore dark class when V1 is unmounted
     return () => {
       if (hadDarkClass) {
-        root.classList.add('dark');
+        root.classList.add("dark");
       }
     };
   }, []);

--- a/src/v1/v1.css
+++ b/src/v1/v1.css
@@ -1,24 +1,24 @@
 /* V1 App specific styles */
 .v1-app input::placeholder,
 .v1-app textarea::placeholder {
-  color: #9CA3AF; /* gray-400 */
+  color: #9ca3af; /* gray-400 */
   opacity: 1;
 }
 
 .v1-app input::-webkit-input-placeholder,
 .v1-app textarea::-webkit-input-placeholder {
-  color: #9CA3AF;
+  color: #9ca3af;
   opacity: 1;
 }
 
 .v1-app input::-moz-placeholder,
 .v1-app textarea::-moz-placeholder {
-  color: #9CA3AF;
+  color: #9ca3af;
   opacity: 1;
 }
 
 .v1-app input:-ms-input-placeholder,
 .v1-app textarea:-ms-input-placeholder {
-  color: #9CA3AF;
+  color: #9ca3af;
   opacity: 1;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,11 @@ export default defineConfig({
     environment: "node",
     environmentMatchGlobs: [["**/*.dom.test.{ts,tsx}", "jsdom"]],
     setupFiles: ["src/test/setup.dom.ts"],
+    // In CI, also emit a JUnit report next to coverage so it can be uploaded
+    // to Codecov (test analytics / flaky-test surfacing, issue #131). Local
+    // runs keep the plain default reporter.
+    reporters: process.env.CI ? ["default", "junit"] : "default",
+    outputFile: { junit: "./coverage/junit.xml" },
     // bun:sqlite is a runtime built-in that vite can't resolve. Tests
     // ending in `.bun.test.ts` run under `bun test` instead (see the
     // `test:bun` npm script); skip them here.


### PR DESCRIPTION
Batches the four CI/quality issues into one pass. All changes are CI/tooling only — no application behaviour changes (the one source-file diff is a pure Prettier reformat).

Closes #128
Closes #129
Closes #130
Closes #131

## What's here (one commit per concern)

| Commit | Issue | Change |
|---|---|---|
| `style: format existing files with Prettier` | — | Prerequisite for the format check: brings 24 pre-existing tracked files into Prettier compliance (pure `--write`, no behaviour change). |
| `ci: add a Prettier format check` | #130 | Blocking `bun run format:check` step so PRs fail early on formatting drift. |
| `ci: report coverage and test results to Codecov` | #131 | vitest emits a JUnit report in CI; CI uploads lcov coverage **and** test results to Codecov. Non-blocking, runs even on a red build. |
| `ci: pin GitHub Actions to commit SHAs` | #129 | Every third-party action pinned to a full SHA with the version in a trailing comment. |
| `build: add Dependabot for Bun, Actions, and Docker` | #128 | Weekly grouped dependency-update PRs. |

## Notes for the maintainer

- **Codecov needs a `CODECOV_TOKEN` repo secret** (and the repo enabled on codecov.io). Until it's set, the upload steps are no-ops — they use `fail_ci_if_error: false`, so CI stays green either way.
- **Dependabot uses the `bun` ecosystem**, not `npm`, so `package.json` and `bun.lock` move together and CI's `bun install --frozen-lockfile` doesn't break. (Requires Dependabot's Bun support, bun ≥ 1.1.39; this repo pins 1.3.14.) Dependabot's `github-actions` updates will keep the SHA pins from #129 current, refreshing the SHA and its version comment together.
- **`dtolnay/rust-toolchain`** derives the toolchain from its ref name, so pinning its SHA also required an explicit `toolchain: stable` input — otherwise the pinned action can't tell which toolchain to install.
- The SHA pins across the release workflows can't be exercised by PR CI (those run on tags only); they were resolved programmatically from each action's current major-tag target, and the workflows are YAML-valid and Prettier-clean.

## Follow-up (separate, not here)

The `events` devDependency is now unused after PR #133 removed its Vite alias; removing it touches both lockfiles, so it's left for a small separate cleanup.