### PR TITLE
test(boot): remove hardcoded retryAfter date bomb in BootGate transitions

### DIFF
--- a/src/cp/application/state/machines/__tests__/BootGate.test.ts
+++ b/src/cp/application/state/machines/__tests__/BootGate.test.ts
@@ -254,7 +254,9 @@ describe("BootGate", () => {
 
     it("transitions from Idle → Rejected", () => {
       const gate = new BootGate();
-      const retryAfter = new Date("2026-07-11T12:00:00Z");
+      // Relative future date: this test exercises the default-clock path of
+      // isCallAllowed, so a hardcoded date becomes a time bomb once it passes.
+      const retryAfter = new Date(Date.now() + 60_000);
       gate.set({ status: "Rejected", retryAfter });
       expect(gate.status.status).toBe("Rejected");
       expect(gate.isCallAllowed(OCPPAction.Authorize)).toBe(false);
@@ -272,7 +274,8 @@ describe("BootGate", () => {
     it("transitions from Pending → Rejected", () => {
       const gate = new BootGate();
       gate.set({ status: "Pending" });
-      const retryAfter = new Date("2026-07-11T12:00:00Z");
+      // Relative future date — same default-clock reasoning as Idle → Rejected.
+      const retryAfter = new Date(Date.now() + 60_000);
       gate.set({ status: "Rejected", retryAfter });
       expect(gate.status.status).toBe("Rejected");
       expect(gate.isCallAllowed(OCPPAction.Authorize)).toBe(false);


### PR DESCRIPTION
## Summary

Two BootGate tests (`transitions from Idle → Rejected`, `transitions from Pending → Rejected`) hardcode `retryAfter = new Date("2026-07-11T12:00:00Z")` while calling `isCallAllowed(...)` **without** an explicit clock. Once real time passed that timestamp (2026-07-11 12:00 UTC — today), `retryAfter` became a past date, the gate correctly started allowing calls again, and both tests began failing deterministically on `main` and every branch.

Fix: use a relative future date (`Date.now() + 60_000`) in exactly those two tests. The other `retryAfter` tests in the file already pass an explicit `now` argument (or assert clock-independent behavior) and are untouched.

## Testing

- `npx vitest run src/cp/application/state/machines/__tests__/BootGate.test.ts` → 42/42 (was 40/42 since 12:00 UTC today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved boot transition test reliability by using a relative retry time.
  * Added clarifying comments for the retry behavior and timing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->