### PR TITLE
fix(scenario): restore dropped autosave suppression + upload testability (#101)

### DIFF
--- a/src/cli/server/__tests__/scenarioUploadRefresh.repro.bun.test.ts
+++ b/src/cli/server/__tests__/scenarioUploadRefresh.repro.bun.test.ts
@@ -1,0 +1,117 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- ack payloads are loosely typed in tests */
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Socket } from "socket.io-client";
+
+import { BunSqliteDatabase } from "../../../cp/domain/persistence/BunSqliteDatabase";
+import { connectTestClient, startTestServer } from "./socketHarness";
+
+// Reproduction harness for #101: upload a scenario in remote mode (the daemon's
+// web console), then "refresh" the page — the uploaded scenario must survive.
+// This drives the exact socket RPC path the web console uses
+// (scenario.definitions.replace = the editor upload persist, then
+// scenario.definitions.list = the refresh re-fetch), with a file-backed daemon
+// SQLite so we can also simulate a daemon restart. No browser file picker.
+
+const cleanups: Array<() => Promise<void> | void> = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()?.();
+});
+
+function emitRpc(
+  socket: Socket,
+  request: { method: string; params?: unknown },
+): Promise<any> {
+  return new Promise((resolve) => socket.emit("rpc", request, resolve));
+}
+
+function uploadedScenario(connectorId: number) {
+  const now = new Date("2026-07-11T10:00:00.000Z").toISOString();
+  return {
+    id: "uploaded-scenario",
+    name: "Uploaded Scenario",
+    description: "freshly uploaded",
+    targetType: "connector" as const,
+    targetId: connectorId,
+    nodes: [],
+    edges: [],
+    createdAt: now,
+    updatedAt: now,
+    enabled: true,
+  };
+}
+
+async function tempDb() {
+  const dir = mkdtempSync(join(tmpdir(), "ocpp-101-"));
+  const path = join(dir, "state.db");
+  cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+  return { path, db: BunSqliteDatabase.open(path) };
+}
+
+describe("#101 scenario upload survives refresh (remote/daemon mode)", () => {
+  const cpId = "cp1";
+  const connectorId = 1;
+
+  it("re-lists the uploaded scenario after a page refresh (new socket)", async () => {
+    const { db } = await tempDb();
+    const server = await startTestServer({ database: db });
+    cleanups.push(() => server.close());
+
+    // Upload persist — exactly what persistEditorScenario() sends.
+    const client = await connectTestClient(server);
+    cleanups.push(() => client.close());
+    const replaceAck = await emitRpc(client, {
+      method: "scenario.definitions.replace",
+      params: {
+        cpId,
+        connectorId,
+        definitions: [uploadedScenario(connectorId)],
+      },
+    });
+    expect(replaceAck.ok).toBe(true);
+
+    // Refresh: a brand-new socket connection re-fetches the list.
+    const afterRefresh = await connectTestClient(server);
+    cleanups.push(() => afterRefresh.close());
+    const listAck = await emitRpc(afterRefresh, {
+      method: "scenario.definitions.list",
+      params: { cpId, connectorId },
+    });
+    expect(listAck.ok).toBe(true);
+    const names = (listAck.result as any[]).map((s) => s.name);
+    expect(names).toContain("Uploaded Scenario");
+  });
+
+  it("survives a daemon restart (durable to disk)", async () => {
+    const { path, db } = await tempDb();
+    const server1 = await startTestServer({ database: db });
+    const client1 = await connectTestClient(server1);
+    const replaceAck = await emitRpc(client1, {
+      method: "scenario.definitions.replace",
+      params: {
+        cpId,
+        connectorId,
+        definitions: [uploadedScenario(connectorId)],
+      },
+    });
+    expect(replaceAck.ok).toBe(true);
+    client1.close();
+    await server1.close();
+
+    // Daemon restart: fresh server + DB adapter over the SAME file.
+    const db2 = BunSqliteDatabase.open(path);
+    const server2 = await startTestServer({ database: db2 });
+    cleanups.push(() => server2.close());
+    const client2 = await connectTestClient(server2);
+    cleanups.push(() => client2.close());
+    const listAck = await emitRpc(client2, {
+      method: "scenario.definitions.list",
+      params: { cpId, connectorId },
+    });
+    expect(listAck.ok).toBe(true);
+    const names = (listAck.result as any[]).map((s) => s.name);
+    expect(names).toContain("Uploaded Scenario");
+  });
+});

--- a/src/cli/server/__tests__/scenarioUploadRefresh.repro.bun.test.ts
+++ b/src/cli/server/__tests__/scenarioUploadRefresh.repro.bun.test.ts
@@ -87,7 +87,14 @@ describe("#101 scenario upload survives refresh (remote/daemon mode)", () => {
   it("survives a daemon restart (durable to disk)", async () => {
     const { path, db } = await tempDb();
     const server1 = await startTestServer({ database: db });
+    let server1Closed = false;
+    // Register cleanups immediately so a failed assertion below can't leak the
+    // socket/server handles and stall later tests.
+    cleanups.push(async () => {
+      if (!server1Closed) await server1.close();
+    });
     const client1 = await connectTestClient(server1);
+    cleanups.push(() => client1.close());
     const replaceAck = await emitRpc(client1, {
       method: "scenario.definitions.replace",
       params: {
@@ -98,6 +105,7 @@ describe("#101 scenario upload survives refresh (remote/daemon mode)", () => {
     });
     expect(replaceAck.ok).toBe(true);
     client1.close();
+    server1Closed = true;
     await server1.close();
 
     // Daemon restart: fresh server + DB adapter over the SAME file.

--- a/src/components/scenario/ScenarioEditor.tsx
+++ b/src/components/scenario/ScenarioEditor.tsx
@@ -391,17 +391,31 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
     ],
   );
 
+  // Stamp a fresh updatedAt on a scenario the user is applying (upload /
+  // template) so it wins the `updated_at DESC` ordering. Does NOT arm the
+  // autosave suppression — see armAppliedScenarioAutosaveSuppression, which
+  // must run only after the apply's persistence succeeds.
   const prepareAppliedRemoteScenario = useCallback(
     (next: ScenarioDefinition): ScenarioDefinition => {
       if (mode !== "remote") return next;
       const updatedAt = next.updatedAt ?? new Date().toISOString();
-      const applied = { ...next, updatedAt };
+      return { ...next, updatedAt };
+    },
+    [mode],
+  );
+
+  // Arm the applied-scenario autosave suppression. MUST be called only after
+  // the apply's persistence (replace) has succeeded: if the import/template
+  // persist fails, the marker must stay unset so the fallback autosave still
+  // writes the scenario instead of being suppressed into a silent drop (#101).
+  const armAppliedScenarioAutosaveSuppression = useCallback(
+    (applied: ScenarioDefinition): void => {
+      if (mode !== "remote") return;
       appliedRemoteScenarioAutosaveRef.current = {
         scenarioId: applied.id,
         updatedAt: applied.updatedAt ?? null,
         fingerprint: scenarioAutosaveSuppressionFingerprint(applied),
       };
-      return applied;
     },
     [mode],
   );
@@ -1277,6 +1291,9 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
           { mode, chargePointService, cpId, connectorId },
           scenarioToPersist,
         );
+        // Only now that the write succeeded may we suppress the redundant
+        // autosave the programmatic setState above triggered.
+        armAppliedScenarioAutosaveSuppression(scenarioToPersist);
       } catch (error) {
         alert(`Failed to import scenario: ${error}`);
       }
@@ -1289,6 +1306,7 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
       setNodes,
       setEdges,
       prepareAppliedRemoteScenario,
+      armAppliedScenarioAutosaveSuppression,
     ],
   );
 
@@ -1336,9 +1354,13 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
       void persistEditorScenario(
         { mode, chargePointService, cpId, connectorId },
         scenarioWithSerialized,
-      ).catch((err) =>
-        console.error("Failed to persist template scenario", err),
-      );
+      )
+        .then(() =>
+          armAppliedScenarioAutosaveSuppression(scenarioWithSerialized),
+        )
+        .catch((err) =>
+          console.error("Failed to persist template scenario", err),
+        );
     },
     [
       cpId,
@@ -1349,6 +1371,7 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
       setNodes,
       setEdges,
       prepareAppliedRemoteScenario,
+      armAppliedScenarioAutosaveSuppression,
     ],
   );
 

--- a/src/components/scenario/ScenarioEditor.tsx
+++ b/src/components/scenario/ScenarioEditor.tsx
@@ -52,10 +52,13 @@ import {
 } from "./forms/nodeFormRegistry";
 import type { NodeFormData } from "./forms/types";
 import {
+  type AppliedScenarioAutosaveSuppression,
   createLatestWinsSaver,
   persistEditorScenario,
   retargetScenarioToConnector,
   saveEditorScenario,
+  scenarioAutosaveSuppressionFingerprint,
+  shouldSuppressAppliedScenarioAutosave,
 } from "./scenarioPersistence";
 import { serializeScenarioGraph } from "./scenarioSerialize";
 import {
@@ -329,6 +332,8 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
   const [historyTick, setHistoryTick] = useState(0);
   const [saveFeedback, setSaveFeedback] = useState<"idle" | "saved">("idle");
   const saveFeedbackTimerRef = useRef<number | null>(null);
+  const appliedRemoteScenarioAutosaveRef =
+    useRef<AppliedScenarioAutosaveSuppression | null>(null);
   // Debounce for the autosave effect's I/O (DB write + ScenarioManager
   // resync): both cost a full sql.js export in local mode and a full
   // connector-scoped definitions re-list either way, so firing them on
@@ -384,6 +389,21 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
       connectorId,
       saveRemoteEditorScenarioLatest,
     ],
+  );
+
+  const prepareAppliedRemoteScenario = useCallback(
+    (next: ScenarioDefinition): ScenarioDefinition => {
+      if (mode !== "remote") return next;
+      const updatedAt = next.updatedAt ?? new Date().toISOString();
+      const applied = { ...next, updatedAt };
+      appliedRemoteScenarioAutosaveRef.current = {
+        scenarioId: applied.id,
+        updatedAt: applied.updatedAt ?? null,
+        fingerprint: scenarioAutosaveSuppressionFingerprint(applied),
+      };
+      return applied;
+    },
+    [mode],
   );
 
   // Reload scenario when props change
@@ -764,6 +784,12 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
       cleanedEvSettings[k] = v;
     });
 
+    const pendingRemoteApply = appliedRemoteScenarioAutosaveRef.current;
+    const appliedUpdatedAt =
+      pendingRemoteApply?.scenarioId === scenario.id
+        ? pendingRemoteApply.updatedAt
+        : null;
+
     const updatedScenario: ScenarioDefinition = {
       ...scenario,
       name: scenarioName,
@@ -777,7 +803,7 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
         Object.keys(cleanedEvSettings).length > 0
           ? cleanedEvSettings
           : undefined,
-      updatedAt: new Date().toISOString(),
+      updatedAt: appliedUpdatedAt ?? new Date().toISOString(),
     };
     setScenario(updatedScenario);
 
@@ -792,11 +818,24 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
           ...updatedScenario,
           ...serializedGraph,
         };
-        // Auto-save through the mode-aware upsert boundary. Fire-and-forget; if
-        // it fails we log to console rather than block the in-flight edit.
-        void saveEditorScenarioLatest(scenarioToSave).catch((err) =>
-          console.error("Failed to autosave scenario", err),
-        );
+        const suppressAppliedRemoteAutosave =
+          mode === "remote" &&
+          shouldSuppressAppliedScenarioAutosave(
+            pendingRemoteApply,
+            scenarioToSave,
+          );
+        if (suppressAppliedRemoteAutosave) {
+          appliedRemoteScenarioAutosaveRef.current = null;
+        } else {
+          if (pendingRemoteApply) {
+            appliedRemoteScenarioAutosaveRef.current = null;
+          }
+          // Auto-save through the latest-wins replace boundary. Fire-and-forget;
+          // if it fails we log to console rather than block the in-flight edit.
+          void saveEditorScenarioLatest(scenarioToSave).catch((err) =>
+            console.error("Failed to autosave scenario", err),
+          );
+        }
       }
 
       // Keep ScenarioManager in sync while editing (local mode only).
@@ -837,6 +876,7 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
     cpId,
     connectorId,
     localCp,
+    mode,
   ]);
 
   // Track structural changes for undo/redo. Position-only changes update
@@ -923,6 +963,7 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
         ...updated,
         ...serializedGraph,
       };
+      appliedRemoteScenarioAutosaveRef.current = null;
       void saveEditorScenarioLatest(scenarioToSave).catch((err) =>
         console.error("Failed to save scenario", err),
       );
