### PR TITLE
feat(scenarios): cert 1.6 Core remainder — 12 built-in certification scenarios (#110)

### DIFF
--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -101,6 +101,9 @@ export class ScenarioExecutor {
   private remoteStopOptions: StopTransactionOptions | null = null;
   private currentNodeId: string | null = null;
   private executedNodes: string[] = [];
+  // Issue #110: track which response overrides were armed during this run,
+  // so they can be cleared when the run ends (both normal completion and stop()).
+  private armedOverrideActions: string[] = [];
 
   constructor(
     scenario: ScenarioDefinition,
@@ -164,6 +167,7 @@ export class ScenarioExecutor {
     this.executedNodes = [];
     this.stepResolve = null;
     this.pendingSteps = 0;
+    this.armedOverrideActions = [];
     this.abortPromise = new Promise<void>((resolve) => {
       this.abortResolve = resolve;
     });
@@ -243,9 +247,18 @@ export class ScenarioExecutor {
         `[${this.scenario.name}] Scenario execution failed: ${errorMessage}`,
         "error",
       );
-    }
+    } finally {
+      // Issue #110: clear any response overrides armed during this run,
+      // both on normal completion and on stop(). Iterate through the
+      // tracking list (which was populated by executeResponseOverride)
+      // and call the clear callback for each one.
+      for (const action of this.armedOverrideActions) {
+        this.callbacks.onClearResponseOverride?.(action);
+      }
+      this.armedOverrideActions = [];
 
-    this.notifyStateChange();
+      this.notifyStateChange();
+    }
   }
 
   /**
@@ -658,6 +671,10 @@ export class ScenarioExecutor {
       return;
     }
     this.callbacks.onArmResponseOverride(data.action, data.status);
+    // Issue #110: track this action so we can clear it when the run ends.
+    if (!this.armedOverrideActions.includes(data.action)) {
+      this.armedOverrideActions.push(data.action);
+    }
     this.callbacks.log?.(
       `Armed response override: ${data.action} → ${data.status}`,
       "info",

--- a/src/cp/application/scenario/ScenarioRuntime.ts
+++ b/src/cp/application/scenario/ScenarioRuntime.ts
@@ -618,6 +618,9 @@ export const createScenarioExecutorCallbacks = (
     onArmResponseOverride: (action, status) => {
       chargePoint.armResponseOverride(action, status);
     },
+    onClearResponseOverride: (action) => {
+      chargePoint.clearResponseOverride(action);
+    },
     onConfigSet: (key, value) => {
       chargePoint.configuration.applyChange(key, value);
     },

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -549,6 +549,10 @@ export interface ScenarioExecutorCallbacks {
   /** Issue #110: arm a one-shot `{ status }` response override for the
    *  next incoming CALL of the given action. */
   onArmResponseOverride?: (action: string, status: string) => void;
+  /** Issue #110: clear an armed response override. Called when a scenario
+   *  run ends (both normal completion and stop()) to clean up any overrides
+   *  armed during the run. */
+  onClearResponseOverride?: (action: string) => void;
   /** §5.3: apply a Configuration key change locally. */
   onConfigSet?: (key: string, value: string) => void;
   /** §4.3: send CP-initiated DataTransfer.req. */

--- a/src/cp/application/scenario/__tests__/cert16CoreScenarios.test.ts
+++ b/src/cp/application/scenario/__tests__/cert16CoreScenarios.test.ts
@@ -120,6 +120,11 @@ describe("cert16 Core certification scenarios with csmsCallTrigger and responseO
       await timeout(execution, 5000);
 
       // After completion, the override should be cleared (end-of-run cleanup per Task 1)
+      // Scope note: this only pins end-of-run cleanup (the executor clears
+      // armed overrides in its finally block whether or not a dispatch
+      // consumed them). The actual override-intercepts-the-handler semantics
+      // are proven at the dispatch layer in handleCallOverride.test.ts; this
+      // test's main value is that TC_026's node graph runs to completion.
       expect(cp.consumeResponseOverride("RemoteStartTransaction")).toBeNull();
     } finally {
       executor.stop();

--- a/src/cp/application/scenario/__tests__/cert16CoreScenarios.test.ts
+++ b/src/cp/application/scenario/__tests__/cert16CoreScenarios.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import { ScenarioExecutor } from "../ScenarioExecutor";
+import { createScenarioExecutorCallbacks } from "../ScenarioRuntime";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+import { getTemplateById } from "../../../../utils/scenarioTemplates";
+
+function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+async function waitUntil(predicate: () => boolean, ms = 500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > ms) {
+      throw new Error("Timed out waiting for predicate");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function newChargePoint(id: string): ChargePoint {
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    "ws://127.0.0.1:9/",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  return cp;
+}
+
+describe("cert16 Core certification scenarios with csmsCallTrigger and responseOverride", () => {
+  it("TC_013 Hard Reset: parks on csmsCallTrigger, then completes when Reset arrives", async () => {
+    const template = getTemplateById("cert16-tc013-hard-reset");
+    expect(template).toBeDefined();
+
+    const cp = newChargePoint("CP-CERT-TC013");
+    const connector = cp.getConnector(1);
+    expect(connector).toBeDefined();
+
+    const scenario = template!.createScenario("CP-CERT-TC013", 1);
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector: connector!,
+    });
+    const executor = new ScenarioExecutor(scenario, callbacks);
+    const execution = executor.start();
+
+    try {
+      // Wait for the csmsCallTrigger node to attach its listener — the scenario
+      // is parked waiting for the incoming Reset call
+      await waitUntil(
+        () => cp.events.listenerCount("incomingCallReceived") > 0,
+        3000,
+      );
+
+      // Simulate the CSMS issuing Reset.req
+      cp.notifyIncomingCall("Reset", { type: "Hard" });
+
+      // Execution should complete after the Reset is received
+      await timeout(execution, 3000);
+    } finally {
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      ).catch(() => undefined);
+    }
+  });
+
+  it("TC_026 Remote Start — Rejected: arms override, parks on trigger, override clears after completion", async () => {
+    const template = getTemplateById("cert16-tc026-remote-start-rejected");
+    expect(template).toBeDefined();
+
+    const cp = newChargePoint("CP-CERT-TC026");
+    const connector = cp.getConnector(1);
+    expect(connector).toBeDefined();
+
+    const scenario = template!.createScenario("CP-CERT-TC026", 1);
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector: connector!,
+    });
+    const executor = new ScenarioExecutor(scenario, callbacks);
+    const execution = executor.start();
+
+    try {
+      // After the responseOverride node runs, it's armed. Then the csmsCallTrigger
+      // parks. We wait for the trigger to be ready (listenerCount > 0 means both
+      // responseOverride has armed and csmsCallTrigger is listening).
+      await waitUntil(
+        () => cp.events.listenerCount("incomingCallReceived") > 0,
+        3000,
+      );
+
+      // Simulate the CSMS issuing RemoteStartTransaction.req — this will be rejected
+      // by the armed override instead of proceeding normally
+      cp.notifyIncomingCall("RemoteStartTransaction", {
+        connectorId: 1,
+        idTag: "TEST",
+      });
+
+      // Execution should complete after the RemoteStartTransaction is received
+      // and rejected by the override (delay is 3s + overhead)
+      await timeout(execution, 5000);
+
+      // After completion, the override should be cleared (end-of-run cleanup per Task 1)
+      expect(cp.consumeResponseOverride("RemoteStartTransaction")).toBeNull();
+    } finally {
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      ).catch(() => undefined);
+    }
+  });
+});

--- a/src/cp/application/scenario/__tests__/responseOverride.test.ts
+++ b/src/cp/application/scenario/__tests__/responseOverride.test.ts
@@ -16,6 +16,16 @@ function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   });
 }
 
