### PR TITLE
ci(pages): build with Bun to fix the failing Pages deploy on main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,14 +28,23 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # Build with Bun to match CI, the release tarball, and the Docker `ui`
+      # stage. `npm install` broke here (ERESOLVE) because bun.lock is the
+      # source of truth and its dependency graph is only npm-peer-consistent
+      # under Bun's resolver; keeping every build path on Bun also stops the
+      # Pages bundle from drifting away from the shipped Docker bundle.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "v22"
+          node-version: lts/*
       - name: Install dependencies
-        run: npm install && npm install -g vite
+        run: bun install --frozen-lockfile
       - name: Build
-        run: VITE_BASE_URL="/ocpp-cp-simulator" npm run build
+        run: VITE_BASE_URL="/ocpp-cp-simulator" bun run build
       - name: Copy index.html to 404.html for SPA routing
         run: cp dist/index.html dist/404.html
       - name: Upload Pages artifact

--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ All SOAP versions share the same endpoint pattern:
 - **CP → CSMS**: BootNotification, Heartbeat, StatusNotification, Authorize,
   Start/StopTransaction, MeterValues.
 - **CSMS → CP**: the daemon hosts `POST <soap-path>/:cpId/ChargePointService`
-  (default `--soap-path /ocpp/soap`); slice-1 handles **Reset** and other call-ins.
-  The endpoint relies on the daemon's `--web-console-basic-auth-*` gate or a trusted
-  network boundary — OCPP-S has no per-message authentication field.
+  (default `--soap-path /ocpp/soap`) to answer CSMS-initiated calls — **Reset** on
+  every SOAP version, and the full OCPP 1.6 command set (RemoteStart/Stop,
+  TriggerMessage, ChangeAvailability, charging profiles, …) on 1.6S. The endpoint
+  relies on the daemon's `--web-console-basic-auth-*` gate or a trusted network
+  boundary — OCPP-S has no per-message authentication field.
 
 Pairs with [SteVe](https://github.com/steve-community/steve) (register charge points
 with protocol `ocpp1.2S`, `ocpp1.5S`, or `ocpp1.6S`, status Accepted).

--- a/src/cp/infrastructure/transport/soap/__tests__/v16RegistryDispatch.test.ts
+++ b/src/cp/infrastructure/transport/soap/__tests__/v16RegistryDispatch.test.ts
@@ -145,6 +145,89 @@ describe("coerceSoapPayloadWithSchema", () => {
     });
   });
 
+  it("coerces numeric fields inside arrays of objects (SetChargingProfile periods)", () => {
+    const schema = {
+      properties: {
+        chargingSchedulePeriod: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              startPeriod: { type: "integer" },
+              limit: { type: "number" },
+            },
+          },
+        },
+      },
+    };
+
+    // Two periods → real array; each period's numeric fields are strings.
+    const payload = {
+      chargingSchedulePeriod: [
+        { startPeriod: "0", limit: "32.0" },
+        { startPeriod: "3600", limit: "16" },
+      ],
+    };
+
+    expect(
+      coerceSoapPayloadWithSchema(payload, schema as Record<string, unknown>),
+    ).toEqual({
+      chargingSchedulePeriod: [
+        { startPeriod: 0, limit: 32.0 },
+        { startPeriod: 3600, limit: 16 },
+      ],
+    });
+  });
+
+  it("wraps a single array element AND coerces its nested numbers", () => {
+    const schema = {
+      properties: {
+        chargingSchedulePeriod: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: { startPeriod: { type: "integer" } },
+          },
+        },
+      },
+    };
+
+    // fast-xml-parser yields a lone object (not an array) for a single element.
+    const payload = { chargingSchedulePeriod: { startPeriod: "900" } };
+
+    expect(
+      coerceSoapPayloadWithSchema(payload, schema as Record<string, unknown>),
+    ).toEqual({
+      chargingSchedulePeriod: [{ startPeriod: 900 }],
+    });
+  });
+
+  it("does not throw or mangle when an object-typed field is null or an array", () => {
+    const schema = {
+      properties: {
+        chargingProfile: {
+          type: "object",
+          properties: { chargingProfileId: { type: "integer" } },
+        },
+      },
+    };
+
+    expect(
+      coerceSoapPayloadWithSchema(
+        { chargingProfile: null },
+        schema as Record<string, unknown>,
+      ),
+    ).toEqual({ chargingProfile: null });
+
+    // An array must not be walked as an index-keyed record ({0: ...}).
+    expect(
+      coerceSoapPayloadWithSchema(
+        { chargingProfile: ["x"] },
+        schema as Record<string, unknown>,
+      ),
+    ).toEqual({ chargingProfile: ["x"] });
+  });
+
   it("passes through unknown keys untouched", () => {
     const schema = {
       properties: {

--- a/src/cp/infrastructure/transport/soap/v16RegistryDispatch.ts
+++ b/src/cp/infrastructure/transport/soap/v16RegistryDispatch.ts
@@ -3,6 +3,7 @@ import { Logger } from "../../../shared/Logger";
 import type {
   SoapOperation,
   SoapParsedPayload,
+  SoapParsedValue,
   SoapPayload,
 } from "./soapEnvelope";
 import type { SoapDialect } from "./dialect";
@@ -173,19 +174,52 @@ function getSchemaForOperation(operation: SoapOperation): {
   };
 }
 
+/** True only for plain objects — excludes null and arrays. */
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 /**
- * Coerce SOAP-parsed payload (all strings from fast-xml-parser) to proper types
- * according to the v16 JSON schema for the operation.
+ * Coerce a single SOAP-parsed value (a string, or a fast-xml-parser
+ * object/array of them) to the type its JSON schema node declares.
  *
- * Schema walk rules:
- * - "integer"/"number" fields: Number(value) if value is a string
- * - "boolean" fields: value === "true"
- * - array fields: if schema expects array but payload has single object/string,
- *   wrap in [ ]
- * - nested objects: recurse
- * - unknown keys: pass through untouched
- *
- * Returns the coerced payload object, ready for handler dispatch.
+ * - integer/number: Number(string)
+ * - boolean: "true" → true
+ * - array: normalize a lone element to a 1-tuple, then coerce EACH element
+ *   through `items` (so nested numeric fields inside e.g. chargingSchedulePeriod
+ *   or localAuthorizationList are converted, not left as strings)
+ * - object: recurse ONLY for a plain record (null/arrays pass through untouched
+ *   rather than throwing or being walked as index-keyed records)
+ */
+function coerceValueWithSchema(
+  value: SoapParsedValue,
+  schema: Record<string, unknown> | undefined,
+): unknown {
+  if (!schema) return value;
+  const type = schema.type;
+
+  if (type === "integer" || type === "number") {
+    return typeof value === "string" ? Number(value) : value;
+  }
+  if (type === "boolean") {
+    return value === "true" || value === true;
+  }
+  if (type === "array") {
+    if (value === undefined || value === null) return value;
+    const items = Array.isArray(value) ? value : [value];
+    const itemSchema = schema.items as Record<string, unknown> | undefined;
+    return items.map((item) => coerceValueWithSchema(item, itemSchema));
+  }
+  if (type === "object" && isPlainRecord(value)) {
+    return coerceSoapPayloadWithSchema(value as SoapParsedPayload, schema);
+  }
+  return value;
+}
+
+/**
+ * Coerce a SOAP-parsed payload (all strings from fast-xml-parser) to proper
+ * types according to the v16 JSON schema for the operation. Unknown keys pass
+ * through untouched. Returns the coerced object, ready for handler dispatch.
  */
 export function coerceSoapPayloadWithSchema(
   payload: SoapParsedPayload,
@@ -201,40 +235,9 @@ export function coerceSoapPayloadWithSchema(
 
   for (const [key, value] of Object.entries(payload)) {
     const propSchema = properties[key] as Record<string, unknown> | undefined;
-    if (!propSchema) {
-      // Unknown key; pass through untouched
-      coerced[key] = value;
-      continue;
-    }
-
-    const propType = propSchema.type;
-
-    if (propType === "integer") {
-      // Coerce string to number
-      coerced[key] = typeof value === "string" ? Number(value) : value;
-    } else if (propType === "number") {
-      coerced[key] = typeof value === "string" ? Number(value) : value;
-    } else if (propType === "boolean") {
-      coerced[key] = value === "true" || value === true;
-    } else if (propType === "array") {
-      // If schema says array but we got a single element, wrap it
-      if (Array.isArray(value)) {
-        coerced[key] = value;
-      } else if (value !== undefined && value !== null) {
-        coerced[key] = [value];
-      } else {
-        coerced[key] = value;
-      }
-    } else if (propType === "object" && typeof value === "object") {
-      // Recurse into nested objects
-      coerced[key] = coerceSoapPayloadWithSchema(
-        value as SoapParsedPayload,
-        propSchema,
-      );
-    } else {
-      // Default: pass through
-      coerced[key] = value;
-    }
+    coerced[key] = propSchema
+      ? coerceValueWithSchema(value, propSchema)
+      : value;
   }
 
   return coerced;


### PR DESCRIPTION
## Fix the failing "Deploy to GitHub Pages" job on `main`

The Pages deploy has failed on every `main` push since the dependency bulk-upgrade
(`006bd65`). Its build job ran `npm install`, which now errors with `ERESOLVE`:

```
npm error Conflicting peer dependency: eslint@10.7.0 ...
npm error   peerOptional eslint@"^10.0.0" from @eslint/js@10.0.1
```

`bun.lock` is the repo's source of truth and its dependency graph is only
peer-consistent under Bun's resolver (the upgrade moved eslint to 10 while
`@typescript-eslint@7.18` still peers on eslint 8). CI (`bun run …`), the release
tarball, and the Docker `ui` stage all build with Bun and are green — only this one
job used npm.

**Fix:** build the Pages bundle with Bun too — `bun install --frozen-lockfile` +
`bun run build` (with `oven-sh/setup-bun@…` pinned to the same SHA CI uses). This
also stops the Pages bundle from drifting away from the shipped Docker bundle.

Verified locally: `bun install --frozen-lockfile` reports no lockfile drift and
`VITE_BASE_URL=/ocpp-cp-simulator bun run build` produces `dist/index.html`.

### Also included: CodeRabbit fixes that missed the #162 merge

#162 was merged at `455cd20`, one commit before its final CodeRabbit follow-up
(`6d0f1e9`) landed, so those changes never reached `main`. Cherry-picked here:

- `coerceSoapPayloadWithSchema` now recurses into array `items` (numeric fields
  inside `chargingSchedulePeriod` / `localAuthorizationList` were left as strings)
  and guards object recursion to plain records (a `null`/array value no longer
  throws or is walked as an index-keyed record); tests added.
- README: drop the internal "slice-1" label from the CSMS→CP description.

Full suite green: vitest 808, `bun test bun.test` 129, lint clean, golden snapshots unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SOAP message handling for nested values, arrays, and numeric fields.
  * Correctly normalizes single SOAP objects into arrays where required.
  * Safely handles null and object-valued SOAP fields.

* **Documentation**
  * Clarified SOAP endpoint behavior, Reset responses, supported OCPP 1.6 commands, and access requirements.

* **Chores**
  * Updated deployment builds to use Bun for more consistent dependency installation and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->