@@ -1208,12 +1249,13 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
           connectorId,
           new Date().toISOString(),
         );
+        const applied = prepareAppliedRemoteScenario(targeted);
         const serializedGraph = serializeScenarioGraph(
-          targeted.nodes,
-          targeted.edges,
+          applied.nodes,
+          applied.edges,
         );
         const scenarioToPersist: ScenarioDefinition = {
-          ...targeted,
+          ...applied,
           ...serializedGraph,
         };
         setScenario(scenarioToPersist);
@@ -1229,9 +1271,8 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
         setScenarioEnabled(scenarioToPersist.enabled !== false);
         setScenarioEvSettings(scenarioToPersist.evSettings ?? {});
 
-        // Persist mode-aware: in remote mode the browser sql.js repository is a
-        // no-op, so the upload has to be pushed to the daemon (and prior
-        // scenarios cleaned up) or it's silently lost on reload (#101).
+        // Persist through the replace boundary so stale connector siblings are
+        // pruned and reload selects the imported scenario (#101).
         await persistEditorScenario(
           { mode, chargePointService, cpId, connectorId },
           scenarioToPersist,
@@ -1240,7 +1281,15 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
         alert(`Failed to import scenario: ${error}`);
       }
     },
-    [cpId, connectorId, mode, chargePointService, setNodes, setEdges],
+    [
+      cpId,
+      connectorId,
+      mode,
+      chargePointService,
+      setNodes,
+      setEdges,
+      prepareAppliedRemoteScenario,
+    ],
   );
 
   const handleLoadTemplate = useCallback(
@@ -1258,33 +1307,35 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
         return;
       }
 
-      const targeted = template.createScenario(cpId, connectorId);
-      const serializedGraph = serializeScenarioGraph(
-        targeted.nodes,
-        targeted.edges,
+      const templateScenario = prepareAppliedRemoteScenario(
+        template.createScenario(cpId, connectorId),
       );
-      const templateScenario: ScenarioDefinition = {
-        ...targeted,
+      const serializedGraph = serializeScenarioGraph(
+        templateScenario.nodes,
+        templateScenario.edges,
+      );
+      const scenarioWithSerialized: ScenarioDefinition = {
+        ...templateScenario,
         ...serializedGraph,
       };
-      setScenario(templateScenario);
-      setNodes(templateScenario.nodes);
-      setEdges(templateScenario.edges);
+      setScenario(scenarioWithSerialized);
+      setNodes(scenarioWithSerialized.nodes);
+      setEdges(scenarioWithSerialized.edges);
       // Keep the metadata fields in sync with the loaded template.
-      setScenarioName(templateScenario.name);
-      setScenarioDescription(templateScenario.description || "");
+      setScenarioName(scenarioWithSerialized.name);
+      setScenarioDescription(scenarioWithSerialized.description || "");
       setDefaultExecutionMode(
-        templateScenario.defaultExecutionMode || "oneshot",
+        scenarioWithSerialized.defaultExecutionMode || "oneshot",
       );
-      setScenarioEnabled(templateScenario.enabled !== false);
-      setScenarioEvSettings(templateScenario.evSettings ?? {});
+      setScenarioEnabled(scenarioWithSerialized.enabled !== false);
+      setScenarioEvSettings(scenarioWithSerialized.evSettings ?? {});
 
       // Same mode-aware persistence as the file-upload path: remote mode pushes
       // through the daemon and prunes stale scenarios; local mode upserts into
       // the browser sql.js repository (#101).
       void persistEditorScenario(
         { mode, chargePointService, cpId, connectorId },
-        templateScenario,
+        scenarioWithSerialized,
       ).catch((err) =>
         console.error("Failed to persist template scenario", err),
       );
@@ -1297,6 +1348,7 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
       nodes.length,
       setNodes,
       setEdges,
+      prepareAppliedRemoteScenario,
     ],
   );
 

--- a/src/components/scenario/__tests__/scenarioPersistence.test.ts
+++ b/src/components/scenario/__tests__/scenarioPersistence.test.ts
@@ -259,6 +259,53 @@ describe("persistEditorScenario (scenario upload / template replace persistence 
       }),
     ).toBe(false);
   });
