### PR TITLE
feat(scenario): generic CSMS-call trigger and response-override engine hooks (#110)

### DIFF
--- a/src/components/scenario/ScenarioEditor.tsx
+++ b/src/components/scenario/ScenarioEditor.tsx
@@ -78,6 +78,8 @@ import NotificationNode from "./nodes/NotificationNode";
 import ConnectorPlugNode from "./nodes/ConnectorPlugNode";
 import RemoteStartTriggerNode from "./nodes/RemoteStartTriggerNode";
 import RemoteStopTriggerNode from "./nodes/RemoteStopTriggerNode";
+import CsmsCallTriggerNode from "./nodes/CsmsCallTriggerNode";
+import ResponseOverrideNode from "./nodes/ResponseOverrideNode";
 import StatusTriggerNode from "./nodes/StatusTriggerNode";
 import ReserveNowNode from "./nodes/ReserveNowNode";
 import CancelReservationNode from "./nodes/CancelReservationNode";
@@ -193,6 +195,8 @@ const nodeTypes: NodeTypes = {
   [ScenarioNodeType.CONNECTOR_PLUG]: ConnectorPlugNode,
   [ScenarioNodeType.REMOTE_START_TRIGGER]: RemoteStartTriggerNode,
   [ScenarioNodeType.REMOTE_STOP_TRIGGER]: RemoteStopTriggerNode,
+  [ScenarioNodeType.CSMS_CALL_TRIGGER]: CsmsCallTriggerNode,
+  [ScenarioNodeType.RESPONSE_OVERRIDE]: ResponseOverrideNode,
   [ScenarioNodeType.STATUS_TRIGGER]: StatusTriggerNode,
   [ScenarioNodeType.RESERVE_NOW]: ReserveNowNode,
   [ScenarioNodeType.CANCEL_RESERVATION]: CancelReservationNode,
@@ -1962,6 +1966,16 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
                 icon="⏹"
               />
               <NodePaletteItem
+                type={ScenarioNodeType.CSMS_CALL_TRIGGER}
+                label="CSMS Call"
+                icon="📥"
+              />
+              <NodePaletteItem
+                type={ScenarioNodeType.RESPONSE_OVERRIDE}
+                label="Override"
+                icon="🚫"
+              />
+              <NodePaletteItem
                 type={ScenarioNodeType.STATUS_NOTIFICATION}
                 label="StatusNotif"
                 icon="📡"
@@ -2199,6 +2213,24 @@ function createNodeByType(
         type,
         position,
         data: { label: "Wait for RemoteStop", timeout: 0 },
+      };
+    case ScenarioNodeType.CSMS_CALL_TRIGGER:
+      return {
+        id,
+        type,
+        position,
+        data: { label: "Wait for CSMS Call", action: "Reset", timeout: 0 },
+      };
+    case ScenarioNodeType.RESPONSE_OVERRIDE:
+      return {
+        id,
+        type,
+        position,
+        data: {
+          label: "Response Override",
+          action: "RemoteStartTransaction",
+          status: "Rejected",
+        },
       };
     case ScenarioNodeType.STATUS_TRIGGER:
       return {

--- a/src/components/scenario/forms/CsmsCallTriggerForm.tsx
+++ b/src/components/scenario/forms/CsmsCallTriggerForm.tsx
@@ -1,0 +1,40 @@
+import { NumberField, SelectField, TextField } from "./FormFields";
+import type { NodeFormComponentProps, NodeFormData } from "./types";
+import { CSMS_CALL_TRIGGER_ACTIONS } from "../../../cp/application/scenario/ScenarioTypes";
+
+export default function CsmsCallTriggerForm({
+  value,
+  onChange,
+}: NodeFormComponentProps<NodeFormData>) {
+  const actionOptions = CSMS_CALL_TRIGGER_ACTIONS.map((action) => ({
+    value: action,
+    label: action,
+  }));
+
+  return (
+    <div className="space-y-3">
+      <TextField
+        label="Label"
+        value={(value.label as string | undefined) ?? ""}
+        onChange={(label) => onChange({ ...value, label })}
+      />
+      <SelectField
+        label="Action"
+        value={(value.action as string | undefined) ?? "Reset"}
+        onChange={(action) => onChange({ ...value, action })}
+        options={actionOptions}
+      />
+      <div>
+        <NumberField
+          label="Timeout (seconds)"
+          value={typeof value.timeout === "number" ? value.timeout : 0}
+          onChange={(timeout) => onChange({ ...value, timeout: timeout ?? 0 })}
+          min={0}
+        />
+        <p className="text-xs text-muted mt-1">
+          0 = No timeout (wait indefinitely for CSMS call)
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scenario/forms/ResponseOverrideForm.tsx
+++ b/src/components/scenario/forms/ResponseOverrideForm.tsx
@@ -1,0 +1,52 @@
+import { SelectField, TextField } from "./FormFields";
+import type { NodeFormComponentProps, NodeFormData } from "./types";
+import { RESPONSE_OVERRIDE_ACTIONS } from "../../../cp/application/scenario/ScenarioTypes";
+
+const OVERRIDE_STATUSES = [
+  "Rejected",
+  "Accepted",
+  "Faulted",
+  "Occupied",
+  "Unavailable",
+  "NotSupported",
+  "NotImplemented",
+  "Failed",
+  "VersionMismatch",
+] as const;
+
+export default function ResponseOverrideForm({
+  value,
+  onChange,
+}: NodeFormComponentProps<NodeFormData>) {
+  const actionOptions = RESPONSE_OVERRIDE_ACTIONS.map((action) => ({
+    value: action,
+    label: action,
+  }));
+
+  const statusOptions = OVERRIDE_STATUSES.map((status) => ({
+    value: status,
+    label: status,
+  }));
+
+  return (
+    <div className="space-y-3">
+      <TextField
+        label="Label"
+        value={(value.label as string | undefined) ?? ""}
+        onChange={(label) => onChange({ ...value, label })}
+      />
+      <SelectField
+        label="Action"
+        value={(value.action as string | undefined) ?? "RemoteStartTransaction"}
+        onChange={(action) => onChange({ ...value, action })}
+        options={actionOptions}
+      />
+      <SelectField
+        label="Status"
+        value={(value.status as string | undefined) ?? "Rejected"}
+        onChange={(status) => onChange({ ...value, status })}
+        options={statusOptions}
+      />
+    </div>
+  );
+}

--- a/src/components/scenario/forms/ResponseOverrideForm.tsx
+++ b/src/components/scenario/forms/ResponseOverrideForm.tsx
@@ -1,18 +1,12 @@
 import { SelectField, TextField } from "./FormFields";
 import type { NodeFormComponentProps, NodeFormData } from "./types";
-import { RESPONSE_OVERRIDE_ACTIONS } from "../../../cp/application/scenario/ScenarioTypes";
+import {
+  RESPONSE_OVERRIDE_ACTIONS,
+  RESPONSE_OVERRIDE_STATUSES,
+} from "../../../cp/application/scenario/ScenarioTypes";
 
-const OVERRIDE_STATUSES = [
-  "Rejected",
-  "Accepted",
-  "Faulted",
-  "Occupied",
-  "Unavailable",
-  "NotSupported",
-  "NotImplemented",
-  "Failed",
-  "VersionMismatch",
-] as const;
+const DEFAULT_ACTION: (typeof RESPONSE_OVERRIDE_ACTIONS)[number] =
+  "RemoteStartTransaction";
 
 export default function ResponseOverrideForm({
   value,
@@ -23,10 +17,30 @@ export default function ResponseOverrideForm({
     label: action,
   }));
 
-  const statusOptions = OVERRIDE_STATUSES.map((status) => ({
+  const currentAction =
+    (value.action as string | undefined) ?? DEFAULT_ACTION;
+  const validStatuses =
+    RESPONSE_OVERRIDE_STATUSES[
+      currentAction as keyof typeof RESPONSE_OVERRIDE_STATUSES
+    ] ?? RESPONSE_OVERRIDE_STATUSES[DEFAULT_ACTION];
+
+  const statusOptions = validStatuses.map((status) => ({
     value: status,
     label: status,
   }));
+
+  const handleActionChange = (action: string) => {
+    const nextStatuses =
+      RESPONSE_OVERRIDE_STATUSES[
+        action as keyof typeof RESPONSE_OVERRIDE_STATUSES
+      ] ?? RESPONSE_OVERRIDE_STATUSES[DEFAULT_ACTION];
+    const currentStatus = value.status as string | undefined;
+    const nextStatus =
+      currentStatus && nextStatuses.includes(currentStatus)
+        ? currentStatus
+        : nextStatuses[0];
+    onChange({ ...value, action, status: nextStatus });
+  };
 
   return (
     <div className="space-y-3">
@@ -37,13 +51,13 @@ export default function ResponseOverrideForm({
       />
       <SelectField
         label="Action"
-        value={(value.action as string | undefined) ?? "RemoteStartTransaction"}
-        onChange={(action) => onChange({ ...value, action })}
+        value={currentAction}
+        onChange={handleActionChange}
         options={actionOptions}
       />
       <SelectField
         label="Status"
-        value={(value.status as string | undefined) ?? "Rejected"}
+        value={(value.status as string | undefined) ?? validStatuses[0]}
         onChange={(status) => onChange({ ...value, status })}
         options={statusOptions}
       />

--- a/src/components/scenario/forms/nodeFormRegistry.ts
+++ b/src/components/scenario/forms/nodeFormRegistry.ts
@@ -3,12 +3,14 @@ import {
   type CancelReservationNodeData,
   type ConfigSetNodeData,
   type ConnectorPlugNodeData,
+  type CsmsCallTriggerNodeData,
   type DataTransferNodeData,
   type DelayNodeData,
   type MeterValueNodeData,
   type NotificationNodeData,
   type RemoteStartTriggerNodeData,
   type RemoteStopTriggerNodeData,
+  type ResponseOverrideNodeData,
   type ReservationTriggerNodeData,
   type ReserveNowNodeData,
   type ScenarioNodeData,
@@ -25,6 +27,7 @@ import type { CurvePoint } from "../../../cp/domain/connector/MeterValueCurve";
 import CancelReservationForm from "./CancelReservationForm";
 import ConfigSetForm from "./ConfigSetForm";
 import ConnectorPlugForm from "./ConnectorPlugForm";
+import CsmsCallTriggerForm from "./CsmsCallTriggerForm";
 import DataTransferForm from "./DataTransferForm";
 import DelayForm from "./DelayForm";
 import EndForm from "./EndForm";
@@ -32,6 +35,7 @@ import MeterValueForm from "./MeterValueForm";
 import NotificationForm from "./NotificationForm";
 import RemoteStartTriggerForm from "./RemoteStartTriggerForm";
 import RemoteStopTriggerForm from "./RemoteStopTriggerForm";
+import ResponseOverrideForm from "./ResponseOverrideForm";
 import ReservationTriggerForm from "./ReservationTriggerForm";
 import ReserveNowForm from "./ReserveNowForm";
 import StartForm from "./StartForm";
@@ -532,6 +536,54 @@ function dataTransferFormToNodeData(
   }) as DataTransferNodeData;
 }
 
+function csmsCallTriggerNodeDataToForm(
+  nodeData: ScenarioNodeData,
+): NodeFormData {
+  return compactDefined({
+    ...baseToForm(nodeData),
+    action: (nodeData as Partial<CsmsCallTriggerNodeData>).action ?? "Reset",
+    timeout: optionalNumber(
+      (nodeData as Partial<CsmsCallTriggerNodeData>).timeout,
+    ),
+  });
+}
+
+function csmsCallTriggerFormToNodeData(
+  formData: NodeFormData,
+): CsmsCallTriggerNodeData {
+  return compactDefined({
+    ...baseFromForm(formData),
+    action: typeof formData.action === "string" ? formData.action : "Reset",
+    timeout: optionalNumber(formData.timeout),
+  }) as CsmsCallTriggerNodeData;
+}
+
+function responseOverrideNodeDataToForm(
+  nodeData: ScenarioNodeData,
+): NodeFormData {
+  return compactDefined({
+    ...baseToForm(nodeData),
+    action:
+      (nodeData as Partial<ResponseOverrideNodeData>).action ??
+      "RemoteStartTransaction",
+    status:
+      (nodeData as Partial<ResponseOverrideNodeData>).status ?? "Rejected",
+  });
+}
+
+function responseOverrideFormToNodeData(
+  formData: NodeFormData,
+): ResponseOverrideNodeData {
+  return {
+    ...baseFromForm(formData),
+    action:
+      typeof formData.action === "string"
+        ? formData.action
+        : "RemoteStartTransaction",
+    status: typeof formData.status === "string" ? formData.status : "Rejected",
+  };
+}
+
 export const NODE_FORM_REGISTRY = {
   [ScenarioNodeType.STATUS_CHANGE]: {
     title: "Status Change",
@@ -628,6 +680,18 @@ export const NODE_FORM_REGISTRY = {
     Component: UnlockOutcomeForm,
     nodeDataToForm: unlockOutcomeNodeDataToForm,
     formToNodeData: unlockOutcomeFormToNodeData,
+  },
+  [ScenarioNodeType.CSMS_CALL_TRIGGER]: {
+    title: "CSMS Call Trigger",
+    Component: CsmsCallTriggerForm,
+    nodeDataToForm: csmsCallTriggerNodeDataToForm,
+    formToNodeData: csmsCallTriggerFormToNodeData,
+  },
+  [ScenarioNodeType.RESPONSE_OVERRIDE]: {
+    title: "Response Override",
+    Component: ResponseOverrideForm,
+    nodeDataToForm: responseOverrideNodeDataToForm,
+    formToNodeData: responseOverrideFormToNodeData,
   },
   [ScenarioNodeType.CONFIG_SET]: {
     title: "Config Set",

--- a/src/components/scenario/nodes/CsmsCallTriggerNode.tsx
+++ b/src/components/scenario/nodes/CsmsCallTriggerNode.tsx
@@ -1,0 +1,65 @@
+import React, { memo } from "react";
+import { Handle, Position, NodeProps } from "@xyflow/react";
+import { CsmsCallTriggerNodeData } from "../../../cp/application/scenario/ScenarioTypes";
+
+interface ExtendedCsmsCallTriggerNodeData extends CsmsCallTriggerNodeData {
+  progress?: {
+    remaining: number;
+    total: number;
+  };
+}
+
+const CsmsCallTriggerNode: React.FC<
+  NodeProps<ExtendedCsmsCallTriggerNodeData>
+> = ({ data, selected }) => {
+  const progress = data.progress;
+  const progressPercent = progress
+    ? ((progress.total - progress.remaining) / progress.total) * 100
+    : 0;
+
+  return (
+    <div
+      className={`px-4 py-3 rounded-lg border-2 bg-purple-50 dark:bg-purple-900 min-w-[180px] ${
+        selected
+          ? "border-blue-500"
+          : "border-purple-400 dark:border-purple-600"
+      }`}
+    >
+      <Handle type="target" position={Position.Top} className="w-3 h-3" />
+
+      <div className="text-xs font-semibold text-purple-700 dark:text-purple-300 mb-1">
+        CSMS Call Trigger
+      </div>
+      <div className="font-bold text-sm text-primary mb-1">{data.label}</div>
+      <div className="text-xs text-muted mb-1">Waits for: {data.action}</div>
+      {data.timeout !== undefined && data.timeout > 0 && (
+        <div className="text-xs text-muted">
+          Timeout: {data.timeout}s
+          {progress && progress.remaining > 0 && (
+            <span className="ml-1 text-purple-700 dark:text-purple-300 font-semibold">
+              ({progress.remaining.toFixed(1)}s left)
+            </span>
+          )}
+        </div>
+      )}
+      {(!data.timeout || data.timeout === 0) && (
+        <div className="text-xs text-muted">No timeout</div>
+      )}
+
+      {progress && progress.remaining > 0 && (
+        <div className="mt-2">
+          <div className="w-full h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-purple-500 dark:bg-purple-400 transition-all duration-100"
+              style={{ width: `${progressPercent}%` }}
+            ></div>
+          </div>
+        </div>
+      )}
+
+      <Handle type="source" position={Position.Bottom} className="w-3 h-3" />
+    </div>
+  );
+};
+
+export default memo(CsmsCallTriggerNode);

--- a/src/components/scenario/nodes/CsmsCallTriggerNode.tsx
+++ b/src/components/scenario/nodes/CsmsCallTriggerNode.tsx
@@ -1,17 +1,25 @@
 import React, { memo } from "react";
-import { Handle, Position, NodeProps } from "@xyflow/react";
+import { Handle, Position, NodeProps, type Node } from "@xyflow/react";
 import { CsmsCallTriggerNodeData } from "../../../cp/application/scenario/ScenarioTypes";
 
-interface ExtendedCsmsCallTriggerNodeData extends CsmsCallTriggerNodeData {
+// Mapped type (not `extends`) so the result is a fresh object type that
+// satisfies xyflow v12's `Node<Record<string, unknown>>` constraint — a
+// plain interface-extending intersection does not.
+type CsmsCallTriggerNodeDataWithProgress = {
+  [K in keyof CsmsCallTriggerNodeData]: CsmsCallTriggerNodeData[K];
+} & {
   progress?: {
     remaining: number;
     total: number;
   };
-}
+};
 
-const CsmsCallTriggerNode: React.FC<
-  NodeProps<ExtendedCsmsCallTriggerNodeData>
-> = ({ data, selected }) => {
+type CsmsCallTriggerFlowNode = Node<CsmsCallTriggerNodeDataWithProgress>;
+
+const CsmsCallTriggerNode: React.FC<NodeProps<CsmsCallTriggerFlowNode>> = ({
+  data,
+  selected,
+}) => {
   const progress = data.progress;
   const progressPercent = progress
     ? ((progress.total - progress.remaining) / progress.total) * 100

--- a/src/components/scenario/nodes/ResponseOverrideNode.tsx
+++ b/src/components/scenario/nodes/ResponseOverrideNode.tsx
@@ -1,0 +1,27 @@
+import React, { memo } from "react";
+import { Handle, Position, NodeProps } from "@xyflow/react";
+import { ResponseOverrideNodeData } from "../../../cp/application/scenario/ScenarioTypes";
+
+const ResponseOverrideNode: React.FC<NodeProps<ResponseOverrideNodeData>> = ({
+  data,
+  selected,
+}) => {
+  return (
+    <div
+      className={`px-4 py-3 rounded-lg border-2 bg-white dark:bg-gray-800 min-w-[200px] ${
+        selected ? "border-blue-500" : "border-gray-300 dark:border-gray-600"
+      }`}
+    >
+      <Handle type="target" position={Position.Top} className="w-3 h-3" />
+      <div className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">
+        Response Override
+      </div>
+      <div className="text-sm font-bold text-amber-700 dark:text-amber-300">
+        {data.action} → {data.status}
+      </div>
+      <Handle type="source" position={Position.Bottom} className="w-3 h-3" />
+    </div>
+  );
+};
+
+export default memo(ResponseOverrideNode);

--- a/src/components/scenario/nodes/ResponseOverrideNode.tsx
+++ b/src/components/scenario/nodes/ResponseOverrideNode.tsx
@@ -1,8 +1,17 @@
 import React, { memo } from "react";
-import { Handle, Position, NodeProps } from "@xyflow/react";
+import { Handle, Position, NodeProps, type Node } from "@xyflow/react";
 import { ResponseOverrideNodeData } from "../../../cp/application/scenario/ScenarioTypes";
 
-const ResponseOverrideNode: React.FC<NodeProps<ResponseOverrideNodeData>> = ({
+// Mapped type (not `extends`) so the result is a fresh object type that
+// satisfies xyflow v12's `Node<Record<string, unknown>>` constraint — a
+// plain interface does not.
+type ResponseOverrideNodeDataMapped = {
+  [K in keyof ResponseOverrideNodeData]: ResponseOverrideNodeData[K];
+};
+
+type ResponseOverrideFlowNode = Node<ResponseOverrideNodeDataMapped>;
+
+const ResponseOverrideNode: React.FC<NodeProps<ResponseOverrideFlowNode>> = ({
   data,
   selected,
 }) => {

--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -15,6 +15,7 @@ import {
   ConnectorPlugNodeData,
   RemoteStartTriggerNodeData,
   RemoteStopTriggerNodeData,
+  CsmsCallTriggerNodeData,
   StatusTriggerNodeData,
   ReserveNowNodeData,
   CancelReservationNodeData,
@@ -566,6 +567,13 @@ export class ScenarioExecutor {
         await this.executeReservationTrigger(
           node.id,
           node.data as ReservationTriggerNodeData,
+        );
+        break;
+
+      case ScenarioNodeType.CSMS_CALL_TRIGGER:
+        await this.executeCsmsCallTrigger(
+          node.id,
+          node.data as CsmsCallTriggerNodeData,
         );
         break;
 
@@ -1463,5 +1471,83 @@ export class ScenarioExecutor {
       new Promise<void>((resolve) => setTimeout(resolve, ms)),
       this.abortPromise,
     ]);
+  }
+
+  /**
+   * Issue #110: park the scenario until the CSMS sends `data.action`.
+   * Mirror of executeRemoteStopTrigger; the CP core handler still runs,
+   * we only synchronize on arrival and log the payload.
+   */
+  private async executeCsmsCallTrigger(
+    nodeId: string,
+    data: CsmsCallTriggerNodeData,
+  ): Promise<void> {
+    if (!this.callbacks.onWaitForCsmsCall) return;
+
+    const timeout = data.timeout || 0;
+    if (!timeout || timeout === 0) {
+      const waitPromise = this.callbacks.onWaitForCsmsCall(
+        data.action,
+        timeout,
+      );
+      try {
+        await this.waitWithOptionalForceSkip(
+          waitPromise.then((res) => {
+            this.callbacks.log?.(
+              `CSMS call received: ${res.action} ${JSON.stringify(res.payload)}`,
+              "info",
+            );
+          }),
+        );
+      } finally {
+        cancelIfCancellable(waitPromise);
+      }
+      return;
+    }
+
+    const startTime = Date.now();
+    const timeoutMs = timeout * 1000;
+    const progressInterval = setInterval(() => {
+      const elapsed = Date.now() - startTime;
+      const remaining = Math.max(0, (timeoutMs - elapsed) / 1000);
+      this.callbacks.onNodeProgress?.(nodeId, remaining, timeout);
+      const progressData = {
+        scenarioId: this.scenario.id,
+        nodeId,
+        remaining,
+        total: timeout,
+      };
+      this.eventEmitter?.emit("nodeProgress", progressData);
+      this.eventEmitter?.emit("node.progress", progressData);
+      if (remaining <= 0) clearInterval(progressInterval);
+    }, 100);
+
+    try {
+      const waitPromise = this.callbacks.onWaitForCsmsCall(
+        data.action,
+        timeout,
+      );
+      try {
+        await this.waitWithOptionalForceSkip(
+          waitPromise.then((res) => {
+            this.callbacks.log?.(
+              `CSMS call received: ${res.action} ${JSON.stringify(res.payload)}`,
+              "info",
+            );
+          }),
+        );
+      } finally {
+        cancelIfCancellable(waitPromise);
+      }
+    } finally {
+      clearInterval(progressInterval);
+      this.callbacks.onNodeProgress?.(nodeId, 0, timeout);
+      this.eventEmitter?.emit("nodeProgress", {
+        scenarioId: this.scenario.id,
+        nodeId,
+        remaining: 0,
+        total: timeout,
+      });
+    }
   }
 }

--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -22,6 +22,7 @@ import {
   ReservationTriggerNodeData,
   StatusNotificationNodeData,
   UnlockOutcomeNodeData,
+  ResponseOverrideNodeData,
   ConfigSetNodeData,
   DataTransferNodeData,
   StartTransactionOptions,
@@ -587,6 +588,12 @@ export class ScenarioExecutor {
         await this.executeUnlockOutcome(node.data as UnlockOutcomeNodeData);
         break;
 
+      case ScenarioNodeType.RESPONSE_OVERRIDE:
+        await this.executeResponseOverride(
+          node.data as ResponseOverrideNodeData,
+        );
+        break;
+
       case ScenarioNodeType.CONFIG_SET:
         await this.executeConfigSet(node.data as ConfigSetNodeData);
         break;
@@ -637,6 +644,24 @@ export class ScenarioExecutor {
     }
     this.callbacks.onSetUnlockOutcome(data.outcome);
     this.callbacks.log?.(`Connector unlockResponse → ${data.outcome}`, "info");
+  }
+
+  /** Issue #110: pre-arm a one-shot `{ status }` response override. */
+  private async executeResponseOverride(
+    data: ResponseOverrideNodeData,
+  ): Promise<void> {
+    if (!this.callbacks.onArmResponseOverride) {
+      this.callbacks.log?.(
+        "ResponseOverride: no onArmResponseOverride callback wired",
+        "warn",
+      );
+      return;
+    }
+    this.callbacks.onArmResponseOverride(data.action, data.status);
+    this.callbacks.log?.(
+      `Armed response override: ${data.action} → ${data.status}`,
+      "info",
+    );
   }
 
   /** Apply a ChangeConfiguration locally via the ConfigurationStore. */

--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -1519,7 +1519,7 @@ export class ScenarioExecutor {
         await this.waitWithOptionalForceSkip(
           waitPromise.then((res) => {
             this.callbacks.log?.(
-              `CSMS call received: ${res.action} ${JSON.stringify(res.payload)}`,
+              `CSMS call received: ${res.action}`,
               "info",
             );
           }),
@@ -1556,7 +1556,7 @@ export class ScenarioExecutor {
         await this.waitWithOptionalForceSkip(
           waitPromise.then((res) => {
             this.callbacks.log?.(
-              `CSMS call received: ${res.action} ${JSON.stringify(res.payload)}`,
+              `CSMS call received: ${res.action}`,
               "info",
             );
           }),

--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -724,7 +724,7 @@ export class ScenarioExecutor {
       }
     } else if (data.action === "stop") {
       if (this.callbacks.onStopTransaction) {
-        const reason = this.remoteStopReason ?? undefined;
+        const reason = this.remoteStopReason ?? data.stopReason ?? undefined;
         const options = this.remoteStopOptions;
         this.remoteStopReason = null;
         this.remoteStopOptions = null;

--- a/src/cp/application/scenario/ScenarioRuntime.ts
+++ b/src/cp/application/scenario/ScenarioRuntime.ts
@@ -615,6 +615,9 @@ export const createScenarioExecutorCallbacks = (
     onSetUnlockOutcome: (outcome) => {
       connector.unlockResponse = outcome;
     },
+    onArmResponseOverride: (action, status) => {
+      chargePoint.armResponseOverride(action, status);
+    },
     onConfigSet: (key, value) => {
       chargePoint.configuration.applyChange(key, value);
     },

--- a/src/cp/application/scenario/ScenarioRuntime.ts
+++ b/src/cp/application/scenario/ScenarioRuntime.ts
@@ -270,6 +270,75 @@ const waitForRemoteStop = (
   };
 };
 
+/** Issue #110: generic wait for any incoming CSMS CALL by action name.
+ *  Subscribes to the `incomingCallReceived` event emitted by the message
+ *  dispatch layer. Unlike waitForRemoteStop this does NOT register any
+ *  scenario handler — the CP core handler for the action still runs. */
+const waitForCsmsCall = (
+  chargePoint: ChargePoint,
+  action: string,
+  timeout?: number,
+): CancellableWait<{ action: string; payload: unknown }> => {
+  // Fail-fast if this transport can never receive CSMS-initiated calls.
+  if (!chargePoint.canReceiveCsmsCall(action)) {
+    const errorMsg =
+      `csmsCallTrigger(${action}) requires a transport that can receive ` +
+      `CSMS-initiated calls; this charge point cannot — the scenario ` +
+      `would wait forever`;
+    return {
+      promise: Promise.reject(new Error(errorMsg)),
+      cancel: () => {},
+    };
+  }
+
+  let cleanupFn: (() => void) | null = null;
+
+  const promise = new Promise<{ action: string; payload: unknown }>(
+    (resolve, reject) => {
+      let timeoutId: NodeJS.Timeout | null = null;
+      let settled = false;
+
+      const cleanup = () => {
+        if (settled) return;
+        settled = true;
+        if (timeoutId) clearTimeout(timeoutId);
+        chargePoint.events.off("incomingCallReceived", handler);
+        chargePoint.events.off("disconnected", disconnectHandler);
+      };
+
+      cleanupFn = cleanup;
+
+      const handler = (data: { action: string; payload: unknown }) => {
+        if (data.action !== action) return;
+        cleanup();
+        resolve(data);
+      };
+
+      const disconnectHandler = () => {
+        cleanup();
+        reject(new Error(`Disconnected while waiting for CSMS call ${action}`));
+      };
+
+      chargePoint.events.on("incomingCallReceived", handler);
+      chargePoint.events.on("disconnected", disconnectHandler);
+
+      if (timeout && timeout > 0) {
+        timeoutId = setTimeout(() => {
+          cleanup();
+          reject(
+            new Error(`Timeout waiting for CSMS call ${action} (${timeout}s)`),
+          );
+        }, timeout * 1000);
+      }
+    },
+  );
+
+  return {
+    promise,
+    cancel: () => cleanupFn?.(),
+  };
+};
+
 const waitForReservation = (
   chargePoint: ChargePoint,
   connector: Connector,
@@ -488,6 +557,9 @@ export const createScenarioExecutorCallbacks = (
       return cancellablePromise(
         waitForRemoteStop(chargePoint, connector, timeout),
       );
+    },
+    onWaitForCsmsCall: (action, timeout) => {
+      return cancellablePromise(waitForCsmsCall(chargePoint, action, timeout));
     },
     onWaitForStatus: async (targetStatus, timeout) =>
       waitForStatus(connector, targetStatus, timeout),

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -293,6 +293,10 @@ export interface UnlockOutcomeNodeData extends BaseNodeData {
  * Response Override Node Data — arms a one-shot canned `{ status }`
  * response on the charge point for the next incoming CALL whose action
  * matches. Non-blocking pre-arm, like unlockOutcome. Issue #110.
+ *
+ * Overrides are armed charge-point-wide (not connector-scoped) and consumed
+ * once per action, so they're intended for single-connector certification
+ * scenarios rather than multi-connector charge points.
  */
 export interface ResponseOverrideNodeData extends BaseNodeData {
   /** OCPP 1.6 action whose next incoming call gets the canned response. */
@@ -725,4 +729,34 @@ export const RESPONSE_OVERRIDE_ACTIONS = [
   "CancelReservation",
   "SendLocalList",
   "ChangeConfiguration",
+  "ClearCache",
+  "SetChargingProfile",
+  "ClearChargingProfile",
+  "ChangeAvailability",
 ] as const;
+
+/** Statuses valid for each responseOverride action's `{ status }`
+ *  CALLRESULT, per this repo's generated OCPP 1.6 response types
+ *  (src/ocpp/v16/types/*-response.ts). Keeps editor UI from offering
+ *  schema-invalid action/status combinations. */
+export const RESPONSE_OVERRIDE_STATUSES: Record<
+  (typeof RESPONSE_OVERRIDE_ACTIONS)[number],
+  readonly string[]
+> = {
+  RemoteStartTransaction: ["Accepted", "Rejected"],
+  RemoteStopTransaction: ["Accepted", "Rejected"],
+  TriggerMessage: ["Accepted", "Rejected", "NotImplemented"],
+  ReserveNow: ["Accepted", "Faulted", "Occupied", "Rejected", "Unavailable"],
+  CancelReservation: ["Accepted", "Rejected"],
+  SendLocalList: ["Accepted", "Failed", "NotSupported", "VersionMismatch"],
+  ChangeConfiguration: [
+    "Accepted",
+    "Rejected",
+    "RebootRequired",
+    "NotSupported",
+  ],
+  ClearCache: ["Accepted", "Rejected"],
+  SetChargingProfile: ["Accepted", "Rejected", "NotSupported"],
+  ClearChargingProfile: ["Accepted", "Unknown"],
+  ChangeAvailability: ["Accepted", "Rejected", "Scheduled"],
+};

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -92,6 +92,10 @@ export interface TransactionNodeData extends BaseNodeData {
   tagId?: string; // Only for start
   batteryCapacityKwh?: number; // Battery capacity of the EV in kWh (e.g., 40, 60, 100)
   initialSoc?: number; // Initial State of Charge percentage (0-100)
+  /** Optional OCPP §6.21 stop reason for action="stop" (e.g.
+   *  "EVDisconnected" for TC_005, "PowerLoss"). A reason captured by a
+   *  preceding RemoteStopTrigger node still wins. Issue #110. */
+  stopReason?: string;
 }
 
 export interface RemoteStartDetails {

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -63,6 +63,10 @@ export enum ScenarioNodeType {
   // incoming CALL (Reset, GetConfiguration, SendLocalList, …). The CP
   // core handler still runs; this node only observes the arrival.
   CSMS_CALL_TRIGGER = "csmsCallTrigger",
+  // Issue #110: arm a one-shot response override for the next incoming
+  // CALL of a given action (e.g. RemoteStartTransaction → Rejected for
+  // TC_026). The armed `{ status }` replaces the handler's response.
+  RESPONSE_OVERRIDE = "responseOverride",
 }
 
 /**
@@ -282,6 +286,18 @@ export interface UnlockOutcomeNodeData extends BaseNodeData {
 }
 
 /**
+ * Response Override Node Data — arms a one-shot canned `{ status }`
+ * response on the charge point for the next incoming CALL whose action
+ * matches. Non-blocking pre-arm, like unlockOutcome. Issue #110.
+ */
+export interface ResponseOverrideNodeData extends BaseNodeData {
+  /** OCPP 1.6 action whose next incoming call gets the canned response. */
+  action: string;
+  /** Status string returned as `{ status }` for that call. */
+  status: string;
+}
+
+/**
  * Config Set Node Data — applies a ChangeConfiguration locally (without
  * round-tripping through CSMS). Useful for tightening
  * MeterValueSampleInterval / changing MeterValuesSampledData mid-scenario.
@@ -320,6 +336,7 @@ export type ScenarioNodeData =
   | ReservationTriggerNodeData
   | StatusNotificationNodeData
   | UnlockOutcomeNodeData
+  | ResponseOverrideNodeData
   | ConfigSetNodeData
   | DataTransferNodeData
   | StartNodeData
@@ -521,6 +538,9 @@ export interface ScenarioExecutorCallbacks {
   onSetUnlockOutcome?: (
     outcome: "Unlocked" | "UnlockFailed" | "NotSupported",
   ) => void;
+  /** Issue #110: arm a one-shot `{ status }` response override for the
+   *  next incoming CALL of the given action. */
+  onArmResponseOverride?: (action: string, status: string) => void;
   /** §5.3: apply a Configuration key change locally. */
   onConfigSet?: (key: string, value: string) => void;
   /** §4.3: send CP-initiated DataTransfer.req. */
@@ -689,4 +709,16 @@ export const CSMS_CALL_TRIGGER_ACTIONS = [
   "RemoteStopTransaction",
   "DataTransfer",
   "ChangeAvailability",
+] as const;
+
+/** Actions a responseOverride node may target: their CALLRESULT payload
+ *  is exactly `{ status }`, so a canned status is schema-valid. */
+export const RESPONSE_OVERRIDE_ACTIONS = [
+  "RemoteStartTransaction",
+  "RemoteStopTransaction",
+  "TriggerMessage",
+  "ReserveNow",
+  "CancelReservation",
+  "SendLocalList",
+  "ChangeConfiguration",
 ] as const;

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -59,6 +59,10 @@ export enum ScenarioNodeType {
   CONFIG_SET = "configSet",
   // §4.3 DataTransfer.req (CP → CSMS, vendor-specific).
   DATA_TRANSFER = "dataTransfer",
+  // Issue #110 certification scenarios: park until the CSMS sends a given
+  // incoming CALL (Reset, GetConfiguration, SendLocalList, …). The CP
+  // core handler still runs; this node only observes the arrival.
+  CSMS_CALL_TRIGGER = "csmsCallTrigger",
 }
 
 /**
@@ -183,6 +187,20 @@ export interface RemoteStopTriggerNodeData extends BaseNodeData {
 }
 
 /**
+ * CSMS Call Trigger Node Data — generic counterpart of the per-action
+ * trigger nodes. Blocks the scenario until the CSMS sends any CALL whose
+ * action matches `action`. The CP core handler for that action still runs
+ * (GetConfiguration still answers from the store, Reset still reboots…);
+ * this node only synchronizes the scenario with the arrival. Issue #110.
+ */
+export interface CsmsCallTriggerNodeData extends BaseNodeData {
+  /** OCPP 1.6 action name of the incoming CSMS call to wait for. */
+  action: string;
+  /** Optional timeout in seconds. 0 (default) = wait forever. */
+  timeout?: number;
+}
+
+/**
  * Status Trigger Node Data
  * This node waits for the connector status to change to a specific state
  */
@@ -295,6 +313,7 @@ export type ScenarioNodeData =
   | ConnectorPlugNodeData
   | RemoteStartTriggerNodeData
   | RemoteStopTriggerNodeData
+  | CsmsCallTriggerNodeData
   | StatusTriggerNodeData
   | ReserveNowNodeData
   | CancelReservationNodeData
@@ -452,6 +471,12 @@ export interface ScenarioExecutorCallbacks {
     reason: string;
     triggerReason?: TransactionStopTriggerReason;
   }>;
+  /** Issue #110: park until the CSMS sends the given incoming CALL
+   *  action. Resolves with the request payload for logging. */
+  onWaitForCsmsCall?: (
+    action: string,
+    timeout?: number,
+  ) => Promise<{ action: string; payload: unknown }>;
   onWaitForStatus?: (
     targetStatus: OCPPStatus,
     timeout?: number,
@@ -642,3 +667,26 @@ export interface ScenarioEvents {
   // These are string-indexed for flexibility with EventEmitter2 wildcards
   [key: string]: unknown;
 }
+
+/** Incoming CSMS→CP calls a csmsCallTrigger node can wait for. */
+export const CSMS_CALL_TRIGGER_ACTIONS = [
+  "Reset",
+  "GetConfiguration",
+  "ChangeConfiguration",
+  "ClearCache",
+  "GetLocalListVersion",
+  "SendLocalList",
+  "TriggerMessage",
+  "SetChargingProfile",
+  "ClearChargingProfile",
+  "GetCompositeSchedule",
+  "UpdateFirmware",
+  "GetDiagnostics",
+  "ReserveNow",
+  "CancelReservation",
+  "UnlockConnector",
+  "RemoteStartTransaction",
+  "RemoteStopTransaction",
+  "DataTransfer",
+  "ChangeAvailability",
+] as const;

--- a/src/cp/application/scenario/__tests__/csmsCallTrigger.test.ts
+++ b/src/cp/application/scenario/__tests__/csmsCallTrigger.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import { ScenarioExecutor } from "../ScenarioExecutor";
+import { createScenarioExecutorCallbacks } from "../ScenarioRuntime";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+import { ScenarioDefinition, ScenarioNodeType } from "../ScenarioTypes";
+
+function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+function newChargePoint(id: string): ChargePoint {
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    "ws://127.0.0.1:9/",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  return cp;
+}
+
+function triggerScenario(action: string, timeoutSec = 0): ScenarioDefinition {
+  const now = new Date().toISOString();
+  return {
+    id: `test-csms-call-trigger-${action}`,
+    name: `csmsCallTrigger ${action}`,
+    targetType: "connector",
+    targetId: 1,
+    trigger: { type: "manual" },
+    defaultExecutionMode: "oneshot",
+    enabled: true,
+    createdAt: now,
+    updatedAt: now,
+    nodes: [
+      {
+        id: "start-1",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start", triggerOn: "connect" },
+      },
+      {
+        id: "wait-call",
+        type: ScenarioNodeType.CSMS_CALL_TRIGGER,
+        position: { x: 0, y: 100 },
+        data: { label: `Wait for ${action}`, action, timeout: timeoutSec },
+      },
+      {
+        id: "end-1",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 200 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "start-1", target: "wait-call" },
+      { id: "e2", source: "wait-call", target: "end-1" },
+    ],
+  };
+}
+
+describe("csmsCallTrigger node (issue #110)", () => {
+  it("parks until the matching incoming call arrives, ignores others", async () => {
+    const cp = newChargePoint("CP-TRIG-RESET");
+    const connector = cp.getConnector(1)!;
+    const executor = new ScenarioExecutor(
+      triggerScenario("Reset"),
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+    );
+    const execution = executor.start();
+
+    try {
+      // parked: a non-matching action must not release it
+      cp.notifyIncomingCall("GetConfiguration", {});
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      let done = false;
+      void execution.then(() => (done = true));
+      expect(done).toBe(false);
+
+      cp.notifyIncomingCall("Reset", { type: "Hard" });
+      await timeout(execution, 1000);
+    } finally {
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      ).catch(() => undefined);
+    }
+  });
+
+  it("rejects when the timeout elapses without a matching call", async () => {
+    const cp = newChargePoint("CP-TRIG-TIMEOUT");
+    const connector = cp.getConnector(1)!;
+    const errors: Error[] = [];
+    const callbacks = {
+      ...createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+      onError: (e: Error) => errors.push(e),
+    };
+    const executor = new ScenarioExecutor(
+      triggerScenario("ClearCache", 1),
+      callbacks,
+    );
+
+    await timeout(executor.start(), 3000);
+    expect(
+      errors.some((e) =>
+        /Timeout waiting for CSMS call ClearCache/.test(e.message),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/cp/application/scenario/__tests__/csmsCallTrigger.test.ts
+++ b/src/cp/application/scenario/__tests__/csmsCallTrigger.test.ts
@@ -16,6 +16,16 @@ function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   });
 }
 
+async function waitUntil(predicate: () => boolean, ms = 500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > ms) {
+      throw new Error("Timed out waiting for predicate");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 function newChargePoint(id: string): ChargePoint {
   const cp = new ChargePoint(
     id,
@@ -84,11 +94,18 @@ describe("csmsCallTrigger node (issue #110)", () => {
     const execution = executor.start();
 
     try {
+      // Wait for the csmsCallTrigger node to attach its listener before firing events
+      await waitUntil(
+        () => cp.events.listenerCount("incomingCallReceived") > 0,
+      );
+
       // parked: a non-matching action must not release it
       cp.notifyIncomingCall("GetConfiguration", {});
       await new Promise((resolve) => setTimeout(resolve, 50));
       let done = false;
       void execution.then(() => (done = true));
+      // Yield to microtasks to allow the then callback to fire if the promise has resolved
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(done).toBe(false);
 
       cp.notifyIncomingCall("Reset", { type: "Hard" });

--- a/src/cp/application/scenario/__tests__/responseOverride.test.ts
+++ b/src/cp/application/scenario/__tests__/responseOverride.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { ScenarioExecutor } from "../ScenarioExecutor";
+import { createScenarioExecutorCallbacks } from "../ScenarioRuntime";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+import { ScenarioDefinition, ScenarioNodeType } from "../ScenarioTypes";
+
+function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+function newChargePoint(id: string): ChargePoint {
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    "ws://127.0.0.1:9/",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  return cp;
+}
+
+function overrideScenario(): ScenarioDefinition {
+  const now = new Date().toISOString();
+  return {
+    id: "test-response-override",
+    name: "responseOverride arms one-shot response",
+    targetType: "connector",
+    targetId: 1,
+    trigger: { type: "manual" },
+    defaultExecutionMode: "oneshot",
+    enabled: true,
+    createdAt: now,
+    updatedAt: now,
+    nodes: [
+      {
+        id: "start-1",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start", triggerOn: "connect" },
+      },
+      {
+        id: "arm-override",
+        type: ScenarioNodeType.RESPONSE_OVERRIDE,
+        position: { x: 0, y: 100 },
+        data: {
+          label: "Reject next RemoteStart",
+          action: "RemoteStartTransaction",
+          status: "Rejected",
+        },
+      },
+      {
+        id: "end-1",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 200 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "start-1", target: "arm-override" },
+      { id: "e2", source: "arm-override", target: "end-1" },
+    ],
+  };
+}
+
+describe("responseOverride node (issue #110)", () => {
+  it("arms a one-shot override on the charge point and completes", async () => {
+    const cp = newChargePoint("CP-OVERRIDE-NODE");
+    const connector = cp.getConnector(1)!;
+    const executor = new ScenarioExecutor(
+      overrideScenario(),
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+    );
+
+    await timeout(executor.start(), 1000);
+
+    expect(cp.consumeResponseOverride("RemoteStartTransaction")).toBe(
+      "Rejected",
+    );
+    expect(cp.consumeResponseOverride("RemoteStartTransaction")).toBeNull();
+  });
+});

--- a/src/cp/application/scenario/__tests__/transactionStopReason.test.ts
+++ b/src/cp/application/scenario/__tests__/transactionStopReason.test.ts
@@ -16,6 +16,16 @@ function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   });
 }
 
+async function waitUntil(predicate: () => boolean, ms = 500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > ms) {
+      throw new Error("Timed out waiting for predicate");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 function newChargePoint(id: string): ChargePoint {
   const cp = new ChargePoint(
     id,
@@ -84,6 +94,63 @@ function stopReasonScenario(): ScenarioDefinition {
   };
 }
 
+function remotePrecedenceScenario(): ScenarioDefinition {
+  const now = new Date().toISOString();
+  return {
+    id: "test-remote-precedence",
+    name: "remote-captured reason wins over node stopReason",
+    targetType: "connector",
+    targetId: 1,
+    trigger: { type: "manual" },
+    defaultExecutionMode: "oneshot",
+    enabled: true,
+    createdAt: now,
+    updatedAt: now,
+    nodes: [
+      {
+        id: "start-1",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start", triggerOn: "connect" },
+      },
+      {
+        id: "tx-start",
+        type: ScenarioNodeType.TRANSACTION,
+        position: { x: 0, y: 100 },
+        data: { label: "Start Tx", action: "start", tagId: "TC-PREC" },
+      },
+      {
+        id: "remote-stop-trigger",
+        type: ScenarioNodeType.REMOTE_STOP_TRIGGER,
+        position: { x: 0, y: 200 },
+        data: { label: "Wait for Remote Stop", timeout: 0 },
+      },
+      {
+        id: "tx-stop",
+        type: ScenarioNodeType.TRANSACTION,
+        position: { x: 0, y: 300 },
+        data: {
+          label: "Stop Tx",
+          action: "stop",
+          stopReason: "PowerLoss",
+        },
+      },
+      {
+        id: "end-1",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 400 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "start-1", target: "tx-start" },
+      { id: "e2", source: "tx-start", target: "remote-stop-trigger" },
+      { id: "e3", source: "remote-stop-trigger", target: "tx-stop" },
+      { id: "e4", source: "tx-stop", target: "end-1" },
+    ],
+  };
+}
+
 describe("transaction stop reason (issue #110, TC_005 support)", () => {
   it("passes the node's stopReason through to the stop path", async () => {
     const cp = newChargePoint("CP-STOP-REASON");
@@ -112,5 +179,52 @@ describe("transaction stop reason (issue #110, TC_005 support)", () => {
     await timeout(executor.start(), 2000);
 
     expect(reasons).toContain("EVDisconnected");
+  });
+
+  it("remote-captured reason wins over node stopReason", async () => {
+    const cp = newChargePoint("CP-REMOTE-PREC");
+    const connector = cp.getConnector(1)!;
+    const reasons: Array<string | undefined> = [];
+
+    // Wrap callbacks to spy on onStopTransaction's reason argument
+    const baseCallbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector,
+    });
+    const spyCallbacks = {
+      ...baseCallbacks,
+      onStopTransaction: async (
+        reason?: string,
+        options?: Parameters<
+          NonNullable<typeof baseCallbacks.onStopTransaction>
+        >[1],
+      ) => {
+        reasons.push(reason);
+        return baseCallbacks.onStopTransaction?.(reason, options);
+      },
+    };
+
+    const executor = new ScenarioExecutor(
+      remotePrecedenceScenario(),
+      spyCallbacks,
+    );
+    const executorPromise = executor.start();
+
+    // Wait until transaction is started so we can capture its ID
+    await waitUntil(() => connector.transaction !== null, 1000);
+    const txId = connector.transaction!.id;
+
+    // Wait until the remote stop trigger has parked and is ready to receive the remote stop
+    await waitUntil(() => cp.isScenarioStopHandled(1), 1000);
+
+    // Fire the CSMS remote stop
+    cp.notifyRemoteStopReceived(1, txId);
+
+    // Wait for executor to complete
+    await timeout(executorPromise, 2000);
+
+    // Verify that the remote reason wins over the node's stopReason
+    expect(reasons).toContain("Remote");
+    expect(reasons).not.toContain("PowerLoss");
   });
 });

--- a/src/cp/application/scenario/__tests__/transactionStopReason.test.ts
+++ b/src/cp/application/scenario/__tests__/transactionStopReason.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import { ScenarioExecutor } from "../ScenarioExecutor";
+import { createScenarioExecutorCallbacks } from "../ScenarioRuntime";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+import { ScenarioDefinition, ScenarioNodeType } from "../ScenarioTypes";
+
+function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+function newChargePoint(id: string): ChargePoint {
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    "ws://127.0.0.1:9/",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  return cp;
+}
+
+function stopReasonScenario(): ScenarioDefinition {
+  const now = new Date().toISOString();
+  return {
+    id: "test-tx-stop-reason",
+    name: "transaction stop carries node stopReason",
+    targetType: "connector",
+    targetId: 1,
+    trigger: { type: "manual" },
+    defaultExecutionMode: "oneshot",
+    enabled: true,
+    createdAt: now,
+    updatedAt: now,
+    nodes: [
+      {
+        id: "start-1",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start", triggerOn: "connect" },
+      },
+      {
+        id: "tx-start",
+        type: ScenarioNodeType.TRANSACTION,
+        position: { x: 0, y: 100 },
+        data: { label: "Start Tx", action: "start", tagId: "TC005" },
+      },
+      {
+        id: "tx-stop",
+        type: ScenarioNodeType.TRANSACTION,
+        position: { x: 0, y: 200 },
+        data: {
+          label: "Stop Tx",
+          action: "stop",
+          stopReason: "EVDisconnected",
+        },
+      },
+      {
+        id: "end-1",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 300 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "start-1", target: "tx-start" },
+      { id: "e2", source: "tx-start", target: "tx-stop" },
+      { id: "e3", source: "tx-stop", target: "end-1" },
+    ],
+  };
+}
+
+describe("transaction stop reason (issue #110, TC_005 support)", () => {
+  it("passes the node's stopReason through to the stop path", async () => {
+    const cp = newChargePoint("CP-STOP-REASON");
+    const connector = cp.getConnector(1)!;
+    const reasons: Array<string | undefined> = [];
+
+    // Wrap callbacks to spy on onStopTransaction's reason argument
+    const baseCallbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector,
+    });
+    const spyCallbacks = {
+      ...baseCallbacks,
+      onStopTransaction: async (
+        reason?: string,
+        options?: Parameters<
+          NonNullable<typeof baseCallbacks.onStopTransaction>
+        >[1],
+      ) => {
+        reasons.push(reason);
+        return baseCallbacks.onStopTransaction?.(reason, options);
+      },
+    };
+
+    const executor = new ScenarioExecutor(stopReasonScenario(), spyCallbacks);
+    await timeout(executor.start(), 2000);
+
+    expect(reasons).toContain("EVDisconnected");
+  });
+});

--- a/src/cp/application/scenario/__tests__/transactionStopReason.test.ts
+++ b/src/cp/application/scenario/__tests__/transactionStopReason.test.ts
@@ -213,6 +213,9 @@ describe("transaction stop reason (issue #110, TC_005 support)", () => {
     // Wait until transaction is started so we can capture its ID
     await waitUntil(() => connector.transaction !== null, 1000);
     const txId = connector.transaction!.id;
+    if (txId == null) {
+      throw new Error("expected transaction to have an id");
+    }
 
     // Wait until the remote stop trigger has parked and is ready to receive the remote stop
     await waitUntil(() => cp.isScenarioStopHandled(1), 1000);

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -112,6 +112,9 @@ export class ChargePoint {
   // itself — the scenario is parked on a RemoteStopTrigger node and will
   // resume into its own Transaction Stop step.
   private readonly _scenarioStopHandledConnectors: Set<number> = new Set();
+  /** One-shot canned `{ status }` responses per incoming action,
+   *  armed by a scenario responseOverride node (issue #110). */
+  private _responseOverrides = new Map<string, string>();
   // §4.9 B6: per-connector ConnectionTimeOut watchdog. Started when a
   // connector enters Preparing, cleared on any other transition. If the
   // timer fires we auto-transition the connector to Finishing.
@@ -605,6 +608,22 @@ export class ChargePoint {
 
   notifyRemoteStopReceived(connectorId: number, transactionId: number): void {
     this._events.emit("remoteStopReceived", { connectorId, transactionId });
+  }
+
+  notifyIncomingCall(action: string, payload: unknown): void {
+    this._events.emit("incomingCallReceived", { action, payload });
+  }
+
+  armResponseOverride(action: string, status: string): void {
+    this._responseOverrides.set(action, status);
+  }
+
+  /** Returns and clears the armed status for `action`, or null. */
+  consumeResponseOverride(action: string): string | null {
+    const status = this._responseOverrides.get(action);
+    if (status === undefined) return null;
+    this._responseOverrides.delete(action);
+    return status;
   }
 
   set loggingCallback(callback: (entry: LogEntry) => void) {

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -114,7 +114,7 @@ export class ChargePoint {
   private readonly _scenarioStopHandledConnectors: Set<number> = new Set();
   /** One-shot canned `{ status }` responses per incoming action,
    *  armed by a scenario responseOverride node (issue #110). */
-  private _responseOverrides = new Map<string, string>();
+  private readonly _responseOverrides = new Map<string, string>();
   // §4.9 B6: per-connector ConnectionTimeOut watchdog. Started when a
   // connector enters Preparing, cleared on any other transition. If the
   // timer fires we auto-transition the connector to Finishing.

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -1041,6 +1041,9 @@ export class ChargePoint {
     this._signedFirmwareUpdateInFlight = false;
     this._scenarioHandledConnectors.clear();
     this._scenarioStopHandledConnectors.clear();
+    // Issue #110: stale response overrides must not survive a
+    // disconnect — they would silently answer the next real CSMS call.
+    this._responseOverrides.clear();
     // Cancel all ConnectionTimeOut watchdogs so the timer doesn't fire
     // against a disconnected CP.
     this._connectionTimeoutTimers.forEach((t) => clearTimeout(t));

--- a/src/cp/domain/charge-point/ChargePointEvents.ts
+++ b/src/cp/domain/charge-point/ChargePointEvents.ts
@@ -54,6 +54,14 @@ export interface ChargePointEvents {
     connectorId: number;
     transactionId: number;
   };
+  /** Emitted for every CSMS-initiated CALL as it enters the dispatch
+   *  layer, before (and regardless of) handler execution or a response
+   *  override. Lets scenario csmsCallTrigger nodes park on arbitrary
+   *  incoming actions without per-action wiring (issue #110). */
+  incomingCallReceived: {
+    action: string;
+    payload: unknown;
+  };
   transactionStarted: {
     connectorId: number;
     transactionId: number;

--- a/src/cp/domain/charge-point/__tests__/incomingCallObservability.test.ts
+++ b/src/cp/domain/charge-point/__tests__/incomingCallObservability.test.ts
@@ -51,4 +51,21 @@ describe("incoming CSMS call observability (issue #110 engine hooks)", () => {
     expect(cp.consumeResponseOverride("ReserveNow")).toBeNull();
     expect(cp.consumeResponseOverride("TriggerMessage")).toBe("Rejected");
   });
+
+  it("teardownAfterClose clears armed overrides (issue #110)", () => {
+    const cp = newChargePoint("CP-TEARDOWN-OVERRIDE");
+    cp.armResponseOverride("RemoteStartTransaction", "Rejected");
+    expect(cp.consumeResponseOverride("RemoteStartTransaction")).toBe(
+      "Rejected",
+    );
+
+    // The consumed override is already gone, but re-arm one and verify
+    // that disconnect() (which triggers teardownAfterClose) clears all
+    // armed overrides so they don't survive the disconnect/reconnect cycle.
+    cp.armResponseOverride("RemoteStopTransaction", "Accepted");
+    cp.disconnect();
+
+    // After teardownAfterClose runs, the armed override is cleared
+    expect(cp.consumeResponseOverride("RemoteStopTransaction")).toBeNull();
+  });
 });

--- a/src/cp/domain/charge-point/__tests__/incomingCallObservability.test.ts
+++ b/src/cp/domain/charge-point/__tests__/incomingCallObservability.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { ChargePoint } from "../ChargePoint";
+import { DefaultBootNotification } from "../../types/OcppTypes";
+
+function newChargePoint(id: string): ChargePoint {
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    "ws://127.0.0.1:9/",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  return cp;
+}
+
+describe("incoming CSMS call observability (issue #110 engine hooks)", () => {
+  it("notifyIncomingCall emits incomingCallReceived with action and payload", () => {
+    const cp = newChargePoint("CP-IN-CALL");
+    const seen: Array<{ action: string; payload: unknown }> = [];
+    cp.events.on("incomingCallReceived", (data) => seen.push(data));
+
+    cp.notifyIncomingCall("Reset", { type: "Soft" });
+
+    expect(seen).toEqual([{ action: "Reset", payload: { type: "Soft" } }]);
+  });
+
+  it("response overrides are one-shot per action", () => {
+    const cp = newChargePoint("CP-OVERRIDE");
+
+    expect(cp.consumeResponseOverride("RemoteStartTransaction")).toBeNull();
+
+    cp.armResponseOverride("RemoteStartTransaction", "Rejected");
+    expect(cp.consumeResponseOverride("RemoteStartTransaction")).toBe(
+      "Rejected",
+    );
+    // consumed — second read falls through to the normal handler path
+    expect(cp.consumeResponseOverride("RemoteStartTransaction")).toBeNull();
+  });
+
+  it("overrides for different actions are independent", () => {
+    const cp = newChargePoint("CP-OVERRIDE-2");
+    cp.armResponseOverride("TriggerMessage", "Rejected");
+    expect(cp.consumeResponseOverride("ReserveNow")).toBeNull();
+    expect(cp.consumeResponseOverride("TriggerMessage")).toBe("Rejected");
+  });
+});

--- a/src/cp/infrastructure/transport/OCPPMessageHandler.ts
+++ b/src/cp/infrastructure/transport/OCPPMessageHandler.ts
@@ -832,7 +832,9 @@ export class OCPPMessageHandler {
 
     // Issue #110: a scenario responseOverride node may have armed a
     // one-shot canned response for this action (e.g. RemoteStartTransaction
-    // → Rejected for TC_026). It replaces the handler entirely.
+    // → Rejected for TC_026). It replaces the handler entirely, so the legacy
+    // remoteStartReceived/remoteStopReceived delegation never fires — scenarios
+    // combining an override with a wait must use the generic csmsCallTrigger.
     const overrideStatus = this._chargePoint.consumeResponseOverride(action);
     if (overrideStatus !== null) {
       this._logger.info(

--- a/src/cp/infrastructure/transport/OCPPMessageHandler.ts
+++ b/src/cp/infrastructure/transport/OCPPMessageHandler.ts
@@ -826,6 +826,23 @@ export class OCPPMessageHandler {
     action: OCPPAction,
     payload: OcppMessagePayloadCall,
   ): Promise<void> {
+    // Issue #110: surface every incoming CSMS call to the scenario layer
+    // (csmsCallTrigger nodes), regardless of handler outcome.
+    this._chargePoint.notifyIncomingCall(action, payload);
+
+    // Issue #110: a scenario responseOverride node may have armed a
+    // one-shot canned response for this action (e.g. RemoteStartTransaction
+    // → Rejected for TC_026). It replaces the handler entirely.
+    const overrideStatus = this._chargePoint.consumeResponseOverride(action);
+    if (overrideStatus !== null) {
+      this._logger.info(
+        `Response override: ${action} → { status: "${overrideStatus}" }`,
+        LogType.OCPP,
+      );
+      this.sendCallResult(messageId, { status: overrideStatus });
+      return;
+    }
+
     // Use registry to get handler
     const handler = this._registry.getCallHandler(action);
 

--- a/src/cp/infrastructure/transport/OCPPMessageHandler.ts
+++ b/src/cp/infrastructure/transport/OCPPMessageHandler.ts
@@ -839,7 +839,12 @@ export class OCPPMessageHandler {
         `Response override: ${action} → { status: "${overrideStatus}" }`,
         LogType.OCPP,
       );
-      this.sendCallResult(messageId, { status: overrideStatus });
+      // Response overrides intentionally carry a caller-chosen status
+      // string (e.g. "Rejected" for TC_026); the closed response union
+      // can't express that, so assert the shape at this one call site.
+      this.sendCallResult(messageId, {
+        status: overrideStatus,
+      } as OcppMessageResponsePayload);
       return;
     }
 


### PR DESCRIPTION
## Summary

Engine slice for #110 (built-in OCPP 1.6 certification scenarios). The first slice (#117) covered test cases expressible with the existing node set; most remaining cases park on a CSMS-initiated call (Reset, GetConfiguration, SendLocalList, TriggerMessage, …) or need a non-default response (RemoteStartTransaction → Rejected). Instead of one node type per action, this adds two generic engine hooks that unlock ~20 further certification scenarios as pure JSON in follow-up PRs:

- **`csmsCallTrigger` node** — parks a scenario until a named CSMS→CP call arrives, then continues. Backed by a new `incomingCallReceived` ChargePoint event emitted at the single dispatch point (`OCPPMessageHandler.handleCall`) for every incoming CALL. The CP core handler still runs — the node only synchronizes the scenario with the arrival.
- **`responseOverride` node** — pre-arms a one-shot canned `{ status }` response for the next incoming call of a given action (e.g. `RemoteStartTransaction → Rejected`), consumed at dispatch before the normal handler. Restricted to actions whose CALLRESULT payload is exactly `{ status }`. Stale overrides are cleared on disconnect/teardown.
- **`stopReason` on the Transaction stop node** — optional OCPP §6.21 reason (e.g. `EVDisconnected`); a reason captured by a preceding RemoteStopTrigger still wins (precedence pinned by test).
- **Editor UI** for both nodes (palette, node cards, config forms with action/status dropdowns). New components are typed against the xyflow v12 `Node` constraint; existing node components are untouched.

## Testing

- `vitest run`: 843 passing (new suites: incoming-call observability, csmsCallTrigger park/ignore/timeout with negative-check-verified action filter, responseOverride arming, stopReason precedence remote-over-node)
- `bun test bun.test`: 131/131 (identical to main)
- `eslint .`: clean
- `tsc -b --noEmit --force` error count: 478, identical to main (zero new type errors)

## Follow-ups (next slices of #110)

- Scenario JSONs for the remaining Core cases (Reset, GetConfiguration/ChangeConfiguration, remote start/stop rejected, ClearCache, DataTransfer), then Local Auth List / Reservation / Remote Trigger / Smart Charging / Firmware profiles
- A dispatch-level test locking the notify-before-consume ordering once the first override scenario lands
- Per-action status filtering in the override form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSMS Call Trigger nodes to pause scenarios until a matching incoming CSMS CALL is received (optional timeout with progress display).
  * Added Response Override nodes to apply a one-shot status override for the next matching incoming CALL.
  * Updated the scenario editor with new node palette entries and configuration forms for both node types.
  * Enhanced stop-reason handling for transaction stop actions with correct fallback precedence.
* **Bug Fixes**
  * Ensured response overrides are consumed once and cleared on disconnect to prevent stale overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->