### PR TITLE
build(deps): bump lucide-react to v1 (#144)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
         "jotai": "^2.12.5",
         "jotai-location": "^0.5.5",
         "jotai-zustand": "^0.4.0",
-        "lucide-react": "^0.552.0",
+        "lucide-react": "^1.24.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-robot": "^1.2.0",
@@ -980,7 +980,7 @@
 
     "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
-    "lucide-react": ["lucide-react@0.552.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-g9WCjmfwqbexSnZE+2cl21PCfXOcqnGeWeMTNAOGEfpPbm/ZF4YIq77Z8qWrxbu660EKuLB4nSLggoKnCb+isw=="],
+    "lucide-react": ["lucide-react@1.24.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jotai": "^2.12.5",
     "jotai-location": "^0.5.5",
     "jotai-zustand": "^0.4.0",
-    "lucide-react": "^0.552.0",
+    "lucide-react": "^1.24.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-robot": "^1.2.0",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,20 @@
 // components/Footer.tsx
 import React from "react";
-import { Github } from "lucide-react";
 
 const REPO_URL = "https://github.com/shiv3/ocpp-cp-simulator";
+
+// lucide-react dropped brand icons in v1, so the GitHub mark ships as a small
+// local SVG instead of pulling in a separate brand-icon package.
+const GithubMark: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    className={className}
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58 0-.29-.01-1.05-.02-2.06-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.09 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.34-5.47-5.96 0-1.32.47-2.39 1.24-3.23-.12-.31-.54-1.53.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.24 2.87.12 3.18.77.84 1.24 1.91 1.24 3.23 0 4.63-2.81 5.65-5.49 5.95.43.37.81 1.1.81 2.22 0 1.6-.01 2.89-.01 3.29 0 .32.22.7.83.58A12 12 0 0 0 24 12.5C24 5.87 18.63.5 12 .5Z" />
+  </svg>
+);
 
 /**
  * Discreet footer pinned to the bottom of the app shell. Self-hosted /
@@ -31,7 +43,7 @@ const Footer: React.FC = () => {
           rel="noopener noreferrer"
           className="inline-flex items-center gap-1 text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:underline"
         >
-          <Github className="h-3.5 w-3.5" />
+          <GithubMark className="h-3.5 w-3.5" />
           GitHub
         </a>
       </div>


### PR DESCRIPTION
Supersedes Dependabot #144 (which failed CI).

lucide-react v1 **dropped brand icons**, so `import { Github } from "lucide-react"` in `Footer.tsx` no longer resolves and the production build fails (`"Github" is not exported`). `Github` is the only brand icon the app uses — every other lucide icon is generic and unaffected.

Fix: bump to `lucide-react@^1.24.0` and replace the one brand icon with a small inline GitHub SVG (same size/visual), avoiding a separate brand-icon dependency.

Verified: `bun run build` succeeds, lint + prettier clean.

Closes #144