+
+  it("does not arm autosave suppression when a delayed apply persist rejects (#101 / #165)", async () => {
+    // ScenarioEditor arms the applied-scenario autosave suppression only in
+    // persistEditorScenario(...).then(...). If the replace rejects, arm() must
+    // never run — otherwise the 400ms fallback autosave matches the
+    // fingerprint, clears the marker, skips its write, and silently drops the
+    // imported/template scenario.
+    const imported = {
+      ...scenario("imported"),
+      updatedAt: "2026-06-30T00:00:00.000Z",
+    };
+    const remote = makeRemoteStyleService([scenario("old")]);
+    const gate = deferred();
+    remote.service.replaceConnectorScenarioDefinitions.mockImplementationOnce(
+      () => gate.promise as unknown as Promise<readonly ScenarioDefinition[]>,
+    );
+
+    let armed: Parameters<typeof shouldSuppressAppliedScenarioAutosave>[0] =
+      null;
+    const apply = persistEditorScenario(
+      {
+        mode: "remote",
+        chargePointService: remote.service,
+        cpId: "CP1",
+        connectorId: 1,
+      },
+      imported,
+    )
+      .then(() => {
+        armed = {
+          scenarioId: imported.id,
+          updatedAt: imported.updatedAt,
+          fingerprint: scenarioAutosaveSuppressionFingerprint(imported),
+        };
+      })
+      .catch(() => {
+        /* apply failed → suppression intentionally left unarmed */
+      });
+
+    gate.reject(new Error("replace failed"));
+    await apply;
+    await flushPromises();
+
+    expect(armed).toBeNull();
+    // Unarmed suppression → the fallback autosave is free to persist the import.
+    expect(shouldSuppressAppliedScenarioAutosave(armed, imported)).toBe(false);
+  });
 });
 
 describe("saveEditorScenario (single definition upsert)", () => {

--- a/src/components/scenario/__tests__/scenarioPersistence.test.ts
+++ b/src/components/scenario/__tests__/scenarioPersistence.test.ts
@@ -426,6 +426,99 @@ describe("createLatestWinsSaver", () => {
   });
 });
 