+async function waitUntil(predicate: () => boolean, ms = 500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > ms) {
+      throw new Error("Timed out waiting for predicate");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 function newChargePoint(id: string): ChargePoint {
   const cp = new ChargePoint(
     id,
@@ -153,8 +163,10 @@ describe("responseOverride node (issue #110)", () => {
 
     const startPromise = executor.start();
 
-    // Give the executor time to arm the override and reach the parked state
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    // Wait for the csmsCallTrigger node to attach its listener — that's
+    // when the executor has armed the override and reached the parked
+    // state (mirrors csmsCallTrigger.test.ts:98-100).
+    await waitUntil(() => cp.events.listenerCount("incomingCallReceived") > 0);
 
     // Stop the scenario while parked (the override is armed)
     executor.stop();

--- a/src/cp/application/scenario/__tests__/responseOverride.test.ts
+++ b/src/cp/application/scenario/__tests__/responseOverride.test.ts
@@ -78,7 +78,7 @@ function overrideScenario(): ScenarioDefinition {
 }
 
 describe("responseOverride node (issue #110)", () => {
-  it("arms a one-shot override on the charge point and completes", async () => {
+  it("clears armed overrides when scenario completes", async () => {
     const cp = newChargePoint("CP-OVERRIDE-NODE");
     const connector = cp.getConnector(1)!;
     const executor = new ScenarioExecutor(
@@ -88,9 +88,81 @@ describe("responseOverride node (issue #110)", () => {
 
     await timeout(executor.start(), 1000);
 
-    expect(cp.consumeResponseOverride("RemoteStartTransaction")).toBe(
-      "Rejected",
+    // After completion, the override should be cleared
+    expect(cp.consumeResponseOverride("RemoteStartTransaction")).toBeNull();
+  });
+
+  it("clears armed overrides when scenario is stopped", async () => {
+    const cp = newChargePoint("CP-OVERRIDE-STOP");
+    const connector = cp.getConnector(1)!;
+    const parkedScenario: ScenarioDefinition = {
+      id: "test-response-override-parked",
+      name: "responseOverride armed, then parked",
+      targetType: "connector",
+      targetId: 1,
+      trigger: { type: "manual" },
+      defaultExecutionMode: "oneshot",
+      enabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      nodes: [
+        {
+          id: "start-1",
+          type: ScenarioNodeType.START,
+          position: { x: 0, y: 0 },
+          data: { label: "Start", triggerOn: "connect" },
+        },
+        {
+          id: "arm-override",
+          type: ScenarioNodeType.RESPONSE_OVERRIDE,
+          position: { x: 0, y: 100 },
+          data: {
+            label: "Arm override",
+            action: "RemoteStartTransaction",
+            status: "Rejected",
+          },
+        },
+        {
+          id: "park",
+          type: ScenarioNodeType.CSMS_CALL_TRIGGER,
+          position: { x: 0, y: 200 },
+          data: {
+            label: "Wait for RemoteStopTransaction",
+            action: "RemoteStopTransaction",
+            timeout: 30,
+          },
+        },
+        {
+          id: "end-1",
+          type: ScenarioNodeType.END,
+          position: { x: 0, y: 300 },
+          data: { label: "End" },
+        },
+      ],
+      edges: [
+        { id: "e1", source: "start-1", target: "arm-override" },
+        { id: "e2", source: "arm-override", target: "park" },
+        { id: "e3", source: "park", target: "end-1" },
+      ],
+    };
+
+    const executor = new ScenarioExecutor(
+      parkedScenario,
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
     );
+
+    const startPromise = executor.start();
+
+    // Give the executor time to arm the override and reach the parked state
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Stop the scenario while parked (the override is armed)
+    executor.stop();
+
+    // Wait for the start promise to resolve
+    await timeout(startPromise, 1000);
+
+    // After stop, the executor's finally block should have cleared the armed override
     expect(cp.consumeResponseOverride("RemoteStartTransaction")).toBeNull();
   });
 });

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -626,6 +626,11 @@ export class ChargePoint {
     return status;
   }
 
+  /** Clear an armed response override. No-op if not armed. */
+  clearResponseOverride(action: string): void {
+    this._responseOverrides.delete(action);
+  }
+
   set loggingCallback(callback: (entry: LogEntry) => void) {
     this._logger._loggingCallback = callback;
   }

--- a/src/cp/infrastructure/transport/__tests__/handleCallOverride.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/handleCallOverride.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import { OCPPMessageHandler } from "../OCPPMessageHandler";
+import type { OCPPWebSocket, OcppMessageErrorPayload } from "../OCPPWebSocket";
+import type { ProtocolCodec } from "../profile/ProtocolProfile";
+import { outgoingV16Warning } from "../codec/validateV16";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import {
+  DefaultBootNotification,
+  OCPPAction,
+  OCPPMessageType,
+} from "../../../domain/types/OcppTypes";
+import { Logger, LogLevel } from "../../../shared/Logger";
+
+function newChargePoint(id: string): ChargePoint {
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    "ws://127.0.0.1:9/",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  return cp;
+}
+
+async function waitUntil(predicate: () => boolean, ms = 500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > ms) {
+      throw new Error("Timed out waiting for predicate");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+// Matches the private `MessageHandler` type in OCPPWebSocket.ts — the
+// callback OCPPMessageHandler registers via `setMessageHandler` and that
+// production code invokes once a frame has been parsed off the wire.
+type IncomingMessageHandler = (
+  messageType: OCPPMessageType,
+  messageId: string,
+  action: OCPPAction,
+  payload: unknown,
+) => void;
+
+describe("OCPPMessageHandler.handleCall response override dispatch (issue #110)", () => {
+  it("fires incomingCallReceived before responding, honors a one-shot override, then falls through to the normal handler", async () => {
+    const cp = newChargePoint("CP-HANDLE-CALL");
+    const logger = new Logger(LogLevel.ERROR);
+    // Reuse the real v16 outbound-warning logic (see profile/profiles.ts) —
+    // it's a pure function, cheap to wire up directly rather than faking it.
+    const codec: ProtocolCodec = { outgoingWarning: outgoingV16Warning };
+
+    let capturedHandler: IncomingMessageHandler | null = null;
+    const order: string[] = [];
+    const sendResultCalls: Array<{ messageId: string; payload: unknown }> = [];
+    const sendErrorCalls: Array<{
+      messageId: string;
+      payload: OcppMessageErrorPayload;
+    }> = [];
+
+    // Duck-typed fake: OCPPMessageHandler only ever touches these four
+    // OCPPWebSocket methods — `setMessageHandler` (constructor, line ~267),
+    // `sendAction` (pumpSerialQueue, line ~665 — unused by this test, no
+    // outgoing CP->CSMS call is triggered), and `sendResult`/`sendError`
+    // (sendCallResult/sendCallError, lines ~973/~985).
+    const fakeSocket = {
+      setMessageHandler: (handler: IncomingMessageHandler) => {
+        capturedHandler = handler;
+      },
+      sendAction: () => true,
+      sendResult: (messageId: string, payload: unknown) => {
+        order.push("sendResult");
+        sendResultCalls.push({ messageId, payload });
+      },
+      sendError: (messageId: string, payload: OcppMessageErrorPayload) => {
+        order.push("sendError");
+        sendErrorCalls.push({ messageId, payload });
+      },
+    } as unknown as OCPPWebSocket;
+
+    new OCPPMessageHandler(cp, fakeSocket, logger, codec);
+
+    expect(capturedHandler).not.toBeNull();
+    const handler = capturedHandler!;
+
+    cp.events.on("incomingCallReceived", () => order.push("event"));
+
+    // --- (a) ordering + normal-handler dispatch -----------------------
+    // No override armed yet: ClearCache falls through to the real
+    // ClearCacheHandler, which answers { status: "Accepted" }. handleCall
+    // is fire-and-forget from the message-handler callback (`void
+    // this.handleCall(...)`), so we poll for the response rather than
+    // assume synchronous completion.
+    handler(OCPPMessageType.CALL, "msg-1", OCPPAction.ClearCache, {});
+    await waitUntil(() => sendResultCalls.length === 1);
+    // The incomingCallReceived event is emitted synchronously at the top
+    // of handleCall, before any response is sent — assert it lands first.
+    expect(order).toEqual(["event", "sendResult"]);
+    expect(sendResultCalls[0]).toEqual({
+      messageId: "msg-1",
+      payload: { status: "Accepted" },
+    });
+
+    // --- (b) armed override preempts the normal handler ----------------
+    cp.armResponseOverride("ClearCache", "Rejected");
+    handler(OCPPMessageType.CALL, "msg-2", OCPPAction.ClearCache, {});
+    await waitUntil(() => sendResultCalls.length === 2);
+    expect(sendResultCalls[1]).toEqual({
+      messageId: "msg-2",
+      payload: { status: "Rejected" },
+    });
+
+    // --- (c) override was one-shot: third identical CALL falls through --
+    handler(OCPPMessageType.CALL, "msg-3", OCPPAction.ClearCache, {});
+    await waitUntil(() => sendResultCalls.length === 3);
+    expect(sendResultCalls[2]).toEqual({
+      messageId: "msg-3",
+      payload: { status: "Accepted" },
+    });
+
+    expect(sendErrorCalls).toEqual([]);
+  });
+});

--- a/src/utils/scenarioTemplates.test.ts
+++ b/src/utils/scenarioTemplates.test.ts
@@ -30,6 +30,8 @@ const EXPECTED_CERT16_IDS = [
   "cert16-tc019-get-configuration-key",
   "cert16-tc021-change-configuration",
   "cert16-tc024-lock-failure",
+  "cert16-tc026-remote-start-rejected",
+  "cert16-tc028-remote-stop-rejected",
   "cert16-tc031-unlock-unknown-connector",
   "cert16-tc061-clear-cache",
   "cert16-tc064-data-transfer",

--- a/src/utils/scenarioTemplates.test.ts
+++ b/src/utils/scenarioTemplates.test.ts
@@ -18,11 +18,15 @@ const EXPECTED_CERT16_IDS = [
   "cert16-tc001-cold-boot",
   "cert16-tc003-charging-plugin-first",
   "cert16-tc004-charging-id-first",
+  "cert16-tc005-ev-side-disconnect",
   "cert16-tc010-remote-start",
   "cert16-tc011-remote-start-stop",
   "cert16-tc012-remote-stop",
+  "cert16-tc013-hard-reset",
+  "cert16-tc014-soft-reset",
   "cert16-tc017-unlock-occupied",
   "cert16-tc018-unlock-failure",
+  "cert16-tc024-lock-failure",
   "cert16-reservation-basic",
 ];
 

--- a/src/utils/scenarioTemplates.test.ts
+++ b/src/utils/scenarioTemplates.test.ts
@@ -29,10 +29,10 @@ const EXPECTED_CERT16_IDS = [
   "cert16-tc019-get-configuration-all",
   "cert16-tc019-get-configuration-key",
   "cert16-tc021-change-configuration",
+  "cert16-tc024-lock-failure",
   "cert16-tc031-unlock-unknown-connector",
   "cert16-tc061-clear-cache",
   "cert16-tc064-data-transfer",
-  "cert16-tc024-lock-failure",
   "cert16-reservation-basic",
 ];
 

--- a/src/utils/scenarioTemplates.test.ts
+++ b/src/utils/scenarioTemplates.test.ts
@@ -26,6 +26,12 @@ const EXPECTED_CERT16_IDS = [
   "cert16-tc014-soft-reset",
   "cert16-tc017-unlock-occupied",
   "cert16-tc018-unlock-failure",
+  "cert16-tc019-get-configuration-all",
+  "cert16-tc019-get-configuration-key",
+  "cert16-tc021-change-configuration",
+  "cert16-tc031-unlock-unknown-connector",
+  "cert16-tc061-clear-cache",
+  "cert16-tc064-data-transfer",
   "cert16-tc024-lock-failure",
   "cert16-reservation-basic",
 ];

--- a/src/utils/scenarioTemplates.ts
+++ b/src/utils/scenarioTemplates.ts
@@ -112,10 +112,10 @@ export const scenarioTemplates: ScenarioTemplate[] = [
   templateFromJson(cert16Tc019GetConfigAllJson as ScenarioDefinition),
   templateFromJson(cert16Tc019GetConfigKeyJson as ScenarioDefinition),
   templateFromJson(cert16Tc021ChangeConfigJson as ScenarioDefinition),
+  templateFromJson(cert16Tc024LockFailureJson as ScenarioDefinition),
   templateFromJson(cert16Tc031UnlockUnknownJson as ScenarioDefinition),
   templateFromJson(cert16Tc061ClearCacheJson as ScenarioDefinition),
   templateFromJson(cert16Tc064DataTransferJson as ScenarioDefinition),
-  templateFromJson(cert16Tc024LockFailureJson as ScenarioDefinition),
   templateFromJson(cert16ReservationBasicJson as ScenarioDefinition),
 ];
 

--- a/src/utils/scenarioTemplates.ts
+++ b/src/utils/scenarioTemplates.ts
@@ -27,6 +27,8 @@ import cert16Tc031UnlockUnknownJson from "./scenarios/cert16-tc031-unlock-unknow
 import cert16Tc061ClearCacheJson from "./scenarios/cert16-tc061-clear-cache.json";
 import cert16Tc064DataTransferJson from "./scenarios/cert16-tc064-data-transfer.json";
 import cert16Tc024LockFailureJson from "./scenarios/cert16-tc024-lock-failure.json";
+import cert16Tc026RemoteStartRejectedJson from "./scenarios/cert16-tc026-remote-start-rejected.json";
+import cert16Tc028RemoteStopRejectedJson from "./scenarios/cert16-tc028-remote-stop-rejected.json";
 import cert16ReservationBasicJson from "./scenarios/cert16-reservation-basic.json";
 
 export interface ScenarioTemplate {
@@ -113,6 +115,8 @@ export const scenarioTemplates: ScenarioTemplate[] = [
   templateFromJson(cert16Tc019GetConfigKeyJson as ScenarioDefinition),
   templateFromJson(cert16Tc021ChangeConfigJson as ScenarioDefinition),
   templateFromJson(cert16Tc024LockFailureJson as ScenarioDefinition),
+  templateFromJson(cert16Tc026RemoteStartRejectedJson as ScenarioDefinition),
+  templateFromJson(cert16Tc028RemoteStopRejectedJson as ScenarioDefinition),
   templateFromJson(cert16Tc031UnlockUnknownJson as ScenarioDefinition),
   templateFromJson(cert16Tc061ClearCacheJson as ScenarioDefinition),
   templateFromJson(cert16Tc064DataTransferJson as ScenarioDefinition),

--- a/src/utils/scenarioTemplates.ts
+++ b/src/utils/scenarioTemplates.ts
@@ -12,11 +12,15 @@ import remoteStartAutoMeterJson from "./scenarios/remote-start-auto-meter.json";
 import cert16Tc001ColdBootJson from "./scenarios/cert16-tc001-cold-boot.json";
 import cert16Tc003ChargingPluginFirstJson from "./scenarios/cert16-tc003-charging-plugin-first.json";
 import cert16Tc004ChargingIdFirstJson from "./scenarios/cert16-tc004-charging-id-first.json";
+import cert16Tc005EvSideDisconnectJson from "./scenarios/cert16-tc005-ev-side-disconnect.json";
 import cert16Tc010RemoteStartJson from "./scenarios/cert16-tc010-remote-start.json";
 import cert16Tc011RemoteStartStopJson from "./scenarios/cert16-tc011-remote-start-stop.json";
 import cert16Tc012RemoteStopJson from "./scenarios/cert16-tc012-remote-stop.json";
+import cert16Tc013HardResetJson from "./scenarios/cert16-tc013-hard-reset.json";
+import cert16Tc014SoftResetJson from "./scenarios/cert16-tc014-soft-reset.json";
 import cert16Tc017UnlockOccupiedJson from "./scenarios/cert16-tc017-unlock-occupied.json";
 import cert16Tc018UnlockFailureJson from "./scenarios/cert16-tc018-unlock-failure.json";
+import cert16Tc024LockFailureJson from "./scenarios/cert16-tc024-lock-failure.json";
 import cert16ReservationBasicJson from "./scenarios/cert16-reservation-basic.json";
 
 export interface ScenarioTemplate {
@@ -91,11 +95,15 @@ export const scenarioTemplates: ScenarioTemplate[] = [
   templateFromJson(cert16Tc001ColdBootJson as ScenarioDefinition),
   templateFromJson(cert16Tc003ChargingPluginFirstJson as ScenarioDefinition),
   templateFromJson(cert16Tc004ChargingIdFirstJson as ScenarioDefinition),
+  templateFromJson(cert16Tc005EvSideDisconnectJson as ScenarioDefinition),
   templateFromJson(cert16Tc010RemoteStartJson as ScenarioDefinition),
   templateFromJson(cert16Tc011RemoteStartStopJson as ScenarioDefinition),
   templateFromJson(cert16Tc012RemoteStopJson as ScenarioDefinition),
+  templateFromJson(cert16Tc013HardResetJson as ScenarioDefinition),
+  templateFromJson(cert16Tc014SoftResetJson as ScenarioDefinition),
   templateFromJson(cert16Tc017UnlockOccupiedJson as ScenarioDefinition),
   templateFromJson(cert16Tc018UnlockFailureJson as ScenarioDefinition),
+  templateFromJson(cert16Tc024LockFailureJson as ScenarioDefinition),
   templateFromJson(cert16ReservationBasicJson as ScenarioDefinition),
 ];
 

--- a/src/utils/scenarioTemplates.ts
+++ b/src/utils/scenarioTemplates.ts
@@ -20,6 +20,12 @@ import cert16Tc013HardResetJson from "./scenarios/cert16-tc013-hard-reset.json";
 import cert16Tc014SoftResetJson from "./scenarios/cert16-tc014-soft-reset.json";
 import cert16Tc017UnlockOccupiedJson from "./scenarios/cert16-tc017-unlock-occupied.json";
 import cert16Tc018UnlockFailureJson from "./scenarios/cert16-tc018-unlock-failure.json";
+import cert16Tc019GetConfigAllJson from "./scenarios/cert16-tc019-get-configuration-all.json";
+import cert16Tc019GetConfigKeyJson from "./scenarios/cert16-tc019-get-configuration-key.json";
+import cert16Tc021ChangeConfigJson from "./scenarios/cert16-tc021-change-configuration.json";
+import cert16Tc031UnlockUnknownJson from "./scenarios/cert16-tc031-unlock-unknown-connector.json";
+import cert16Tc061ClearCacheJson from "./scenarios/cert16-tc061-clear-cache.json";
+import cert16Tc064DataTransferJson from "./scenarios/cert16-tc064-data-transfer.json";
 import cert16Tc024LockFailureJson from "./scenarios/cert16-tc024-lock-failure.json";
 import cert16ReservationBasicJson from "./scenarios/cert16-reservation-basic.json";
 
@@ -103,6 +109,12 @@ export const scenarioTemplates: ScenarioTemplate[] = [
   templateFromJson(cert16Tc014SoftResetJson as ScenarioDefinition),
   templateFromJson(cert16Tc017UnlockOccupiedJson as ScenarioDefinition),
   templateFromJson(cert16Tc018UnlockFailureJson as ScenarioDefinition),
+  templateFromJson(cert16Tc019GetConfigAllJson as ScenarioDefinition),
+  templateFromJson(cert16Tc019GetConfigKeyJson as ScenarioDefinition),
+  templateFromJson(cert16Tc021ChangeConfigJson as ScenarioDefinition),
+  templateFromJson(cert16Tc031UnlockUnknownJson as ScenarioDefinition),
+  templateFromJson(cert16Tc061ClearCacheJson as ScenarioDefinition),
+  templateFromJson(cert16Tc064DataTransferJson as ScenarioDefinition),
   templateFromJson(cert16Tc024LockFailureJson as ScenarioDefinition),
   templateFromJson(cert16ReservationBasicJson as ScenarioDefinition),
 ];

--- a/src/utils/scenarios/README.md
+++ b/src/utils/scenarios/README.md
@@ -1,0 +1,68 @@
+# Certification Scenario Templates
+
+These built-in JSON templates implement the Charge Point side of OCPP 1.6 certification test cases. Each scenario encodes a specific flow or condition described in the OCPPSC test-case spec. To run a scenario:
+
+1. Open the Scenario Editor in the web console.
+2. Select one of the cert16-* scenarios from the dropdown.
+3. Connect a real CSMS (or a test harness like GOCPP) to the simulator.
+4. Click **Play** to execute the scenario.
+5. Follow the CSMS-side operator actions listed below to complete the test case.
+
+## Scenario Mapping
+
+| Scenario ID                           | TC       | Title                                   | Profile       | CSMS-Side Operator Action                                                                                                                           |
+| ------------------------------------- | -------- | --------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| cert16-tc001-cold-boot                | TC_001   | Cold Boot                               | Core          | Verify BootNotification and StatusNotification are sent automatically on connection.                                                                |
+| cert16-tc003-charging-plugin-first    | TC_003   | Charging Session (Plug-In First)        | Core          | Provide idTag after the cable is plugged in. Accept StartTransaction. Verify MeterValue samples and StopTransaction.                                |
+| cert16-tc004-charging-id-first        | TC_004   | Charging Session (Identification First) | Core          | Provide idTag before the cable is plugged in. Accept StartTransaction. Verify MeterValue samples and StopTransaction.                               |
+| cert16-tc005-ev-side-disconnect       | TC_005   | EV Side Disconnected                    | Core          | Initiate the EV-side disconnect (plugout) during charging. Verify StopTransaction with EVDisconnected reason.                                       |
+| cert16-tc010-remote-start             | TC_010   | Remote Start Transaction                | RemoteTrigger | Send RemoteStartTransaction.req. Accept the response. Verify StatusNotification(Preparing) and StartTransaction.                                    |
+| cert16-tc011-remote-start-stop        | TC_011   | Remote Start + Remote Stop Transaction  | RemoteTrigger | Send RemoteStartTransaction.req, accept. Send RemoteStopTransaction.req during charging. Verify StopTransaction and StatusNotification sequence.    |
+| cert16-tc012-remote-stop              | TC_012   | Remote Stop Transaction                 | RemoteTrigger | Verify a charging session in progress. Send RemoteStopTransaction.req. Accept the response. Verify StopTransaction.                                 |
+| cert16-tc013-hard-reset               | TC_013   | Hard Reset                              | Core          | Send Reset(type=Hard) during charging. Verify StopTransaction with HardReset reason and CP reboot.                                                  |
+| cert16-tc014-soft-reset               | TC_014   | Soft Reset                              | Core          | Send Reset(type=Soft) during charging. Verify StopTransaction with SoftReset reason and CP reboot.                                                  |
+| cert16-tc017-unlock-occupied          | TC_017   | Unlock Connector (Occupied, Succeeds)   | Core          | Verify a charging session in progress. Send UnlockConnector.req. Accept the response. Verify the session completes normally.                        |
+| cert16-tc018-unlock-failure           | TC_018   | Unlock Connector (Failure)              | Core          | Verify a charging session in progress. Send UnlockConnector.req. Accept the failure (UnlockFailed) response. Verify the session completes normally. |
+| cert16-tc019-get-configuration-all    | TC_019_1 | Retrieve All Configuration Keys         | Core          | Send GetConfiguration with no key filter. Verify the CP returns all supported configuration keys.                                                   |
+| cert16-tc019-get-configuration-key    | TC_019_2 | Retrieve Specific Configuration Key     | Core          | Send GetConfiguration for a specific key (e.g., HeartbeatInterval). Verify the CP returns the requested configuration.                              |
+| cert16-tc021-change-configuration     | TC_021   | Change Configuration                    | Core          | Send ChangeConfiguration to update a key (e.g., MeterValueSampleInterval). Verify the CP accepts and applies the change.                            |
+| cert16-tc024-lock-failure             | TC_024   | Start Charging Session — Lock Failure   | Core          | Plug in the cable. Verify StatusNotification(Faulted, ConnectorLockFailure) and no transaction started. Plug out.                                   |
+| cert16-tc026-remote-start-rejected    | TC_026   | Remote Start — Rejected                 | RemoteTrigger | Send RemoteStartTransaction.req on an Available connector. Verify the CP responds with Rejected status.                                             |
+| cert16-tc028-remote-stop-rejected     | TC_028   | Remote Stop — Rejected                  | RemoteTrigger | Verify a charging session in progress. Send RemoteStopTransaction.req. Verify the CP responds with Rejected status and charging continues.          |
+| cert16-tc031-unlock-unknown-connector | TC_031   | Unlock Connector — Unknown Connector    | Core          | Send UnlockConnector for a non-existent connector ID. Verify the CP responds with NotSupported.                                                     |
+| cert16-reservation-basic              | TC_046   | Reservation (Basic)                     | Reservation   | Send ReserveNow.req for a future reservation. Present the reserved idTag. Accept StartTransaction. Verify MeterValue and StopTransaction.           |
+| cert16-tc061-clear-cache              | TC_061   | Clear Authorization Cache               | Core          | Send ClearCache. Verify the CP accepts (Accepted).                                                                                                  |
+| cert16-tc064-data-transfer            | TC_064   | Data Transfer to Central System         | Core          | Verify the CP sends DataTransfer.req with vendorId com.example.cert16. Accept or respond with UnknownVendorId as appropriate.                       |
+
+## Numbering Note
+
+Scenario identifiers follow the OCPP Certification Test Cases (OCPPSC) specification test-case numbering: TC_001, TC_003, TC_004, etc. The unlock scenarios TC_017 (Unlock Connector — Occupied, Succeeds) and TC_018 (Unlock Connector — Failure) predate the formal OCPPSC mapping; TC_017 ≈ "unlock with active session" and TC_018 ≈ "unlock failure / stuck lock".
+
+## Response-Override Valid Statuses
+
+When using the `responseOverride` node to arm a one-shot response override for an incoming OCPP request, the following status values are valid per action:
+
+| Action                 | Valid Statuses                                     |
+| ---------------------- | -------------------------------------------------- |
+| RemoteStartTransaction | Accepted, Rejected                                 |
+| RemoteStopTransaction  | Accepted, Rejected                                 |
+| TriggerMessage         | Accepted, Rejected, NotImplemented                 |
+| ReserveNow             | Accepted, Faulted, Occupied, Rejected, Unavailable |
+| CancelReservation      | Accepted, Rejected                                 |
+| SendLocalList          | Accepted, Failed, NotSupported, VersionMismatch    |
+| ChangeConfiguration    | Accepted, Rejected, RebootRequired, NotSupported   |
+| ClearCache             | Accepted, Rejected                                 |
+| SetChargingProfile     | Accepted, Rejected, NotSupported                   |
+| ClearChargingProfile   | Accepted, Unknown                                  |
+| ChangeAvailability     | Accepted, Rejected, Scheduled                      |
+
+## Out-of-Scope
+
+The following test cases are not yet covered by scenarios:
+
+- **TC_007** (Cached Authorization) — No scenario-drivable authorization flow with caching infrastructure.
+- **TC_023** (Authorize Outcome Variants) — No scenario-drivable Authorize request/response orchestration.
+- **TC_032, TC_037, TC_039** (Offline Power Failure, Offline Transactions) — No offline transaction queue or transaction replication orchestration in the scenario engine.
+- **TC_073–TC_088** (Security, Certificates, Key Provisioning) — TLS/PKI infrastructure and security setup are outside the requested feature profiles.
+
+Support for LocalAuthList, additional RemoteTrigger cases, SmartCharging, and Firmware Management profiles will be added in follow-up releases.

--- a/src/utils/scenarios/cert16-tc005-ev-side-disconnect.json
+++ b/src/utils/scenarios/cert16-tc005-ev-side-disconnect.json
@@ -1,0 +1,93 @@
+{
+  "id": "cert16-tc005-ev-side-disconnect",
+  "name": "Cert 1.6 Core: TC_005 EV Side Disconnected",
+  "description": "Plug-in → StatusNotification(Preparing) → StartTransaction.req → StatusNotification(Charging); bounded MeterValue.req; EV-side disconnect (plugout) → StopTransaction.req with EVDisconnected reason → StatusNotification(Available).",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Start Transaction",
+        "action": "start",
+        "tagId": "CERT005"
+      }
+    },
+    {
+      "id": "status-charging",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Set Charging", "status": "Charging" }
+    },
+    {
+      "id": "meter-auto",
+      "type": "meterValue",
+      "position": { "x": 400, "y": 450 },
+      "data": {
+        "label": "Auto MeterValue (5s intervals, 500 Wh, 15s max)",
+        "value": 0,
+        "sendMessage": true,
+        "autoIncrement": true,
+        "incrementInterval": 5,
+        "incrementAmount": 500,
+        "maxTime": 15,
+        "maxValue": 0
+      }
+    },
+    {
+      "id": "plug-out",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 550 },
+      "data": { "label": "Plug Out", "action": "plugout" }
+    },
+    {
+      "id": "tx-stop",
+      "type": "transaction",
+      "position": { "x": 400, "y": 650 },
+      "data": {
+        "label": "Stop Transaction",
+        "action": "stop",
+        "stopReason": "EVDisconnected"
+      }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 750 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 850 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "status-preparing" },
+    { "id": "e2", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "status-charging" },
+    { "id": "e4", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e5", "source": "meter-auto", "target": "plug-out" },
+    { "id": "e6", "source": "plug-out", "target": "tx-stop" },
+    { "id": "e7", "source": "tx-stop", "target": "status-available" },
+    { "id": "e8", "source": "status-available", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc005-ev-side-disconnect.json
+++ b/src/utils/scenarios/cert16-tc005-ev-side-disconnect.json
@@ -15,15 +15,21 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
+      "id": "plug-in",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Plug In", "action": "plugin" }
+    },
+    {
       "id": "status-preparing",
       "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
+      "position": { "x": 400, "y": 250 },
       "data": { "label": "Set Preparing", "status": "Preparing" }
     },
     {
       "id": "tx-start",
       "type": "transaction",
-      "position": { "x": 400, "y": 250 },
+      "position": { "x": 400, "y": 350 },
       "data": {
         "label": "Start Transaction",
         "action": "start",
@@ -33,13 +39,13 @@
     {
       "id": "status-charging",
       "type": "statusChange",
-      "position": { "x": 400, "y": 350 },
+      "position": { "x": 400, "y": 450 },
       "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
       "type": "meterValue",
-      "position": { "x": 400, "y": 450 },
+      "position": { "x": 400, "y": 550 },
       "data": {
         "label": "Auto MeterValue (5s intervals, 500 Wh, 15s max)",
         "value": 0,
@@ -54,13 +60,13 @@
     {
       "id": "plug-out",
       "type": "connectorPlug",
-      "position": { "x": 400, "y": 550 },
+      "position": { "x": 400, "y": 650 },
       "data": { "label": "Plug Out", "action": "plugout" }
     },
     {
       "id": "tx-stop",
       "type": "transaction",
-      "position": { "x": 400, "y": 650 },
+      "position": { "x": 400, "y": 750 },
       "data": {
         "label": "Stop Transaction",
         "action": "stop",
@@ -70,24 +76,25 @@
     {
       "id": "status-available",
       "type": "statusChange",
-      "position": { "x": 400, "y": 750 },
+      "position": { "x": 400, "y": 850 },
       "data": { "label": "Set Available", "status": "Available" }
     },
     {
       "id": "end-1",
       "type": "end",
-      "position": { "x": 400, "y": 850 },
+      "position": { "x": 400, "y": 950 },
       "data": { "label": "End" }
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-preparing" },
-    { "id": "e2", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e3", "source": "tx-start", "target": "status-charging" },
-    { "id": "e4", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e5", "source": "meter-auto", "target": "plug-out" },
-    { "id": "e6", "source": "plug-out", "target": "tx-stop" },
-    { "id": "e7", "source": "tx-stop", "target": "status-available" },
-    { "id": "e8", "source": "status-available", "target": "end-1" }
+    { "id": "e1", "source": "start-1", "target": "plug-in" },
+    { "id": "e2", "source": "plug-in", "target": "status-preparing" },
+    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e4", "source": "tx-start", "target": "status-charging" },
+    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e6", "source": "meter-auto", "target": "plug-out" },
+    { "id": "e7", "source": "plug-out", "target": "tx-stop" },
+    { "id": "e8", "source": "tx-stop", "target": "status-available" },
+    { "id": "e9", "source": "status-available", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc013-hard-reset.json
+++ b/src/utils/scenarios/cert16-tc013-hard-reset.json
@@ -1,0 +1,79 @@
+{
+  "id": "cert16-tc013-hard-reset",
+  "name": "Cert 1.6 Core: TC_013 Hard Reset",
+  "description": "Plug-in → StatusNotification(Preparing) → StartTransaction.req → StatusNotification(Charging); unbounded MeterValue.req; operator sends Reset(type=Hard) from CSMS, CP stops transaction with HardReset reason and reboots.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Start Transaction",
+        "action": "start",
+        "tagId": "CERT013"
+      }
+    },
+    {
+      "id": "status-charging",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Set Charging", "status": "Charging" }
+    },
+    {
+      "id": "meter-auto",
+      "type": "meterValue",
+      "position": { "x": 400, "y": 450 },
+      "data": {
+        "label": "Auto MeterValue (unbounded background)",
+        "value": 0,
+        "sendMessage": true,
+        "autoIncrement": true,
+        "incrementInterval": 5,
+        "incrementAmount": 500,
+        "maxTime": 0,
+        "maxValue": 0
+      }
+    },
+    {
+      "id": "trigger-reset",
+      "type": "csmsCallTrigger",
+      "position": { "x": 400, "y": 550 },
+      "data": {
+        "label": "Wait for Reset (Hard)",
+        "action": "Reset",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 650 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "status-preparing" },
+    { "id": "e2", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "status-charging" },
+    { "id": "e4", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e5", "source": "meter-auto", "target": "trigger-reset" },
+    { "id": "e6", "source": "trigger-reset", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc013-hard-reset.json
+++ b/src/utils/scenarios/cert16-tc013-hard-reset.json
@@ -15,15 +15,21 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
+      "id": "plug-in",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Plug In", "action": "plugin" }
+    },
+    {
       "id": "status-preparing",
       "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
+      "position": { "x": 400, "y": 250 },
       "data": { "label": "Set Preparing", "status": "Preparing" }
     },
     {
       "id": "tx-start",
       "type": "transaction",
-      "position": { "x": 400, "y": 250 },
+      "position": { "x": 400, "y": 350 },
       "data": {
         "label": "Start Transaction",
         "action": "start",
@@ -33,13 +39,13 @@
     {
       "id": "status-charging",
       "type": "statusChange",
-      "position": { "x": 400, "y": 350 },
+      "position": { "x": 400, "y": 450 },
       "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
       "type": "meterValue",
-      "position": { "x": 400, "y": 450 },
+      "position": { "x": 400, "y": 550 },
       "data": {
         "label": "Auto MeterValue (unbounded background)",
         "value": 0,
@@ -54,7 +60,7 @@
     {
       "id": "trigger-reset",
       "type": "csmsCallTrigger",
-      "position": { "x": 400, "y": 550 },
+      "position": { "x": 400, "y": 650 },
       "data": {
         "label": "Wait for Reset (Hard)",
         "action": "Reset",
@@ -64,16 +70,17 @@
     {
       "id": "end-1",
       "type": "end",
-      "position": { "x": 400, "y": 650 },
+      "position": { "x": 400, "y": 750 },
       "data": { "label": "End" }
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-preparing" },
-    { "id": "e2", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e3", "source": "tx-start", "target": "status-charging" },
-    { "id": "e4", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e5", "source": "meter-auto", "target": "trigger-reset" },
-    { "id": "e6", "source": "trigger-reset", "target": "end-1" }
+    { "id": "e1", "source": "start-1", "target": "plug-in" },
+    { "id": "e2", "source": "plug-in", "target": "status-preparing" },
+    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e4", "source": "tx-start", "target": "status-charging" },
+    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e6", "source": "meter-auto", "target": "trigger-reset" },
+    { "id": "e7", "source": "trigger-reset", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc014-soft-reset.json
+++ b/src/utils/scenarios/cert16-tc014-soft-reset.json
@@ -15,15 +15,21 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
+      "id": "plug-in",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Plug In", "action": "plugin" }
+    },
+    {
       "id": "status-preparing",
       "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
+      "position": { "x": 400, "y": 250 },
       "data": { "label": "Set Preparing", "status": "Preparing" }
     },
     {
       "id": "tx-start",
       "type": "transaction",
-      "position": { "x": 400, "y": 250 },
+      "position": { "x": 400, "y": 350 },
       "data": {
         "label": "Start Transaction",
         "action": "start",
@@ -33,13 +39,13 @@
     {
       "id": "status-charging",
       "type": "statusChange",
-      "position": { "x": 400, "y": 350 },
+      "position": { "x": 400, "y": 450 },
       "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
       "type": "meterValue",
-      "position": { "x": 400, "y": 450 },
+      "position": { "x": 400, "y": 550 },
       "data": {
         "label": "Auto MeterValue (unbounded background)",
         "value": 0,
@@ -54,7 +60,7 @@
     {
       "id": "trigger-reset",
       "type": "csmsCallTrigger",
-      "position": { "x": 400, "y": 550 },
+      "position": { "x": 400, "y": 650 },
       "data": {
         "label": "Wait for Reset (Soft)",
         "action": "Reset",
@@ -64,16 +70,17 @@
     {
       "id": "end-1",
       "type": "end",
-      "position": { "x": 400, "y": 650 },
+      "position": { "x": 400, "y": 750 },
       "data": { "label": "End" }
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-preparing" },
-    { "id": "e2", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e3", "source": "tx-start", "target": "status-charging" },
-    { "id": "e4", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e5", "source": "meter-auto", "target": "trigger-reset" },
-    { "id": "e6", "source": "trigger-reset", "target": "end-1" }
+    { "id": "e1", "source": "start-1", "target": "plug-in" },
+    { "id": "e2", "source": "plug-in", "target": "status-preparing" },
+    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e4", "source": "tx-start", "target": "status-charging" },
+    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e6", "source": "meter-auto", "target": "trigger-reset" },
+    { "id": "e7", "source": "trigger-reset", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc014-soft-reset.json
+++ b/src/utils/scenarios/cert16-tc014-soft-reset.json
@@ -1,0 +1,79 @@
+{
+  "id": "cert16-tc014-soft-reset",
+  "name": "Cert 1.6 Core: TC_014 Soft Reset",
+  "description": "Plug-in → StatusNotification(Preparing) → StartTransaction.req → StatusNotification(Charging); unbounded MeterValue.req; operator sends Reset(type=Soft) from CSMS, CP stops transaction with SoftReset reason and reboots.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Start Transaction",
+        "action": "start",
+        "tagId": "CERT014"
+      }
+    },
+    {
+      "id": "status-charging",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Set Charging", "status": "Charging" }
+    },
+    {
+      "id": "meter-auto",
+      "type": "meterValue",
+      "position": { "x": 400, "y": 450 },
+      "data": {
+        "label": "Auto MeterValue (unbounded background)",
+        "value": 0,
+        "sendMessage": true,
+        "autoIncrement": true,
+        "incrementInterval": 5,
+        "incrementAmount": 500,
+        "maxTime": 0,
+        "maxValue": 0
+      }
+    },
+    {
+      "id": "trigger-reset",
+      "type": "csmsCallTrigger",
+      "position": { "x": 400, "y": 550 },
+      "data": {
+        "label": "Wait for Reset (Soft)",
+        "action": "Reset",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 650 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "status-preparing" },
+    { "id": "e2", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "status-charging" },
+    { "id": "e4", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e5", "source": "meter-auto", "target": "trigger-reset" },
+    { "id": "e6", "source": "trigger-reset", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc019-get-configuration-all.json
+++ b/src/utils/scenarios/cert16-tc019-get-configuration-all.json
@@ -1,0 +1,49 @@
+{
+  "id": "cert16-tc019-get-configuration-all",
+  "name": "Cert 1.6 Core: TC_019_1 Retrieve All Configuration Keys",
+  "description": "CSMS sends GetConfiguration with no key filter. CP retrieves and returns all configuration keys from its store.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "trigger-get-config",
+      "type": "csmsCallTrigger",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Wait for GetConfiguration (all keys)",
+        "action": "GetConfiguration",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "status-available" },
+    {
+      "id": "e2",
+      "source": "status-available",
+      "target": "trigger-get-config"
+    },
+    { "id": "e3", "source": "trigger-get-config", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc019-get-configuration-key.json
+++ b/src/utils/scenarios/cert16-tc019-get-configuration-key.json
@@ -1,0 +1,49 @@
+{
+  "id": "cert16-tc019-get-configuration-key",
+  "name": "Cert 1.6 Core: TC_019_2 Retrieve Specific Configuration Key",
+  "description": "CSMS sends GetConfiguration requesting a specific key (e.g., HeartbeatInterval). CP retrieves and returns the requested configuration value.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "trigger-get-config",
+      "type": "csmsCallTrigger",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Wait for GetConfiguration (specific key)",
+        "action": "GetConfiguration",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "status-available" },
+    {
+      "id": "e2",
+      "source": "status-available",
+      "target": "trigger-get-config"
+    },
+    { "id": "e3", "source": "trigger-get-config", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc021-change-configuration.json
+++ b/src/utils/scenarios/cert16-tc021-change-configuration.json
@@ -1,0 +1,49 @@
+{
+  "id": "cert16-tc021-change-configuration",
+  "name": "Cert 1.6 Core: TC_021 Change Configuration",
+  "description": "CSMS sends ChangeConfiguration to update a configuration key (e.g., MeterValueSampleInterval). CP applies the change and confirms acceptance.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "trigger-change-config",
+      "type": "csmsCallTrigger",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Wait for ChangeConfiguration",
+        "action": "ChangeConfiguration",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "status-available" },
+    {
+      "id": "e2",
+      "source": "status-available",
+      "target": "trigger-change-config"
+    },
+    { "id": "e3", "source": "trigger-change-config", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc024-lock-failure.json
+++ b/src/utils/scenarios/cert16-tc024-lock-failure.json
@@ -28,7 +28,7 @@
         "label": "Connector Lock Failure",
         "status": "Faulted",
         "errorCode": "ConnectorLockFailure",
-        "errorInfo": "Connector lock failure, no transaction started"
+        "info": "Connector lock failure, no transaction started"
       }
     },
     {

--- a/src/utils/scenarios/cert16-tc024-lock-failure.json
+++ b/src/utils/scenarios/cert16-tc024-lock-failure.json
@@ -15,15 +15,27 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
+      "id": "plug-in",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Plug In", "action": "plugin" }
+    },
+    {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 250 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
       "id": "delay-1",
       "type": "delay",
-      "position": { "x": 400, "y": 150 },
+      "position": { "x": 400, "y": 350 },
       "data": { "label": "Wait 2s", "delaySeconds": 2 }
     },
     {
       "id": "status-faulted",
       "type": "statusNotification",
-      "position": { "x": 400, "y": 250 },
+      "position": { "x": 400, "y": 450 },
       "data": {
         "label": "Connector Lock Failure",
         "status": "Faulted",
@@ -34,34 +46,36 @@
     {
       "id": "delay-2",
       "type": "delay",
-      "position": { "x": 400, "y": 350 },
+      "position": { "x": 400, "y": 550 },
       "data": { "label": "Wait 2s", "delaySeconds": 2 }
     },
     {
       "id": "plug-out",
       "type": "connectorPlug",
-      "position": { "x": 400, "y": 450 },
+      "position": { "x": 400, "y": 650 },
       "data": { "label": "Plug Out", "action": "plugout" }
     },
     {
       "id": "status-available",
       "type": "statusChange",
-      "position": { "x": 400, "y": 550 },
+      "position": { "x": 400, "y": 750 },
       "data": { "label": "Set Available", "status": "Available" }
     },
     {
       "id": "end-1",
       "type": "end",
-      "position": { "x": 400, "y": 650 },
+      "position": { "x": 400, "y": 850 },
       "data": { "label": "End" }
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "delay-1" },
-    { "id": "e2", "source": "delay-1", "target": "status-faulted" },
-    { "id": "e3", "source": "status-faulted", "target": "delay-2" },
-    { "id": "e4", "source": "delay-2", "target": "plug-out" },
-    { "id": "e5", "source": "plug-out", "target": "status-available" },
-    { "id": "e6", "source": "status-available", "target": "end-1" }
+    { "id": "e1", "source": "start-1", "target": "plug-in" },
+    { "id": "e2", "source": "plug-in", "target": "status-preparing" },
+    { "id": "e3", "source": "status-preparing", "target": "delay-1" },
+    { "id": "e4", "source": "delay-1", "target": "status-faulted" },
+    { "id": "e5", "source": "status-faulted", "target": "delay-2" },
+    { "id": "e6", "source": "delay-2", "target": "plug-out" },
+    { "id": "e7", "source": "plug-out", "target": "status-available" },
+    { "id": "e8", "source": "status-available", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc024-lock-failure.json
+++ b/src/utils/scenarios/cert16-tc024-lock-failure.json
@@ -1,0 +1,67 @@
+{
+  "id": "cert16-tc024-lock-failure",
+  "name": "Cert 1.6 Core: TC_024 Start Charging Session — Lock Failure",
+  "description": "Plug-in; delay 2s; StatusNotification(Faulted, ConnectorLockFailure, no transaction started); delay 2s; plug-out → StatusNotification(Available).",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "delay-1",
+      "type": "delay",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Wait 2s", "delaySeconds": 2 }
+    },
+    {
+      "id": "status-faulted",
+      "type": "statusNotification",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Connector Lock Failure",
+        "status": "Faulted",
+        "errorCode": "ConnectorLockFailure",
+        "errorInfo": "Connector lock failure, no transaction started"
+      }
+    },
+    {
+      "id": "delay-2",
+      "type": "delay",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Wait 2s", "delaySeconds": 2 }
+    },
+    {
+      "id": "plug-out",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 450 },
+      "data": { "label": "Plug Out", "action": "plugout" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 550 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 650 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "delay-1" },
+    { "id": "e2", "source": "delay-1", "target": "status-faulted" },
+    { "id": "e3", "source": "status-faulted", "target": "delay-2" },
+    { "id": "e4", "source": "delay-2", "target": "plug-out" },
+    { "id": "e5", "source": "plug-out", "target": "status-available" },
+    { "id": "e6", "source": "status-available", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc026-remote-start-rejected.json
+++ b/src/utils/scenarios/cert16-tc026-remote-start-rejected.json
@@ -1,0 +1,66 @@
+{
+  "id": "cert16-tc026-remote-start-rejected",
+  "name": "Cert 1.6 Core: TC_026 Remote Start — Rejected",
+  "description": "Connector Available; CSMS sends RemoteStartTransaction.req; CP responds with Rejected status; no transaction starts.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "arm-override",
+      "type": "responseOverride",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Arm Rejected response for RemoteStartTransaction",
+        "action": "RemoteStartTransaction",
+        "status": "Rejected"
+      }
+    },
+    {
+      "id": "trigger-remote-start",
+      "type": "csmsCallTrigger",
+      "position": { "x": 400, "y": 350 },
+      "data": {
+        "label": "Wait for RemoteStartTransaction (will be Rejected)",
+        "action": "RemoteStartTransaction",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "delay-verify",
+      "type": "delay",
+      "position": { "x": 400, "y": 450 },
+      "data": {
+        "label": "Verify no transaction starts",
+        "delaySeconds": 3
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 550 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "status-available" },
+    { "id": "e2", "source": "status-available", "target": "arm-override" },
+    { "id": "e3", "source": "arm-override", "target": "trigger-remote-start" },
+    { "id": "e4", "source": "trigger-remote-start", "target": "delay-verify" },
+    { "id": "e5", "source": "delay-verify", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc028-remote-stop-rejected.json
+++ b/src/utils/scenarios/cert16-tc028-remote-stop-rejected.json
@@ -1,0 +1,132 @@
+{
+  "id": "cert16-tc028-remote-stop-rejected",
+  "name": "Cert 1.6 Core: TC_028 Remote Stop — Rejected",
+  "description": "Plug-in → Preparing → StartTransaction → Charging with auto-meter; CSMS sends RemoteStopTransaction.req; CP responds with Rejected status; charging continues; Local stop after delay.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "plug-in",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Plug In", "action": "plugin" }
+    },
+    {
+      "id": "status-preparing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 250 },
+      "data": { "label": "Set Preparing", "status": "Preparing" }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 350 },
+      "data": {
+        "label": "Start Transaction",
+        "action": "start",
+        "tagId": "CERT028"
+      }
+    },
+    {
+      "id": "status-charging",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 450 },
+      "data": { "label": "Set Charging", "status": "Charging" }
+    },
+    {
+      "id": "meter-auto",
+      "type": "meterValue",
+      "position": { "x": 400, "y": 550 },
+      "data": {
+        "label": "Auto MeterValue (unbounded background)",
+        "value": 0,
+        "sendMessage": true,
+        "autoIncrement": true,
+        "incrementInterval": 5,
+        "incrementAmount": 500,
+        "maxTime": 0,
+        "maxValue": 0
+      }
+    },
+    {
+      "id": "arm-override",
+      "type": "responseOverride",
+      "position": { "x": 400, "y": 650 },
+      "data": {
+        "label": "Arm Rejected response for RemoteStopTransaction",
+        "action": "RemoteStopTransaction",
+        "status": "Rejected"
+      }
+    },
+    {
+      "id": "trigger-remote-stop",
+      "type": "csmsCallTrigger",
+      "position": { "x": 400, "y": 750 },
+      "data": {
+        "label": "Wait for RemoteStopTransaction (will be Rejected)",
+        "action": "RemoteStopTransaction",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "delay-continue",
+      "type": "delay",
+      "position": { "x": 400, "y": 850 },
+      "data": {
+        "label": "Charging continues after rejection",
+        "delaySeconds": 5
+      }
+    },
+    {
+      "id": "tx-stop",
+      "type": "transaction",
+      "position": { "x": 400, "y": 950 },
+      "data": {
+        "label": "Stop Transaction (Local)",
+        "action": "stop",
+        "stopReason": "Local"
+      }
+    },
+    {
+      "id": "status-finishing",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 1050 },
+      "data": { "label": "Set Finishing", "status": "Finishing" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 1150 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 1250 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "plug-in" },
+    { "id": "e2", "source": "plug-in", "target": "status-preparing" },
+    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
+    { "id": "e4", "source": "tx-start", "target": "status-charging" },
+    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e6", "source": "meter-auto", "target": "arm-override" },
+    { "id": "e7", "source": "arm-override", "target": "trigger-remote-stop" },
+    { "id": "e8", "source": "trigger-remote-stop", "target": "delay-continue" },
+    { "id": "e9", "source": "delay-continue", "target": "tx-stop" },
+    { "id": "e10", "source": "tx-stop", "target": "status-finishing" },
+    { "id": "e11", "source": "status-finishing", "target": "status-available" },
+    { "id": "e12", "source": "status-available", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc031-unlock-unknown-connector.json
+++ b/src/utils/scenarios/cert16-tc031-unlock-unknown-connector.json
@@ -1,0 +1,45 @@
+{
+  "id": "cert16-tc031-unlock-unknown-connector",
+  "name": "Cert 1.6 Core: TC_031 Unlock Connector — Unknown Connector",
+  "description": "CSMS sends UnlockConnector for a non-existent connector ID. CP returns NotSupported per §7.46 errata 3.87.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "trigger-unlock",
+      "type": "csmsCallTrigger",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Wait for UnlockConnector (unknown id)",
+        "action": "UnlockConnector",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "status-available" },
+    { "id": "e2", "source": "status-available", "target": "trigger-unlock" },
+    { "id": "e3", "source": "trigger-unlock", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc061-clear-cache.json
+++ b/src/utils/scenarios/cert16-tc061-clear-cache.json
@@ -1,0 +1,49 @@
+{
+  "id": "cert16-tc061-clear-cache",
+  "name": "Cert 1.6 Core: TC_061 Clear Authorization Cache",
+  "description": "CSMS sends ClearCache. CP has no authorization cache (per §5.3, a CP without a cache may still accept the request) and confirms Accepted.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "trigger-clear-cache",
+      "type": "csmsCallTrigger",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Wait for ClearCache",
+        "action": "ClearCache",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "status-available" },
+    {
+      "id": "e2",
+      "source": "status-available",
+      "target": "trigger-clear-cache"
+    },
+    { "id": "e3", "source": "trigger-clear-cache", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc064-data-transfer.json
+++ b/src/utils/scenarios/cert16-tc064-data-transfer.json
@@ -1,0 +1,57 @@
+{
+  "id": "cert16-tc064-data-transfer",
+  "name": "Cert 1.6 Core: TC_064 Data Transfer to Central System",
+  "description": "CP sends DataTransfer.req (§4.3) with vendorId com.example.cert16 and test payload. CSMS response status (Accepted or UnknownVendorId) is tested on the CSMS side.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "send-data-transfer",
+      "type": "dataTransfer",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Send DataTransfer",
+        "vendorId": "com.example.cert16",
+        "messageId": "certTest",
+        "data": "hello-csms"
+      }
+    },
+    {
+      "id": "delay-1",
+      "type": "delay",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Wait 1s", "delaySeconds": 1 }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 450 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "status-available" },
+    {
+      "id": "e2",
+      "source": "status-available",
+      "target": "send-data-transfer"
+    },
+    { "id": "e3", "source": "send-data-transfer", "target": "delay-1" },
+    { "id": "e4", "source": "delay-1", "target": "end-1" }
+  ]
+}


### PR DESCRIPTION
## Summary

Second slice of #110 (stacks on #167; will be retargeted to `main` once #167 merges). Adds the remaining Core-profile certification test cases as built-in scenarios, using the engine hooks from #167:

| TC | Scenario | Mechanism |
|---|---|---|
| TC_005 | EV side disconnected | plug-out + explicit `StopTransaction(EVDisconnected)` (plug-out does not auto-stop — verified) |
| TC_013 / TC_014 | Hard / Soft reset | `csmsCallTrigger(Reset)`; the CP core performs the transaction stop + reboot itself |
| TC_019_1 / TC_019_2 | Retrieve configuration (all / specific key) | `csmsCallTrigger(GetConfiguration)` |
| TC_021 | Change configuration | `csmsCallTrigger(ChangeConfiguration)` |
| TC_024 | Lock failure | `StatusNotification(Faulted, ConnectorLockFailure)`, no transaction |
| TC_026 / TC_028 | Remote start / stop rejected | `responseOverride(…, Rejected)` + `csmsCallTrigger` |
| TC_031 | Unlock unknown connector | CP answers `NotSupported` (verified against handler) |
| TC_061 | Clear authorization cache | stub `Accepted` documented (no cache simulated) |
| TC_064 | Data transfer CP→CSMS | existing `dataTransfer` node |

Also:
- **Engine**: armed response overrides are now cleared when a scenario run ends (completion, stop and error paths) so a stopped run can't leave a stale override intercepting later calls.
- **Dispatch-layer test**: `handleCallOverride.test.ts` drives the real `OCPPMessageHandler` with a fake socket and pins event-before-response ordering, override-preempts-handler, and one-shot fall-through.
- **Docs**: `src/utils/scenarios/README.md` — mapping table for all 21 built-in certification scenarios (id ↔ TC ↔ operator action), valid override statuses per action, and the documented out-of-scope list.

## Testing

- vitest full suite: 907+ passing (behavior tests for TC_013 park/complete and TC_026 override lifecycle; template invariants cover all 21 scenarios)
- `bun test bun.test`: 131/131 (identical to base)
- `eslint .`: clean
- `tsc -b --noEmit --force` error count: 478, identical to main (zero new type errors)

## Remaining slices

Local Auth List / Reservation → Remote Trigger / Smart Charging → Firmware (final slice closes #110).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp