### PR TITLE
feat(ui): consistent OCPP version labels + transport-aware URL scheme (#164)

### DIFF
--- a/src/components/ChargePointConfigModal.dom.test.tsx
+++ b/src/components/ChargePointConfigModal.dom.test.tsx
@@ -272,7 +272,7 @@ describe("ChargePointConfigModal — OCPP-1.5 + Security Profile UI", () => {
       "SOAP Callback URL is required",
     );
 
-    await selectOption("ocppVersion", "OCPP 1.6J");
+    await selectOption("ocppVersion", "OCPP 1.6 (JSON)");
 
     expect(document.body.textContent).not.toContain(
       "SOAP Callback URL is required",
@@ -428,7 +428,7 @@ describe("ChargePointConfigModal — OCPP-1.5 + Security Profile UI", () => {
       "SOAP Callback URL is required",
     );
 
-    await selectOption("ocppVersion", "OCPP 1.6J");
+    await selectOption("ocppVersion", "OCPP 1.6 (JSON)");
 
     expect(document.body.textContent).not.toContain(
       "SOAP Callback URL is required",
@@ -452,10 +452,36 @@ describe("ChargePointConfigModal — OCPP-1.5 + Security Profile UI", () => {
       "SOAP Callback URL is required",
     );
 
-    await selectOption("ocppVersion", "OCPP 1.6J");
+    await selectOption("ocppVersion", "OCPP 1.6 (JSON)");
 
     expect(document.body.textContent).not.toContain(
       "SOAP Callback URL is required",
+    );
+  });
+
+  it("converts the Central System URL scheme to match the selected transport (#164)", async () => {
+    const rendered = await renderModal({
+      mode: "local",
+      initialConfig: baseConfig({
+        ocppVersion: "OCPP-1.6J",
+        wsURL: "ws://localhost:8080/steve/websocket/CentralSystemService/",
+      }),
+    });
+    roots.push(rendered.root);
+
+    const wsURLValue = () =>
+      (document.getElementById("wsURL") as HTMLInputElement).value;
+
+    // JSON -> SOAP: ws:// becomes http://; host/port/path preserved.
+    await selectOption("ocppVersion", "OCPP 1.2 (SOAP)");
+    expect(wsURLValue()).toBe(
+      "http://localhost:8080/steve/websocket/CentralSystemService/",
+    );
+
+    // SOAP -> JSON: http:// converts back to ws://.
+    await selectOption("ocppVersion", "OCPP 1.6 (JSON)");
+    expect(wsURLValue()).toBe(
+      "ws://localhost:8080/steve/websocket/CentralSystemService/",
     );
   });
 });

--- a/src/components/ChargePointConfigModal.tsx
+++ b/src/components/ChargePointConfigModal.tsx
@@ -3,6 +3,7 @@ import { Save, X } from "lucide-react";
 import { buildFullOcppUrl, parseFullOcppUrl } from "../utils/ocppUrl";
 import { BROWSER_TLS_UNSUPPORTED_MESSAGE } from "../data/interfaces/UnsupportedFeatureError";
 import { isSoapVersion } from "../cp/domain/types/OcppVersion";
+import { adaptCentralSystemUrlScheme } from "../utils/ocppUrlScheme";
 import type {
   OcppSecurityProfile,
   OcppTlsOptions,
@@ -193,6 +194,17 @@ const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
     setConfig({ ...config, [key]: value });
   };
 
+  // Changing the OCPP version also flips the Central System URL scheme to match
+  // the new transport (SOAP = http(s), JSON = ws(s)), but only when the current
+  // scheme is incompatible — a custom compatible URL is preserved (#164).
+  const changeOcppVersion = (value: string) => {
+    setConfig((prev) => ({
+      ...prev,
+      ocppVersion: value,
+      wsURL: adaptCentralSystemUrlScheme(prev.wsURL, isSoapVersion(value)),
+    }));
+  };
+
   const updateTls = (patch: Partial<OcppTlsOptions>) => {
     setConfig((prev) => ({ ...prev, tls: { ...prev.tls, ...patch } }));
   };
@@ -379,7 +391,7 @@ const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
                 </Label>
                 <Select
                   value={config.ocppVersion}
-                  onValueChange={(value) => updateConfig("ocppVersion", value)}
+                  onValueChange={changeOcppVersion}
                 >
                   <SelectTrigger id="ocppVersion">
                     <SelectValue />
@@ -387,7 +399,7 @@ const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
                   <SelectContent>
                     <SelectItem value="OCPP-1.2">OCPP 1.2 (SOAP)</SelectItem>
                     <SelectItem value="OCPP-1.5">OCPP 1.5 (SOAP)</SelectItem>
-                    <SelectItem value="OCPP-1.6J">OCPP 1.6J</SelectItem>
+                    <SelectItem value="OCPP-1.6J">OCPP 1.6 (JSON)</SelectItem>
                     <SelectItem value="OCPP-1.6S">OCPP 1.6 (SOAP)</SelectItem>
                     <SelectItem value="OCPP-2.0.1">OCPP 2.0.1</SelectItem>
                     <SelectItem value="OCPP-2.1">OCPP 2.1</SelectItem>

--- a/src/utils/__tests__/ocppUrlScheme.test.ts
+++ b/src/utils/__tests__/ocppUrlScheme.test.ts
@@ -50,6 +50,21 @@ describe("adaptCentralSystemUrlScheme (#164)", () => {
     });
   });
 
+  it("matches schemes case-insensitively (RFC 3986)", () => {
+    expect(adaptCentralSystemUrlScheme(`WS://${STEVE}`, true)).toBe(
+      `http://${STEVE}`,
+    );
+    expect(adaptCentralSystemUrlScheme(`WSS://${STEVE}`, true)).toBe(
+      `https://${STEVE}`,
+    );
+    expect(adaptCentralSystemUrlScheme(`HTTP://${STEVE}`, false)).toBe(
+      `ws://${STEVE}`,
+    );
+    expect(adaptCentralSystemUrlScheme(`HTTPS://${STEVE}`, false)).toBe(
+      `wss://${STEVE}`,
+    );
+  });
+
   it("preserves a custom URL with an unrecognised scheme", () => {
     expect(adaptCentralSystemUrlScheme("example.com/ocpp", true)).toBe(
       "example.com/ocpp",

--- a/src/utils/__tests__/ocppUrlScheme.test.ts
+++ b/src/utils/__tests__/ocppUrlScheme.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { adaptCentralSystemUrlScheme } from "../ocppUrlScheme";
+
+describe("adaptCentralSystemUrlScheme (#164)", () => {
+  const STEVE = "localhost:8080/steve/websocket/CentralSystemService/";
+
+  describe("switching to a SOAP transport", () => {
+    it("maps ws:// -> http:// and keeps host/port/path", () => {
+      expect(adaptCentralSystemUrlScheme(`ws://${STEVE}`, true)).toBe(
+        `http://${STEVE}`,
+      );
+    });
+
+    it("maps wss:// -> https:// (secure stays secure)", () => {
+      expect(adaptCentralSystemUrlScheme(`wss://${STEVE}`, true)).toBe(
+        `https://${STEVE}`,
+      );
+    });
+
+    it("leaves an already-compatible http/https URL unchanged", () => {
+      expect(adaptCentralSystemUrlScheme(`http://${STEVE}`, true)).toBe(
+        `http://${STEVE}`,
+      );
+      expect(adaptCentralSystemUrlScheme(`https://${STEVE}`, true)).toBe(
+        `https://${STEVE}`,
+      );
+    });
+  });
+
+  describe("switching to a JSON/WebSocket transport", () => {
+    it("maps http:// -> ws:// and keeps host/port/path", () => {
+      expect(adaptCentralSystemUrlScheme(`http://${STEVE}`, false)).toBe(
+        `ws://${STEVE}`,
+      );
+    });
+
+    it("maps https:// -> wss:// (secure stays secure)", () => {
+      expect(adaptCentralSystemUrlScheme(`https://${STEVE}`, false)).toBe(
+        `wss://${STEVE}`,
+      );
+    });
+
+    it("leaves an already-compatible ws/wss URL unchanged", () => {
+      expect(adaptCentralSystemUrlScheme(`ws://${STEVE}`, false)).toBe(
+        `ws://${STEVE}`,
+      );
+      expect(adaptCentralSystemUrlScheme(`wss://${STEVE}`, false)).toBe(
+        `wss://${STEVE}`,
+      );
+    });
+  });
+
+  it("preserves a custom URL with an unrecognised scheme", () => {
+    expect(adaptCentralSystemUrlScheme("example.com/ocpp", true)).toBe(
+      "example.com/ocpp",
+    );
+    expect(adaptCentralSystemUrlScheme("tcp://host:9000", false)).toBe(
+      "tcp://host:9000",
+    );
+  });
+
+  it("does not touch host/port/path — only the scheme is converted", () => {
+    expect(
+      adaptCentralSystemUrlScheme("wss://ocpp.example.com:443/path?q=1", true),
+    ).toBe("https://ocpp.example.com:443/path?q=1");
+  });
+});

--- a/src/utils/ocppUrlScheme.ts
+++ b/src/utils/ocppUrlScheme.ts
@@ -1,0 +1,23 @@
+/**
+ * Adapt a Central System URL's scheme to the selected OCPP transport (#164).
+ *
+ * SOAP dialects (1.2 / 1.5 / 1.6-SOAP) speak HTTP; JSON dialects speak
+ * WebSocket. When the operator switches transport we flip only an
+ * *incompatible* scheme and leave everything after it — host, port, path —
+ * untouched, since the correct SOAP endpoint path can't be inferred. A URL that
+ * is already compatible, or uses some other scheme the user typed on purpose,
+ * is returned unchanged. Secure stays secure: `wss` <-> `https`, `ws` <-> `http`.
+ */
+export function adaptCentralSystemUrlScheme(
+  url: string,
+  toSoap: boolean,
+): string {
+  if (toSoap) {
+    if (url.startsWith("ws://")) return `http://${url.slice(5)}`;
+    if (url.startsWith("wss://")) return `https://${url.slice(6)}`;
+    return url;
+  }
+  if (url.startsWith("http://")) return `ws://${url.slice(7)}`;
+  if (url.startsWith("https://")) return `wss://${url.slice(8)}`;
+  return url;
+}

--- a/src/utils/ocppUrlScheme.ts
+++ b/src/utils/ocppUrlScheme.ts
@@ -12,12 +12,14 @@ export function adaptCentralSystemUrlScheme(
   url: string,
   toSoap: boolean,
 ): string {
+  // URL schemes are case-insensitive (RFC 3986), so match accordingly. Each
+  // prefix has the same length regardless of case, so the slice offsets hold.
   if (toSoap) {
-    if (url.startsWith("ws://")) return `http://${url.slice(5)}`;
-    if (url.startsWith("wss://")) return `https://${url.slice(6)}`;
+    if (/^ws:\/\//i.test(url)) return `http://${url.slice(5)}`;
+    if (/^wss:\/\//i.test(url)) return `https://${url.slice(6)}`;
     return url;
   }
-  if (url.startsWith("http://")) return `ws://${url.slice(7)}`;
-  if (url.startsWith("https://")) return `wss://${url.slice(8)}`;
+  if (/^http:\/\//i.test(url)) return `ws://${url.slice(7)}`;
+  if (/^https:\/\//i.test(url)) return `wss://${url.slice(8)}`;
   return url;
 }


### PR DESCRIPTION
Closes #164.

## 1. Consistent version labels
The dropdown mixed conventions (`OCPP 1.6J` vs `OCPP 1.2 (SOAP)`). Relabel the one odd item to the explicit form (issue's Option B):

| value | label before | label after |
|---|---|---|
| `OCPP-1.6J` | `OCPP 1.6J` | **`OCPP 1.6 (JSON)`** |

The **stored value stays `OCPP-1.6J`** — existing configs and the CLI/daemon are unaffected (backward compatible). The 1.2/1.5/1.6-SOAP items already read `(SOAP)`; 2.0.1/2.1 need no suffix.

## 2. Transport-aware Central System URL scheme
On version change, `adaptCentralSystemUrlScheme(url, isSoap)` flips only an **incompatible** scheme:

- → SOAP: `ws://`→`http://`, `wss://`→`https://`
- → JSON/WS: `http://`→`ws://`, `https://`→`wss://`
- already-compatible or custom/other schemes are left as-is; **host, port and path are never touched**; secure stays secure.

## Acceptance criteria
- [x] One consistent naming convention for 1.6 JSON vs SOAP
- [x] Selecting 1.2/1.5/1.6-SOAP → `http(s)://`
- [x] Selecting a JSON/WS version → `ws(s)://`
- [x] Only the scheme is converted; host/port/path unchanged
- [x] `wss://`↔`https://` secure mapping
- [x] Existing configurations remain backward compatible (value unchanged)

## Tests
- `ocppUrlScheme.test.ts` — pure conversion, all directions + preservation cases
- `ChargePointConfigModal.dom.test.tsx` — new test drives the version switch and asserts the URL field flips `ws://`↔`http://` with the path preserved (existing label refs updated)
- Full suite: 817 tests pass; lint + build clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Central System URLs now automatically remap between WebSocket and HTTP(S) schemes when changing OCPP transport types.
  * URL paths, ports, queries, and security behavior are preserved during scheme conversion.
  * The JSON OCPP 1.6 option is now labeled “OCPP 1.6 (JSON).”

* **Bug Fixes**
  * Improved handling of stale callback validation messages when switching between OCPP versions.

* **Tests**
  * Added regression coverage for Central System URL scheme remapping across transport changes (issue `#164`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->