+describe("shouldSuppressAppliedScenarioAutosave (fingerprint guard)", () => {
+  it("returns true for identical scenario (unedited after apply)", () => {
+    const applied = {
+      ...scenario("applied-1"),
+      name: "Applied Scenario",
+      updatedAt: "2026-06-30T00:00:00.000Z",
+    };
+    const suppression = {
+      scenarioId: applied.id,
+      updatedAt: applied.updatedAt,
+      fingerprint: scenarioAutosaveSuppressionFingerprint(applied),
+    };
+
+    expect(shouldSuppressAppliedScenarioAutosave(suppression, applied)).toBe(
+      true,
+    );
+  });
+
+  it("returns false when scenario name changes (real user edit)", () => {
+    const applied = {
+      ...scenario("applied-1"),
+      name: "Original Name",
+      updatedAt: "2026-06-30T00:00:00.000Z",
+    };
+    const suppression = {
+      scenarioId: applied.id,
+      updatedAt: applied.updatedAt,
+      fingerprint: scenarioAutosaveSuppressionFingerprint(applied),
+    };
+    const edited = {
+      ...applied,
+      name: "Edited Name",
+    };
+
+    expect(shouldSuppressAppliedScenarioAutosave(suppression, edited)).toBe(
+      false,
+    );
+  });
+
+  it("returns false when a node property changes", () => {
+    const applied = {
+      ...scenario("applied-1"),
+      updatedAt: "2026-06-30T00:00:00.000Z",
+      nodes: [
+        {
+          id: "node-1",
+          type: "start",
+          position: { x: 0, y: 0 },
+          data: { label: "Start" },
+        },
+      ],
+    } as unknown as ScenarioDefinition;
+    const suppression = {
+      scenarioId: applied.id,
+      updatedAt: applied.updatedAt,
+      fingerprint: scenarioAutosaveSuppressionFingerprint(applied),
+    };
+    const edited = {
+      ...applied,
+      nodes: [
+        {
+          id: "node-1",
+          type: "start",
+          position: { x: 100, y: 100 },
+          data: { label: "Start Modified" },
+        },
+      ],
+    } as unknown as ScenarioDefinition;
+
+    expect(shouldSuppressAppliedScenarioAutosave(suppression, edited)).toBe(
+      false,
+    );
+  });
+
+  it("returns false when null suppression record is passed", () => {
+    const scenario1 = scenario("any-scenario");
+    expect(shouldSuppressAppliedScenarioAutosave(null, scenario1)).toBe(false);
+  });
+
+  it("returns false when scenario id differs from suppression record", () => {
+    const suppression = {
+      scenarioId: "other-id",
+      updatedAt: "2026-06-30T00:00:00.000Z",
+      fingerprint: "some-fingerprint",
+    };
+    const applied = scenario("applied-1");
+
+    expect(shouldSuppressAppliedScenarioAutosave(suppression, applied)).toBe(
+      false,
+    );
+  });
+});
+
 describe("retargetScenarioToConnector (upload retargeting — #101)", () => {
   const now = "2026-06-30T00:00:00.000Z";
 

--- a/src/components/scenario/scenarioPersistence.ts
+++ b/src/components/scenario/scenarioPersistence.ts
@@ -107,9 +107,8 @@ async function activateRemoteScenario(
 ): Promise<void> {
   const { mode, chargePointService, cpId, connectorId } = deps;
   if (mode !== "remote") return;
-  if (connectorId === null) {
-    throw new Error("Remote scenario activation requires a connector id");
-  }
+  // CP-level scenarios (connectorId === null) have no connector runtime to activate into; persistence already happened.
+  if (connectorId === null) return;
 
   await chargePointService.loadScenario(cpId, connectorId, scenario);
 }

--- a/src/utils/__tests__/scenarioFile.test.ts
+++ b/src/utils/__tests__/scenarioFile.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { parseScenarioJSON } from "../scenarioFile";
+import type { ScenarioDefinition } from "../../cp/application/scenario/ScenarioTypes";
+
+describe("parseScenarioJSON", () => {
+  const createValidScenario = (
+    overrides: Partial<ScenarioDefinition> = {},
+  ): ScenarioDefinition => ({
+    id: "test-scenario",
+    name: "Test Scenario",
+    description: "A test scenario",
+    targetType: "connector" as const,
+    targetId: 1,
+    nodes: [
+      {
+        id: "start",
+        type: "start",
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "end",
+        type: "end",
+        position: { x: 0, y: 100 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      {
+        id: "e-start-end",
+        source: "start",
+        target: "end",
+      },
+    ],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    trigger: { type: "manual" as const },
+    defaultExecutionMode: "oneshot" as const,
+    enabled: true,
+    ...overrides,
+  });
+
+  it("parses a valid scenario JSON", () => {
+    const scenario = createValidScenario();
+    const json = JSON.stringify(scenario);
+    const result = parseScenarioJSON(json);
+    expect(result.id).toBe("test-scenario");
+    expect(result.name).toBe("Test Scenario");
+    expect(result.nodes).toHaveLength(2);
+    expect(result.edges).toHaveLength(1);
+  });
+
+  it("throws on missing id", () => {
+    const scenario = createValidScenario({ id: undefined });
+    const json = JSON.stringify(scenario);
+    expect(() => parseScenarioJSON(json)).toThrow(
+      "Invalid scenario file format",
+    );
+  });
+
+  it("throws on missing nodes", () => {
+    const scenario = createValidScenario({ nodes: undefined });
+    const json = JSON.stringify(scenario);
+    expect(() => parseScenarioJSON(json)).toThrow(
+      "Invalid scenario file format",
+    );
+  });
+
+  it("throws on missing edges", () => {
+    const scenario = createValidScenario({ edges: undefined });
+    const json = JSON.stringify(scenario);
+    expect(() => parseScenarioJSON(json)).toThrow(
+      "Invalid scenario file format",
+    );
+  });
+
+  it("throws on invalid JSON", () => {
+    const invalidJson = "{ invalid json }";
+    expect(() => parseScenarioJSON(invalidJson)).toThrow();
+  });
+
+  it("throws on empty nodes array", () => {
+    const scenario = createValidScenario({ nodes: [] });
+    // Note: empty array is truthy, so this should NOT throw
+    const json = JSON.stringify(scenario);
+    const result = parseScenarioJSON(json);
+    expect(result.nodes).toHaveLength(0);
+  });
+
+  it("throws on empty edges array", () => {
+    const scenario = createValidScenario({ edges: [] });
+    // Note: empty array is truthy, so this should NOT throw
+    const json = JSON.stringify(scenario);
+    const result = parseScenarioJSON(json);
+    expect(result.edges).toHaveLength(0);
+  });
+});

--- a/src/utils/__tests__/scenarioFile.test.ts
+++ b/src/utils/__tests__/scenarioFile.test.ts
@@ -79,19 +79,46 @@ describe("parseScenarioJSON", () => {
     expect(() => parseScenarioJSON(invalidJson)).toThrow();
   });
 
-  it("throws on empty nodes array", () => {
+  it("accepts an empty nodes array", () => {
     const scenario = createValidScenario({ nodes: [] });
-    // Note: empty array is truthy, so this should NOT throw
-    const json = JSON.stringify(scenario);
-    const result = parseScenarioJSON(json);
+    const result = parseScenarioJSON(JSON.stringify(scenario));
     expect(result.nodes).toHaveLength(0);
   });
 
-  it("throws on empty edges array", () => {
+  it("accepts an empty edges array", () => {
     const scenario = createValidScenario({ edges: [] });
-    // Note: empty array is truthy, so this should NOT throw
-    const json = JSON.stringify(scenario);
-    const result = parseScenarioJSON(json);
+    const result = parseScenarioJSON(JSON.stringify(scenario));
     expect(result.edges).toHaveLength(0);
+  });
+
+  it("rejects non-array nodes/edges (truthiness alone would accept these)", () => {
+    expect(() =>
+      parseScenarioJSON(
+        JSON.stringify(createValidScenario({ nodes: {} as never })),
+      ),
+    ).toThrow("Invalid scenario file format");
+    expect(() =>
+      parseScenarioJSON(
+        JSON.stringify(createValidScenario({ edges: "invalid" as never })),
+      ),
+    ).toThrow("Invalid scenario file format");
+  });
+
+  it("rejects an empty-string id", () => {
+    expect(() =>
+      parseScenarioJSON(JSON.stringify(createValidScenario({ id: "" }))),
+    ).toThrow("Invalid scenario file format");
+  });
+
+  it("rejects non-object top-level JSON (null / array / scalar)", () => {
+    expect(() => parseScenarioJSON("null")).toThrow(
+      "Invalid scenario file format",
+    );
+    expect(() => parseScenarioJSON("[]")).toThrow(
+      "Invalid scenario file format",
+    );
+    expect(() => parseScenarioJSON("42")).toThrow(
+      "Invalid scenario file format",
+    );
   });
 });

--- a/src/utils/scenarioFile.ts
+++ b/src/utils/scenarioFile.ts
@@ -22,6 +22,15 @@ export function exportScenarioToJSON(scenario: ScenarioDefinition): void {
   URL.revokeObjectURL(url);
 }
 
+/** Parse and validate a scenario from JSON text. Throws on invalid structure. */
+export function parseScenarioJSON(text: string): ScenarioDefinition {
+  const scenario = JSON.parse(text) as ScenarioDefinition;
+  if (!scenario.id || !scenario.nodes || !scenario.edges) {
+    throw new Error("Invalid scenario file format");
+  }
+  return scenario;
+}
+
 /** Parse a user-picked file as a `ScenarioDefinition`. Rejects when the
  *  structure is missing required fields. */
 export function importScenarioFromJSON(
@@ -32,10 +41,7 @@ export function importScenarioFromJSON(
     reader.onload = (e) => {
       try {
         const content = e.target?.result as string;
-        const scenario = JSON.parse(content) as ScenarioDefinition;
-        if (!scenario.id || !scenario.nodes || !scenario.edges) {
-          throw new Error("Invalid scenario file format");
-        }
+        const scenario = parseScenarioJSON(content);
         resolve(scenario);
       } catch (error) {
         reject(error);

--- a/src/utils/scenarioFile.ts
+++ b/src/utils/scenarioFile.ts
@@ -22,13 +22,24 @@ export function exportScenarioToJSON(scenario: ScenarioDefinition): void {
   URL.revokeObjectURL(url);
 }
 
-/** Parse and validate a scenario from JSON text. Throws on invalid structure. */
+/** Parse and validate a scenario from JSON text. Throws on invalid structure —
+ *  rejects non-objects, requires a non-empty string `id`, and requires `nodes`
+ *  and `edges` to be arrays (truthiness alone would accept `nodes: {}` etc.). */
 export function parseScenarioJSON(text: string): ScenarioDefinition {
-  const scenario = JSON.parse(text) as ScenarioDefinition;
-  if (!scenario.id || !scenario.nodes || !scenario.edges) {
+  const parsed: unknown = JSON.parse(text);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     throw new Error("Invalid scenario file format");
   }
-  return scenario;
+  const scenario = parsed as Partial<ScenarioDefinition>;
+  if (
+    typeof scenario.id !== "string" ||
+    scenario.id.length === 0 ||
+    !Array.isArray(scenario.nodes) ||
+    !Array.isArray(scenario.edges)
+  ) {
+    throw new Error("Invalid scenario file format");
+  }
+  return scenario as ScenarioDefinition;
 }
 
 /** Parse a user-picked file as a `ScenarioDefinition`. Rejects when the


### PR DESCRIPTION
## Addresses #101 — uploaded scenario reverts to the old one after refresh

### Investigation

The web console in Docker / `--web-console` runs in **remote mode** (the health probe at the
served origin answers, so it talks to the daemon's SQLite). The earlier #132 fix only touched
the **local** sql.js path (`SqlJsDatabase.flush`), which remote mode never uses — so it couldn't
affect a Docker repro.

I verified the **remote/daemon persistence path is correct**: a new headless end-to-end test
drives the exact socket RPCs the editor uses — `scenario.definitions.replace` (the upload
persist) then `scenario.definitions.list` (the refresh re-fetch) — across a fresh reconnect
**and** a daemon restart, and the uploaded scenario survives both. So the daemon store, the
`replaceConnector` upsert, and the refresh read are all sound.

### What was actually broken

**A regression: the applied-scenario autosave suppression was silently dropped.** Commit
`1547cee` wired a fingerprint guard into the editor (a #101 fix) so that the debounced autosave
triggered by an upload's *programmatic* state change wouldn't fire a second, redundant persist +
runtime re-activation right after the apply. A later merge dropped that wiring from
`ScenarioEditor.tsx` — the helpers and their unit tests survived in `scenarioPersistence.ts` but
nothing consulted them, so every upload/template-apply did a `replace` **and** then an unguarded
`upsert` + double `loadScenario`.

This PR restores the wiring: an apply records the applied scenario's fingerprint, and the
following autosave is suppressed **only** when the editor content still exactly matches it (any
real edit changes the fingerprint and saves normally).

**Plus a concrete bug:** a charge-point-level upload (`connectorId === null`) threw out of
`activateRemoteScenario` (“requires a connector id”) *after* persisting, surfacing as a spurious
“Failed to import scenario” alert. CP-level scenarios have no connector runtime to activate into,
so it now returns instead of throwing.

### Testability (why this kept regressing)

There was no end-to-end test of upload → persist → refresh, so each fix regressed unnoticed.
This PR adds:
- a pure `parseScenarioJSON(text)` extracted from the `FileReader`-bound `importScenarioFromJSON`,
  with unit tests (upload parsing is now testable headlessly);
- the daemon-path repro test described above;
- fingerprint-guard tests proving suppression fires for an unedited apply and *not* after an edit.

`vitest` 817, `bun test bun.test` 0 fail, lint clean, golden snapshots unchanged.

### Honest caveat

I could not reproduce the exact **visual** "old scenario shows" drop headlessly — the daemon
persistence is verifiably correct, and browser automation was unavailable in my environment. If
it still reproduces after this lands, the next most likely cause is a **stale Docker UI bundle**
(`docker compose up` reusing a cached image); a clean `docker compose up --build` is worth
confirming. Happy to dig further with a browser console log from a fresh build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scenario updates now persist across app refreshes and remote service restarts.
  * Remote “applied scenario” autosave is now suppressed to prevent unintended overwrites.
  * Improved remote activation behavior for CP-level scenarios (no longer errors when no connector id is present).
  * Scenario imports now use consistent JSON parsing/validation with clearer error handling.

* **Tests**
  * Added a Bun test covering remote scenario persistence across refresh and restart.
  * Added unit tests for remote autosave suppression logic.
  * Expanded scenario file parsing/validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->