### PR TITLE
feat(scenarios): cert 1.6 Firmware/Diagnostics scenarios — completes the certification suite (#110)

### DIFF
--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -820,7 +820,9 @@ export class ChargePoint {
    * 1.6 Firmware TC_044_2 / TC_044_3) via the `SimulatedFirmwareUpdateFailure`
    * custom config key (set through a scenario `configSet` node before
    * UpdateFirmware fires): `"DownloadFailed"` diverts at the Downloaded
-   * step, `"InstallationFailed"` diverts at the Installed step.
+   * step, `"InstallationFailed"` diverts at the Installed step. The armed
+   * value is one-shot: it is consumed and cleared on the next UpdateFirmware,
+   * so a second UpdateFirmware without re-arming will run the happy path.
    */
   simulateFirmwareUpdate(retrieveDate: Date, intervalMs = 2000): void {
     if (this._firmwareUpdateInFlight) {
@@ -839,6 +841,11 @@ export class ChargePoint {
     const failureMode = this._configuration.getString(
       "SimulatedFirmwareUpdateFailure",
     );
+    // One-shot: clear the armed failure immediately so the next UpdateFirmware
+    // runs the happy path unless re-armed.
+    if (failureMode) {
+      this._configuration.applyChange("SimulatedFirmwareUpdateFailure", "");
+    }
 
     const fireStep = (index: number) => {
       if (index >= sequence.length) {

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -814,9 +814,13 @@ export class ChargePoint {
    *
    * Real charge points download a binary, install it, and reboot. The
    * simulator just walks the status machine so the CSMS observes the
-   * full happy-path. Failure paths (DownloadFailed / InstallationFailed)
-   * are reachable via TriggerMessage(FirmwareStatusNotification) for
-   * tests that want to drive them manually.
+   * full happy-path by default. Failure paths are also reachable via
+   * TriggerMessage(FirmwareStatusNotification) for tests that want to
+   * drive them manually, or pre-armed for certification scenarios (cert
+   * 1.6 Firmware TC_044_2 / TC_044_3) via the `SimulatedFirmwareUpdateFailure`
+   * custom config key (set through a scenario `configSet` node before
+   * UpdateFirmware fires): `"DownloadFailed"` diverts at the Downloaded
+   * step, `"InstallationFailed"` diverts at the Installed step.
    */
   simulateFirmwareUpdate(retrieveDate: Date, intervalMs = 2000): void {
     if (this._firmwareUpdateInFlight) {
@@ -832,6 +836,9 @@ export class ChargePoint {
     const sequence: Array<
       "Downloading" | "Downloaded" | "Installing" | "Installed"
     > = ["Downloading", "Downloaded", "Installing", "Installed"];
+    const failureMode = this._configuration.getString(
+      "SimulatedFirmwareUpdateFailure",
+    );
 
     const fireStep = (index: number) => {
       if (index >= sequence.length) {
@@ -839,7 +846,20 @@ export class ChargePoint {
         this._firmwareUpdateTimers = [];
         return;
       }
-      this.sendFirmwareStatusNotification(sequence[index]);
+      const step = sequence[index];
+      if (step === "Downloaded" && failureMode === "DownloadFailed") {
+        this.sendFirmwareStatusNotification("DownloadFailed");
+        this._firmwareUpdateInFlight = false;
+        this._firmwareUpdateTimers = [];
+        return;
+      }
+      if (step === "Installed" && failureMode === "InstallationFailed") {
+        this.sendFirmwareStatusNotification("InstallationFailed");
+        this._firmwareUpdateInFlight = false;
+        this._firmwareUpdateTimers = [];
+        return;
+      }
+      this.sendFirmwareStatusNotification(step);
       const t = setTimeout(() => fireStep(index + 1), intervalMs);
       this._firmwareUpdateTimers.push(t);
     };

--- a/src/cp/domain/charge-point/Configuration.ts
+++ b/src/cp/domain/charge-point/Configuration.ts
@@ -403,6 +403,16 @@ export const ConfigurationKeys = {
       readonly: false,
       type: "string",
     } as StringConfigurationKey,
+    // Cert 1.6 Firmware TC_044_2/TC_044_3: pre-arm `simulateFirmwareUpdate`
+    // to divert onto a failure status instead of completing the happy
+    // path. Set via the scenario `configSet` node before UpdateFirmware
+    // fires. "" (default) = no failure injected.
+    SimulatedFirmwareUpdateFailure: {
+      name: "SimulatedFirmwareUpdateFailure",
+      required: false,
+      readonly: false,
+      type: "string",
+    } as StringConfigurationKey,
   },
 };
 
@@ -560,5 +570,6 @@ export const defaultConfiguration: (cp: ChargePoint) => Configuration = (
 
     // ── Custom (non-standard) ──────────────────────────────────────────
     strVal(ConfigurationKeys.Custom.OcppServer, cp.wsUrl),
+    strVal(ConfigurationKeys.Custom.SimulatedFirmwareUpdateFailure, ""),
   ];
 };

--- a/src/cp/domain/charge-point/__tests__/ChargePoint.firmwareFailure.test.ts
+++ b/src/cp/domain/charge-point/__tests__/ChargePoint.firmwareFailure.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChargePoint } from "../ChargePoint";
+import type { BootNotification } from "../../types/OcppTypes";
+import { DefaultBootNotification } from "../../types/OcppTypes";
+
+/**
+ * Cert 1.6 Firmware TC_044_2 (Download Failed) / TC_044_3 (Installation
+ * Failed): `simulateFirmwareUpdate` normally walks the happy-path status
+ * train (Downloading → Downloaded → Installing → Installed). Setting the
+ * `SimulatedFirmwareUpdateFailure` custom config key — the same seam a
+ * scenario's `configSet` node writes through before UpdateFirmware fires —
+ * diverts it onto a failure status instead.
+ */
+
+const bootNotification: BootNotification = DefaultBootNotification;
+
+function buildChargePoint(): ChargePoint {
+  return new ChargePoint(
+    "test-cp-firmware-failure",
+    bootNotification,
+    1,
+    "ws://localhost:8080",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+}
+
+describe("ChargePoint.simulateFirmwareUpdate — pre-armed failure outcomes", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("TC_044_2: SimulatedFirmwareUpdateFailure=DownloadFailed diverts after Downloading", async () => {
+    const cp = buildChargePoint();
+    const status = cp.configuration.applyChange(
+      "SimulatedFirmwareUpdateFailure",
+      "DownloadFailed",
+    );
+    expect(status).toBe("Accepted");
+
+    const sent: string[] = [];
+    vi.spyOn(cp, "sendFirmwareStatusNotification").mockImplementation((s) => {
+      sent.push(s);
+    });
+
+    cp.simulateFirmwareUpdate(new Date(Date.now() - 1000));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sent).toEqual(["Downloading"]);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(sent).toEqual(["Downloading", "DownloadFailed"]);
+
+    // Sequence stops here — no Installing/Installed after a download failure.
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(sent).toEqual(["Downloading", "DownloadFailed"]);
+  });
+
+  it("TC_044_3: SimulatedFirmwareUpdateFailure=InstallationFailed diverts after Installing", async () => {
+    const cp = buildChargePoint();
+    const status = cp.configuration.applyChange(
+      "SimulatedFirmwareUpdateFailure",
+      "InstallationFailed",
+    );
+    expect(status).toBe("Accepted");
+
+    const sent: string[] = [];
+    vi.spyOn(cp, "sendFirmwareStatusNotification").mockImplementation((s) => {
+      sent.push(s);
+    });
+
+    cp.simulateFirmwareUpdate(new Date(Date.now() - 1000));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sent).toEqual(["Downloading"]);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(sent).toEqual(["Downloading", "Downloaded"]);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(sent).toEqual(["Downloading", "Downloaded", "Installing"]);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(sent).toEqual([
+      "Downloading",
+      "Downloaded",
+      "Installing",
+      "InstallationFailed",
+    ]);
+  });
+
+  it("default (no config key set) still completes the happy path", async () => {
+    const cp = buildChargePoint();
+    const sent: string[] = [];
+    vi.spyOn(cp, "sendFirmwareStatusNotification").mockImplementation((s) => {
+      sent.push(s);
+    });
+
+    cp.simulateFirmwareUpdate(new Date(Date.now() - 1000));
+    await vi.advanceTimersByTimeAsync(6000);
+    expect(sent).toEqual([
+      "Downloading",
+      "Downloaded",
+      "Installing",
+      "Installed",
+    ]);
+  });
+});

--- a/src/cp/domain/charge-point/__tests__/ChargePoint.firmwareFailure.test.ts
+++ b/src/cp/domain/charge-point/__tests__/ChargePoint.firmwareFailure.test.ts
@@ -111,4 +111,33 @@ describe("ChargePoint.simulateFirmwareUpdate — pre-armed failure outcomes", ()
       "Installed",
     ]);
   });
+
+  it("one-shot: after DownloadFailed, second UpdateFirmware (without re-arm) completes happy path", async () => {
+    const cp = buildChargePoint();
+    const sent: string[] = [];
+    vi.spyOn(cp, "sendFirmwareStatusNotification").mockImplementation((s) => {
+      sent.push(s);
+    });
+
+    // First UpdateFirmware: arm the failure
+    cp.configuration.applyChange(
+      "SimulatedFirmwareUpdateFailure",
+      "DownloadFailed",
+    );
+    cp.simulateFirmwareUpdate(new Date(Date.now() - 1000));
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(sent).toEqual(["Downloading", "DownloadFailed"]);
+
+    // Second UpdateFirmware: no re-arm — arm was auto-cleared by the first call
+    // Should now complete the happy path
+    sent.length = 0;
+    cp.simulateFirmwareUpdate(new Date(Date.now() - 1000));
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(sent).toEqual([
+      "Downloading",
+      "Downloaded",
+      "Installing",
+      "Installed",
+    ]);
+  });
 });

--- a/src/utils/scenarioTemplates.test.ts
+++ b/src/utils/scenarioTemplates.test.ts
@@ -56,6 +56,8 @@ const EXPECTED_CERT16_IDS = [
   "cert16-tc066-get-composite-schedule",
   "cert16-tc067-clear-charging-profile",
   "cert16-tc044-1-firmware-update",
+  "cert16-tc044-2-firmware-download-failed",
+  "cert16-tc044-3-firmware-install-failed",
   "cert16-tc045-1-get-diagnostics",
 ];
 

--- a/src/utils/scenarioTemplates.test.ts
+++ b/src/utils/scenarioTemplates.test.ts
@@ -55,6 +55,8 @@ const EXPECTED_CERT16_IDS = [
   "cert16-tc059-remote-start-with-profile",
   "cert16-tc066-get-composite-schedule",
   "cert16-tc067-clear-charging-profile",
+  "cert16-tc044-1-firmware-update",
+  "cert16-tc045-1-get-diagnostics",
 ];
 
 /** BFS from the single start node; true if any END node is reachable. */

--- a/src/utils/scenarioTemplates.ts
+++ b/src/utils/scenarioTemplates.ts
@@ -58,6 +58,10 @@ import cert16Tc059RemoteStartWithProfileJson from "./scenarios/cert16-tc059-remo
 import cert16Tc066GetCompositeScheduleJson from "./scenarios/cert16-tc066-get-composite-schedule.json";
 import cert16Tc067ClearChargingProfileJson from "./scenarios/cert16-tc067-clear-charging-profile.json";
 
+// OCPP 1.6 Firmware certification scenarios (issue #110, PR 5).
+import cert16Tc044_1FirmwareUpdateJson from "./scenarios/cert16-tc044-1-firmware-update.json";
+import cert16Tc045_1GetDiagnosticsJson from "./scenarios/cert16-tc045-1-get-diagnostics.json";
+
 export interface ScenarioTemplate {
   id: string;
   name: string;
@@ -195,6 +199,11 @@ export const scenarioTemplates: ScenarioTemplate[] = [
   templateFromJson(cert16Tc059RemoteStartWithProfileJson as ScenarioDefinition),
   templateFromJson(cert16Tc066GetCompositeScheduleJson as ScenarioDefinition),
   templateFromJson(cert16Tc067ClearChargingProfileJson as ScenarioDefinition),
+
+  // OCPP 1.6 Firmware certification scenarios (issue #110, PR 5) —
+  // grouped together so they surface as a block in the template picker.
+  templateFromJson(cert16Tc044_1FirmwareUpdateJson as ScenarioDefinition),
+  templateFromJson(cert16Tc045_1GetDiagnosticsJson as ScenarioDefinition),
 ];
 
 export function getTemplateById(

--- a/src/utils/scenarioTemplates.ts
+++ b/src/utils/scenarioTemplates.ts
@@ -60,6 +60,8 @@ import cert16Tc067ClearChargingProfileJson from "./scenarios/cert16-tc067-clear-
 
 // OCPP 1.6 Firmware certification scenarios (issue #110, PR 5).
 import cert16Tc044_1FirmwareUpdateJson from "./scenarios/cert16-tc044-1-firmware-update.json";
+import cert16Tc044_2FirmwareDownloadFailedJson from "./scenarios/cert16-tc044-2-firmware-download-failed.json";
+import cert16Tc044_3FirmwareInstallFailedJson from "./scenarios/cert16-tc044-3-firmware-install-failed.json";
 import cert16Tc045_1GetDiagnosticsJson from "./scenarios/cert16-tc045-1-get-diagnostics.json";
 
 export interface ScenarioTemplate {
@@ -203,6 +205,12 @@ export const scenarioTemplates: ScenarioTemplate[] = [
   // OCPP 1.6 Firmware certification scenarios (issue #110, PR 5) —
   // grouped together so they surface as a block in the template picker.
   templateFromJson(cert16Tc044_1FirmwareUpdateJson as ScenarioDefinition),
+  templateFromJson(
+    cert16Tc044_2FirmwareDownloadFailedJson as ScenarioDefinition,
+  ),
+  templateFromJson(
+    cert16Tc044_3FirmwareInstallFailedJson as ScenarioDefinition,
+  ),
   templateFromJson(cert16Tc045_1GetDiagnosticsJson as ScenarioDefinition),
 ];
 

--- a/src/utils/scenarios/README.md
+++ b/src/utils/scenarios/README.md
@@ -52,6 +52,10 @@ These built-in JSON templates implement the Charge Point side of OCPP 1.6 certif
 | cert16-tc059-remote-start-with-profile              | TC_059   | Remote Start with Charging Profile        | SmartCharging | Send RemoteStartTransaction with attached ChargingProfile. Verify the CP accepts and starts the transaction but does not store or apply the profile (per §5.11; Core CP may ignore SmartCharging profiles).                                    |
 | cert16-tc066-get-composite-schedule                 | TC_066   | Get Composite Schedule                    | SmartCharging | Send SetChargingProfile then GetCompositeSchedule in sequence (tests dual-park re-entry). Verify both requests are accepted.                                                                                                                   |
 | cert16-tc067-clear-charging-profile                 | TC_067   | Clear Charging Profile                    | SmartCharging | Send SetChargingProfile to store a profile. Send ClearChargingProfile. Verify CP clears the profile and responds with Accepted.                                                                                                                |
+| cert16-tc044-1-firmware-update                      | TC_044.1 | Firmware Update — Download and Install    | Firmware      | CSMS sends UpdateFirmware.req. Verify CP progresses through FirmwareStatusNotification states Downloading → Downloaded → Installing → Installed (~6 seconds simulated).                                                                        |
+| cert16-tc044-2-firmware-download-failed             | TC_044.2 | Firmware Update — Download Failed         | Firmware      | Pre-arms SimulatedFirmwareUpdateFailure=DownloadFailed (one-shot config auto-cleared after next UpdateFirmware). CSMS sends UpdateFirmware.req. Verify CP sends Downloading then DownloadFailed.                                               |
+| cert16-tc044-3-firmware-install-failed              | TC_044.3 | Firmware Update — Installation Failed     | Firmware      | Pre-arms SimulatedFirmwareUpdateFailure=InstallationFailed (one-shot config auto-cleared after next UpdateFirmware). CSMS sends UpdateFirmware.req. Verify CP progresses Downloading → Downloaded → Installing → InstallationFailed.           |
+| cert16-tc045-1-get-diagnostics                      | TC_045.1 | Get Diagnostics                           | Firmware      | CSMS sends GetDiagnostics.req with an upload location. CP responds with fileName and sends DiagnosticsStatusNotification (Uploading, then Uploaded or UploadFailed depending on HTTP response).                                                |
 
 ## Numbering Note
 
@@ -85,13 +89,11 @@ When using the `responseOverride` node to arm a one-shot response override for a
 
 ## Out-of-Scope
 
-The following test cases are not yet covered by scenarios:
+The following test cases are not covered by scenarios:
 
-- **TC_007** (Cached Authorization) — No scenario-drivable authorization flow with caching infrastructure.
+- **TC_007** (Cached Authorization) — No scenario-drivable Authorize flow with cache orchestration.
 - **TC_023** (Authorize Outcome Variants) — No scenario-drivable Authorize request/response orchestration.
-- **TC_032, TC_037, TC_039** (Offline Power Failure, Offline Transactions) — No offline transaction queue or transaction replication orchestration in the scenario engine.
-- **TC_047** (Reservation Expiry) — CP core expires reservations passively. The Reserved → Available transition is not emitted as a status change; it occurs internally on TTL expiry. No observable flow for scenario verification.
-- **TC_049** (Charge-Point-Wide Reservation) — CP has no connector 0. ReserveNow requests for connectorId 0 are rejected by core. No distinct behavior to verify beyond the rejection itself.
+- **TC_032, TC_037, TC_039** (Offline Power Failure, Offline Transactions) — No offline transaction queue or transaction replication in the scenario engine.
+- **TC_047** (Reservation Expiry) — CP expires reservations passively on TTL; transition is internal, not observable as a status change.
+- **TC_049** (Charge-Point-Wide Reservation) — CP has no connector 0; ReserveNow(connectorId=0) is rejected by core; no distinct behavior to verify.
 - **TC_073–TC_088** (Security, Certificates, Key Provisioning) — TLS/PKI infrastructure and security setup are outside the requested feature profiles.
-
-Support for additional RemoteTrigger cases, SmartCharging, and Firmware Management profiles will be added in follow-up releases.

--- a/src/utils/scenarios/cert16-tc044-1-firmware-update.json
+++ b/src/utils/scenarios/cert16-tc044-1-firmware-update.json
@@ -1,0 +1,63 @@
+{
+  "id": "cert16-tc044-1-firmware-update",
+  "name": "Cert 1.6 Firmware: TC_044_1 Firmware Update — Download and Install",
+  "description": "CSMS sends UpdateFirmware.req with a retrieveDate in the near past; the CP progresses through FirmwareStatusNotification states Downloading → Downloaded → Installing → Installed (simulated at 2-second intervals, ~6 seconds total sequence). BootNotification is not re-sent at completion.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "trigger-firmware-update",
+      "type": "csmsCallTrigger",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Wait for UpdateFirmware",
+        "action": "UpdateFirmware",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "delay-firmware-sequence",
+      "type": "delay",
+      "position": { "x": 400, "y": 350 },
+      "data": {
+        "label": "CP simulates Downloading → Downloaded → Installing → Installed",
+        "delaySeconds": 10
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 450 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "status-available" },
+    {
+      "id": "e2",
+      "source": "status-available",
+      "target": "trigger-firmware-update"
+    },
+    {
+      "id": "e3",
+      "source": "trigger-firmware-update",
+      "target": "delay-firmware-sequence"
+    },
+    { "id": "e4", "source": "delay-firmware-sequence", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc044-2-firmware-download-failed.json
+++ b/src/utils/scenarios/cert16-tc044-2-firmware-download-failed.json
@@ -1,0 +1,82 @@
+{
+  "id": "cert16-tc044-2-firmware-download-failed",
+  "name": "Cert 1.6 Firmware: TC_044_2 Firmware Update — Download Failed",
+  "description": "Pre-arms the CP via the custom `SimulatedFirmwareUpdateFailure` config key (set to 'DownloadFailed' through a local configSet step) so the simulated firmware train diverts after Downloading: CSMS sends UpdateFirmware.req with a retrieveDate in the near past; the CP sends FirmwareStatusNotification(Downloading) then FirmwareStatusNotification(DownloadFailed) and stops — Installing/Installed are never reached.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "config-arm-download-failed",
+      "type": "configSet",
+      "position": { "x": 400, "y": 150 },
+      "data": {
+        "label": "Arm SimulatedFirmwareUpdateFailure=DownloadFailed",
+        "key": "SimulatedFirmwareUpdateFailure",
+        "value": "DownloadFailed"
+      }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 250 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "trigger-firmware-update",
+      "type": "csmsCallTrigger",
+      "position": { "x": 400, "y": 350 },
+      "data": {
+        "label": "Wait for UpdateFirmware",
+        "action": "UpdateFirmware",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "delay-firmware-sequence",
+      "type": "delay",
+      "position": { "x": 400, "y": 450 },
+      "data": {
+        "label": "CP simulates Downloading → DownloadFailed",
+        "delaySeconds": 6
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 550 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    {
+      "id": "e1",
+      "source": "start-1",
+      "target": "config-arm-download-failed"
+    },
+    {
+      "id": "e2",
+      "source": "config-arm-download-failed",
+      "target": "status-available"
+    },
+    {
+      "id": "e3",
+      "source": "status-available",
+      "target": "trigger-firmware-update"
+    },
+    {
+      "id": "e4",
+      "source": "trigger-firmware-update",
+      "target": "delay-firmware-sequence"
+    },
+    { "id": "e5", "source": "delay-firmware-sequence", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc044-2-firmware-download-failed.json
+++ b/src/utils/scenarios/cert16-tc044-2-firmware-download-failed.json
@@ -1,7 +1,7 @@
 {
   "id": "cert16-tc044-2-firmware-download-failed",
   "name": "Cert 1.6 Firmware: TC_044_2 Firmware Update — Download Failed",
-  "description": "Pre-arms the CP via the custom `SimulatedFirmwareUpdateFailure` config key (set to 'DownloadFailed' through a local configSet step) so the simulated firmware train diverts after Downloading: CSMS sends UpdateFirmware.req with a retrieveDate in the near past; the CP sends FirmwareStatusNotification(Downloading) then FirmwareStatusNotification(DownloadFailed) and stops — Installing/Installed are never reached.",
+  "description": "Pre-arms the CP via the custom `SimulatedFirmwareUpdateFailure` config key (set to 'DownloadFailed' through a local configSet step) so the simulated firmware train diverts after Downloading: CSMS sends UpdateFirmware.req with a retrieveDate in the near past; the CP sends FirmwareStatusNotification(Downloading) then FirmwareStatusNotification(DownloadFailed) and stops — Installing/Installed are never reached. The arm applies to the next UpdateFirmware only and clears itself automatically.",
   "targetType": "connector",
   "targetId": 1,
   "trigger": { "type": "manual" },

--- a/src/utils/scenarios/cert16-tc044-3-firmware-install-failed.json
+++ b/src/utils/scenarios/cert16-tc044-3-firmware-install-failed.json
@@ -1,7 +1,7 @@
 {
   "id": "cert16-tc044-3-firmware-install-failed",
   "name": "Cert 1.6 Firmware: TC_044_3 Firmware Update — Installation Failed",
-  "description": "Pre-arms the CP via the custom `SimulatedFirmwareUpdateFailure` config key (set to 'InstallationFailed' through a local configSet step) so the simulated firmware train diverts after Installing: CSMS sends UpdateFirmware.req with a retrieveDate in the near past; the CP progresses through FirmwareStatusNotification states Downloading → Downloaded → Installing, then sends FirmwareStatusNotification(InstallationFailed) instead of Installed.",
+  "description": "Pre-arms the CP via the custom `SimulatedFirmwareUpdateFailure` config key (set to 'InstallationFailed' through a local configSet step) so the simulated firmware train diverts after Installing: CSMS sends UpdateFirmware.req with a retrieveDate in the near past; the CP progresses through FirmwareStatusNotification states Downloading → Downloaded → Installing, then sends FirmwareStatusNotification(InstallationFailed) instead of Installed. The arm applies to the next UpdateFirmware only and clears itself automatically.",
   "targetType": "connector",
   "targetId": 1,
   "trigger": { "type": "manual" },

--- a/src/utils/scenarios/cert16-tc044-3-firmware-install-failed.json
+++ b/src/utils/scenarios/cert16-tc044-3-firmware-install-failed.json
@@ -1,0 +1,82 @@
+{
+  "id": "cert16-tc044-3-firmware-install-failed",
+  "name": "Cert 1.6 Firmware: TC_044_3 Firmware Update — Installation Failed",
+  "description": "Pre-arms the CP via the custom `SimulatedFirmwareUpdateFailure` config key (set to 'InstallationFailed' through a local configSet step) so the simulated firmware train diverts after Installing: CSMS sends UpdateFirmware.req with a retrieveDate in the near past; the CP progresses through FirmwareStatusNotification states Downloading → Downloaded → Installing, then sends FirmwareStatusNotification(InstallationFailed) instead of Installed.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "config-arm-install-failed",
+      "type": "configSet",
+      "position": { "x": 400, "y": 150 },
+      "data": {
+        "label": "Arm SimulatedFirmwareUpdateFailure=InstallationFailed",
+        "key": "SimulatedFirmwareUpdateFailure",
+        "value": "InstallationFailed"
+      }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 250 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "trigger-firmware-update",
+      "type": "csmsCallTrigger",
+      "position": { "x": 400, "y": 350 },
+      "data": {
+        "label": "Wait for UpdateFirmware",
+        "action": "UpdateFirmware",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "delay-firmware-sequence",
+      "type": "delay",
+      "position": { "x": 400, "y": 450 },
+      "data": {
+        "label": "CP simulates Downloading → Downloaded → Installing → InstallationFailed",
+        "delaySeconds": 10
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 550 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    {
+      "id": "e1",
+      "source": "start-1",
+      "target": "config-arm-install-failed"
+    },
+    {
+      "id": "e2",
+      "source": "config-arm-install-failed",
+      "target": "status-available"
+    },
+    {
+      "id": "e3",
+      "source": "status-available",
+      "target": "trigger-firmware-update"
+    },
+    {
+      "id": "e4",
+      "source": "trigger-firmware-update",
+      "target": "delay-firmware-sequence"
+    },
+    { "id": "e5", "source": "delay-firmware-sequence", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc045-1-get-diagnostics.json
+++ b/src/utils/scenarios/cert16-tc045-1-get-diagnostics.json
@@ -1,0 +1,63 @@
+{
+  "id": "cert16-tc045-1-get-diagnostics",
+  "name": "Cert 1.6 Firmware: TC_045_1 Get Diagnostics",
+  "description": "CSMS sends GetDiagnostics.req with an upload location; CP responds with fileName 'diagnostics.txt' and sends DiagnosticsStatusNotification (Uploading, then Uploaded on successful POST to the location, or UploadFailed if the location is unreachable or returns non-2xx HTTP status — both outcomes are certification-relevant).",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "status-available",
+      "type": "statusChange",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Set Available", "status": "Available" }
+    },
+    {
+      "id": "trigger-get-diagnostics",
+      "type": "csmsCallTrigger",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Wait for GetDiagnostics",
+        "action": "GetDiagnostics",
+        "timeout": 0
+      }
+    },
+    {
+      "id": "delay-diagnostics-upload",
+      "type": "delay",
+      "position": { "x": 400, "y": 350 },
+      "data": {
+        "label": "CP uploads diagnostics and reports status",
+        "delaySeconds": 5
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 450 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "status-available" },
+    {
+      "id": "e2",
+      "source": "status-available",
+      "target": "trigger-get-diagnostics"
+    },
+    {
+      "id": "e3",
+      "source": "trigger-get-diagnostics",
+      "target": "delay-diagnostics-upload"
+    },
+    { "id": "e4", "source": "delay-diagnostics-upload", "target": "end-1" }
+  ]
+}


### PR DESCRIPTION
## Summary

Final slice of the built-in OCPP 1.6 certification scenario series (stacks on #171; retarget to `main` as predecessors merge).

Closes #110

| TC | Scenario | Mechanism |
|---|---|---|
| TC_044_1 | Firmware Update — Download and Install | `csmsCallTrigger(UpdateFirmware)`; core simulates Downloading → Downloaded → Installing → Installed (6 s); BootNotification is not re-sent — stated honestly |
| TC_044_2 / TC_044_3 | Firmware Update — Download Failed / Installation Failed | new 35-line core seam: `SimulatedFirmwareUpdateFailure` config key, armed by the scenario's config-set step; **one-shot** — consumed and self-cleared (memory + SQLite) on the next UpdateFirmware, proven by an un-rearmed second-run test |
| TC_045_1 | Get Diagnostics | core answers a fileName and reports Uploading → Uploaded (or UploadFailed for an unreachable location) |

## Series result (5 PRs: #167 → #168 → #170 → #171 → this)

**44 built-in certification scenarios across all six profiles the issue requested** — Core (15), Remote Trigger (7), Local Auth List (6), Reservation (7), Smart Charging (5), Firmware/Diagnostics (4) — each with an operator-facing description of the CSMS-side steps, plus a README mapping table (scenario ↔ TC ↔ operator action, valid override statuses per action).

Documented out of scope with reasons (README): authorize-outcome variants TC_023 / cached-id TC_007 (no scenario-drivable Authorize flow), power-failure & offline TC_032/037/039 (no offline-queue orchestration), reservation expiry TC_047 (core cleanup is passive — nothing observable), CP-wide reservation TC_049 (no connector 0), security TC_073–088 (TLS/PKI infra).

## Testing

- New unit tests for the firmware failure seam (both failure paths + happy-path regression + one-shot consumption)
- vitest 1029 passing (+ the 2 known BootGate date-bomb failures fixed separately in #169); `bun test bun.test` 131/131; `eslint .` clean; `tsc -b --noEmit --force` error count 478 == main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp