### PR TITLE
fix: remove duplicate lifecycle StatusNotifications by deleting redundant scenario nodes (#176)

### DIFF
--- a/src/cp/application/scenario/__tests__/cert16RemoteStart.test.ts
+++ b/src/cp/application/scenario/__tests__/cert16RemoteStart.test.ts
@@ -8,6 +8,9 @@ import {
   OCPPStatus,
 } from "../../../domain/types/OcppTypes";
 import { getTemplateById } from "../../../../utils/scenarioTemplates";
+import { StartTransactionResultHandler } from "../../../infrastructure/transport/handlers/callresult/TransactionResultHandlers";
+import { Logger } from "../../../shared/Logger";
+import type { HandlerContext } from "../../../infrastructure/transport/handlers/MessageHandlerRegistry";
 
 function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -76,6 +79,20 @@ describe("cert16-tc010-remote-start (built-in certification template)", () => {
       // Simulate the CSMS issuing RemoteStartTransaction.req — the same
       // entry point the real RemoteStartTransaction handler uses.
       cp.notifyRemoteStartReceived(1, "CERT010-LIVE-TAG");
+
+      // The scenario's own "Set Preparing"/"Set Charging" nodes were
+      // removed (#176) — Preparing is now driven intrinsically by
+      // ChargePoint.startTransaction() (request-time), and Charging is
+      // only driven by StartTransactionResultHandler on the
+      // StartTransaction.conf CALLRESULT. This test has no live transport
+      // (see newChargePoint's comment), so simulate that CALLRESULT
+      // arriving directly, exactly as a real CSMS accepting the start
+      // would trigger it.
+      await waitUntil(() => connector!.transaction !== null);
+      new StartTransactionResultHandler(1).handle(
+        { transactionId: 1010, idTagInfo: { status: "Accepted" } },
+        { chargePoint: cp, logger: new Logger() } satisfies HandlerContext,
+      );
 
       await waitUntil(() => connector!.status === OCPPStatus.Charging);
 

--- a/src/cp/application/scenario/__tests__/exactlyOnceLifecycleStatus.test.ts
+++ b/src/cp/application/scenario/__tests__/exactlyOnceLifecycleStatus.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+
+import { ScenarioExecutor } from "../ScenarioExecutor";
+import { createScenarioExecutorCallbacks } from "../ScenarioRuntime";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import {
+  DefaultBootNotification,
+  OCPPStatus,
+} from "../../../domain/types/OcppTypes";
+import { getTemplateById } from "../../../../utils/scenarioTemplates";
+import { StartTransactionResultHandler } from "../../../infrastructure/transport/handlers/callresult/TransactionResultHandlers";
+import { Logger } from "../../../shared/Logger";
+import type { HandlerContext } from "../../../infrastructure/transport/handlers/MessageHandlerRegistry";
+
+/**
+ * Issue #176: Preparing, Charging, Finishing, and post-stop Available are
+ * now driven exclusively by ChargePoint's own startTransaction/
+ * stopTransaction cascade (see ChargePoint.ts and the 17 scenario JSONs
+ * edited alongside this test) rather than by scenario `statusChange`
+ * nodes. This is the coverage gap flagged in review: a real end-to-end
+ * regression pinning that, driven purely by the domain, each of the four
+ * lifecycle statuses is emitted EXACTLY ONCE per run — no duplicates
+ * (the bug #176 fixed) and no missing transitions (a regression the node
+ * removal in isolation could introduce).
+ *
+ * Runs the REAL ScenarioExecutor against a REAL ChargePoint (no mocks),
+ * following the harness established by cert16CoreScenarios.test.ts /
+ * cert16RemoteStart.test.ts. There is no live transport, so — exactly as
+ * in cert16RemoteStart.test.ts — the StartTransaction.conf CALLRESULT
+ * that drives Charging is simulated directly via
+ * StartTransactionResultHandler.
+ */
+
+function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+async function waitUntil(predicate: () => boolean, ms = 500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > ms) {
+      throw new Error("Timed out waiting for predicate");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function newChargePoint(id: string): ChargePoint {
+  // No real transport connection is ever attempted (unused local port) —
+  // matches the pattern used throughout src/cp/application/scenario/__tests__.
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    "ws://127.0.0.1:9/",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  return cp;
+}
+
+/** Simulate the CSMS's StartTransaction.conf CALLRESULT — the only thing
+ *  that drives Charging (StartTransactionResultHandler), which never
+ *  arrives on its own with no live transport connected. */
+function simulateStartTransactionAccepted(
+  cp: ChargePoint,
+  connectorId: number,
+  transactionId: number,
+): void {
+  new StartTransactionResultHandler(connectorId).handle(
+    { transactionId, idTagInfo: { status: "Accepted" } },
+    { chargePoint: cp, logger: new Logger() } satisfies HandlerContext,
+  );
+}
+
+const LIFECYCLE_STATUSES = [
+  OCPPStatus.Preparing,
+  OCPPStatus.Charging,
+  OCPPStatus.Finishing,
+  OCPPStatus.Available,
+] as const;
+
+function countOccurrences(statuses: OCPPStatus[], target: OCPPStatus): number {
+  return statuses.filter((s) => s === target).length;
+}
+
+function assertExactlyOnceEach(statuses: OCPPStatus[]): void {
+  for (const status of LIFECYCLE_STATUSES) {
+    expect(
+      countOccurrences(statuses, status),
+      `expected ${status} exactly once in [${statuses.join(", ")}]`,
+    ).toBe(1);
+  }
+}
+
+describe("domain-driven lifecycle status is emitted exactly once (#176)", () => {
+  it("essential-cp-behavior (zero status nodes): Preparing/Charging/Finishing/Available each fire exactly once, driven entirely by the domain", async () => {
+    const template = getTemplateById("essential-cp-behavior");
+    expect(template).toBeDefined();
+
+    const cp = newChargePoint("CP-176-ESSENTIAL");
+    const connector = cp.getConnector(1);
+    expect(connector).toBeDefined();
+
+    const statuses: OCPPStatus[] = [];
+    cp.events.on("connectorStatusChange", (e) => statuses.push(e.status));
+
+    const scenario = template!.createScenario("CP-176-ESSENTIAL", 1);
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector: connector!,
+    });
+    const executor = new ScenarioExecutor(scenario, callbacks);
+    const execution = executor.start();
+
+    try {
+      // Scenario runs delay-2s -> plug-in -> delay-1s (real wall time,
+      // ~3s) before parking on the remoteStartTrigger node.
+      await waitUntil(() => cp.isScenarioHandled(1), 6000);
+      expect(connector!.transaction).toBeNull();
+
+      cp.notifyRemoteStartReceived(1, "ESSENTIAL-LIVE-TAG");
+
+      // tx-start runs: ChargePoint.startTransaction() drives Preparing
+      // intrinsically (#176 domain fix), before StartTransaction.req is
+      // even enqueued.
+      await waitUntil(() => connector!.transaction !== null);
+      expect(connector!.status).toBe(OCPPStatus.Preparing);
+
+      simulateStartTransactionAccepted(cp, 1, 5501);
+      await waitUntil(() => connector!.status === OCPPStatus.Charging);
+
+      // meter-auto uses stopMode "evSettings" (capacity 75kWh, 20% ->
+      // 80%), which blocks the scenario node on a real meter-value
+      // threshold (45,000 Wh) with no timeout. Fast-forward past it
+      // directly rather than waiting on real increments — resolves the
+      // meterValueChange-driven wait exactly as a real charging session
+      // crossing the threshold would.
+      await waitUntil(() => connector!.isAutoMeterValueActive());
+      cp.setMeterValue(1, 100_000);
+
+      // Scenario proceeds past meter-auto and parks on remoteStopTrigger.
+      await waitUntil(() => cp.isScenarioStopHandled(1), 2000);
+
+      const txId = connector!.transaction!.id;
+      if (txId == null) {
+        throw new Error("expected transaction to have an id");
+      }
+      cp.notifyRemoteStopReceived(1, txId);
+
+      // ChargePoint.stopTransaction() drives Finishing -> Available
+      // synchronously and unconditionally (no scenario node involved).
+      await waitUntil(() => connector!.status === OCPPStatus.Available);
+
+      // plug-out is a no-op callback; end-1 follows immediately.
+      await timeout(execution, 2000);
+
+      assertExactlyOnceEach(statuses);
+    } finally {
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      ).catch(() => undefined);
+    }
+  }, 10000);
+
+  it("cert16-tc011-remote-start-stop (edited, redundant status nodes removed): Preparing/Charging/Finishing/Available each fire exactly once", async () => {
+    const template = getTemplateById("cert16-tc011-remote-start-stop");
+    expect(template).toBeDefined();
+
+    const cp = newChargePoint("CP-176-TC011");
+    const connector = cp.getConnector(1);
+    expect(connector).toBeDefined();
+
+    const statuses: OCPPStatus[] = [];
+    cp.events.on("connectorStatusChange", (e) => statuses.push(e.status));
+
+    const scenario = template!.createScenario("CP-176-TC011", 1);
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector: connector!,
+    });
+    const executor = new ScenarioExecutor(scenario, callbacks);
+    const execution = executor.start();
+
+    try {
+      // No leading delay in this scenario — parks on remoteStartTrigger
+      // almost immediately.
+      await waitUntil(() => cp.isScenarioHandled(1), 3000);
+      expect(connector!.transaction).toBeNull();
+
+      cp.notifyRemoteStartReceived(1, "CERT011-LIVE-TAG");
+
+      await waitUntil(() => connector!.transaction !== null);
+      expect(connector!.status).toBe(OCPPStatus.Preparing);
+
+      simulateStartTransactionAccepted(cp, 1, 5511);
+      await waitUntil(() => connector!.status === OCPPStatus.Charging);
+
+      // meter-auto here is unbounded (maxTime: 0, maxValue: 0 — "until
+      // Remote Stop") so the node completes immediately without
+      // blocking; the scenario parks on remoteStopTrigger right after.
+      await waitUntil(() => cp.isScenarioStopHandled(1), 2000);
+
+      const txId = connector!.transaction!.id;
+      if (txId == null) {
+        throw new Error("expected transaction to have an id");
+      }
+      cp.notifyRemoteStopReceived(1, txId);
+
+      await waitUntil(() => connector!.status === OCPPStatus.Available);
+
+      await timeout(execution, 2000);
+
+      assertExactlyOnceEach(statuses);
+    } finally {
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      ).catch(() => undefined);
+    }
+  }, 8000);
+});

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -1237,12 +1237,18 @@ export class ChargePoint {
     }
 
     connector.beginTransaction(transaction);
+    // Drive Preparing before enqueueing StartTransaction.req: the outbound
+    // CALL queue is strictly serial/FIFO, so whichever we queue first is
+    // what the wire sees first. Sending Preparing's StatusNotification.req
+    // ahead of StartTransaction.req makes the OCPP-conformant wire order
+    // (Preparing precedes StartTransaction) intrinsic to the domain rather
+    // than an accident of scenario node ordering (#176).
+    this.updateConnectorStatus(connectorId, OCPPStatus.Preparing);
     this._outbox.sendTransactionEvent({
       phase: "started",
       transaction,
       connectorId,
     });
-    this.updateConnectorStatus(connectorId, OCPPStatus.Preparing);
 
     this._events.emit("transactionStarted", {
       connectorId,

--- a/src/cp/infrastructure/transport/__tests__/__snapshots__/v16Transaction.bun.test.ts.snap
+++ b/src/cp/infrastructure/transport/__tests__/__snapshots__/v16Transaction.bun.test.ts.snap
@@ -1,6 +1,6 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`OCPP 1.6 transaction lifecycle (golden) sends StartTransaction, MeterValues, and StopTransaction with CSMS transaction id 1`] = `
+exports[`OCPP 1.6 transaction lifecycle (golden) sends StartTransaction, MeterValues, and StopTransaction with CSMS transaction id, with Preparing preceding StartTransaction on the wire (#176) 1`] = `
 [
   [
     2,

--- a/src/cp/infrastructure/transport/__tests__/v16Transaction.bun.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/v16Transaction.bun.test.ts
@@ -40,7 +40,7 @@ async function replyStatusNotification(
 }
 
 describe("OCPP 1.6 transaction lifecycle (golden)", () => {
-  it("sends StartTransaction, MeterValues, and StopTransaction with CSMS transaction id", async () => {
+  it("sends StartTransaction, MeterValues, and StopTransaction with CSMS transaction id, with Preparing preceding StartTransaction on the wire (#176)", async () => {
     const csms = startMockCsms();
     const cp = new ChargePoint(
       "CP016-TX",
@@ -71,6 +71,14 @@ describe("OCPP 1.6 transaction lifecycle (golden)", () => {
       await replyStatusNotification(csms, 1, "Available");
 
       cp.startTransaction("TAG-16", 1);
+
+      // The outbound CALL queue is strictly serial/FIFO (§4.1.1), and
+      // startTransaction() now drives Preparing before enqueueing
+      // StartTransaction.req (#176) — so the wire sees Preparing's
+      // StatusNotification.req first, and StartTransaction.req is only
+      // sent once that's acked.
+      await replyStatusNotification(csms, 1, "Preparing");
+
       const startCall = await csms.waitForCall("StartTransaction");
       const startPayload = startCall.payload as StartTransactionRequestV16;
       expect(startPayload).toMatchObject({
@@ -84,7 +92,6 @@ describe("OCPP 1.6 transaction lifecycle (golden)", () => {
         idTagInfo: { status: "Accepted" },
       });
 
-      await replyStatusNotification(csms, 1, "Preparing");
       await replyStatusNotification(csms, 1, "Charging");
 
       cp.sendMeterValue(1);
@@ -114,6 +121,28 @@ describe("OCPP 1.6 transaction lifecycle (golden)", () => {
       expect(
         payload<StopTransactionRequestV16>(relevantFrames[2]).transactionId,
       ).toBe(1001);
+
+      // #176: explicit wire-order pin. Preparing's StatusNotification.req
+      // must be enqueued (and therefore sent, given the serial CALL queue)
+      // strictly before StartTransaction.req — not just "eventually acked
+      // before" as an artifact of a scenario node, but intrinsic to
+      // ChargePoint.startTransaction() itself for a plain, non-scenario
+      // start.
+      const preparingIndex = csms.received.findIndex(
+        (frame) =>
+          frame[0] === 2 &&
+          frame[2] === "StatusNotification" &&
+          (frame[3] as { connectorId?: number; status?: string })
+            .connectorId === 1 &&
+          (frame[3] as { connectorId?: number; status?: string }).status ===
+            "Preparing",
+      );
+      const startTransactionIndex = csms.received.findIndex(
+        (frame) => frame[0] === 2 && frame[2] === "StartTransaction",
+      );
+      expect(preparingIndex).toBeGreaterThanOrEqual(0);
+      expect(startTransactionIndex).toBeGreaterThanOrEqual(0);
+      expect(preparingIndex).toBeLessThan(startTransactionIndex);
 
       expect(normalizeTranscript(relevantFrames)).toMatchSnapshot();
     } finally {

--- a/src/utils/scenarios/cert16-reservation-basic.json
+++ b/src/utils/scenarios/cert16-reservation-basic.json
@@ -33,12 +33,6 @@
       "data": { "label": "Reserved idTag arrives", "delaySeconds": 2 }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 450 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "tx-start",
       "type": "transaction",
       "position": { "x": 400, "y": 550 },
@@ -47,12 +41,6 @@
         "action": "start",
         "tagId": "CERT-RES01"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 650 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -76,18 +64,6 @@
       "data": { "label": "Stop Transaction", "action": "stop" }
     },
     {
-      "id": "status-finishing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 950 },
-      "data": { "label": "Set Finishing", "status": "Finishing" }
-    },
-    {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 1050 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "end-1",
       "type": "end",
       "position": { "x": 400, "y": 1150 },
@@ -102,13 +78,9 @@
       "target": "status-reserved"
     },
     { "id": "e3", "source": "status-reserved", "target": "delay-arrival" },
-    { "id": "e4", "source": "delay-arrival", "target": "status-preparing" },
-    { "id": "e5", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e6", "source": "tx-start", "target": "status-charging" },
-    { "id": "e7", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e8", "source": "meter-auto", "target": "tx-stop" },
-    { "id": "e9", "source": "tx-stop", "target": "status-finishing" },
-    { "id": "e10", "source": "status-finishing", "target": "status-available" },
-    { "id": "e11", "source": "status-available", "target": "end-1" }
+    { "id": "e4", "source": "delay-arrival", "target": "tx-start" },
+    { "id": "e5", "source": "tx-start", "target": "meter-auto" },
+    { "id": "e6", "source": "meter-auto", "target": "tx-stop" },
+    { "id": "e7", "source": "tx-stop", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc003-charging-plugin-first.json
+++ b/src/utils/scenarios/cert16-tc003-charging-plugin-first.json
@@ -27,12 +27,6 @@
       "data": { "label": "Plug In", "action": "plugin" }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 350 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "delay-idtag",
       "type": "delay",
       "position": { "x": 400, "y": 450 },
@@ -47,12 +41,6 @@
         "action": "start",
         "tagId": "CERT003"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 650 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -76,22 +64,10 @@
       "data": { "label": "Stop Transaction", "action": "stop" }
     },
     {
-      "id": "status-finishing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 950 },
-      "data": { "label": "Set Finishing", "status": "Finishing" }
-    },
-    {
       "id": "plug-out",
       "type": "connectorPlug",
       "position": { "x": 400, "y": 1050 },
       "data": { "label": "Plug Out", "action": "plugout" }
-    },
-    {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 1150 },
-      "data": { "label": "Set Available", "status": "Available" }
     },
     {
       "id": "end-1",
@@ -103,15 +79,11 @@
   "edges": [
     { "id": "e1", "source": "start-1", "target": "delay-connect" },
     { "id": "e2", "source": "delay-connect", "target": "plug-in" },
-    { "id": "e3", "source": "plug-in", "target": "status-preparing" },
-    { "id": "e4", "source": "status-preparing", "target": "delay-idtag" },
-    { "id": "e5", "source": "delay-idtag", "target": "tx-start" },
-    { "id": "e6", "source": "tx-start", "target": "status-charging" },
-    { "id": "e7", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e8", "source": "meter-auto", "target": "tx-stop" },
-    { "id": "e9", "source": "tx-stop", "target": "status-finishing" },
-    { "id": "e10", "source": "status-finishing", "target": "plug-out" },
-    { "id": "e11", "source": "plug-out", "target": "status-available" },
-    { "id": "e12", "source": "status-available", "target": "end-1" }
+    { "id": "e3", "source": "plug-in", "target": "delay-idtag" },
+    { "id": "e4", "source": "delay-idtag", "target": "tx-start" },
+    { "id": "e5", "source": "tx-start", "target": "meter-auto" },
+    { "id": "e6", "source": "meter-auto", "target": "tx-stop" },
+    { "id": "e7", "source": "tx-stop", "target": "plug-out" },
+    { "id": "e8", "source": "plug-out", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc004-charging-id-first.json
+++ b/src/utils/scenarios/cert16-tc004-charging-id-first.json
@@ -21,12 +21,6 @@
       "data": { "label": "Present idTag (before plug-in)", "delaySeconds": 2 }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 250 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "tx-start",
       "type": "transaction",
       "position": { "x": 400, "y": 350 },
@@ -35,12 +29,6 @@
         "action": "start",
         "tagId": "CERT004"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 450 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -64,18 +52,6 @@
       "data": { "label": "Stop Transaction", "action": "stop" }
     },
     {
-      "id": "status-finishing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 750 },
-      "data": { "label": "Set Finishing", "status": "Finishing" }
-    },
-    {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 850 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "end-1",
       "type": "end",
       "position": { "x": 400, "y": 950 },
@@ -84,13 +60,9 @@
   ],
   "edges": [
     { "id": "e1", "source": "start-1", "target": "delay-idtag" },
-    { "id": "e2", "source": "delay-idtag", "target": "status-preparing" },
-    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e4", "source": "tx-start", "target": "status-charging" },
-    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e6", "source": "meter-auto", "target": "tx-stop" },
-    { "id": "e7", "source": "tx-stop", "target": "status-finishing" },
-    { "id": "e8", "source": "status-finishing", "target": "status-available" },
-    { "id": "e9", "source": "status-available", "target": "end-1" }
+    { "id": "e2", "source": "delay-idtag", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "meter-auto" },
+    { "id": "e4", "source": "meter-auto", "target": "tx-stop" },
+    { "id": "e5", "source": "tx-stop", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc005-ev-side-disconnect.json
+++ b/src/utils/scenarios/cert16-tc005-ev-side-disconnect.json
@@ -21,12 +21,6 @@
       "data": { "label": "Plug In", "action": "plugin" }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 250 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "tx-start",
       "type": "transaction",
       "position": { "x": 400, "y": 350 },
@@ -35,12 +29,6 @@
         "action": "start",
         "tagId": "CERT005"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 450 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -74,12 +62,6 @@
       }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 850 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "end-1",
       "type": "end",
       "position": { "x": 400, "y": 950 },
@@ -88,13 +70,10 @@
   ],
   "edges": [
     { "id": "e1", "source": "start-1", "target": "plug-in" },
-    { "id": "e2", "source": "plug-in", "target": "status-preparing" },
-    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e4", "source": "tx-start", "target": "status-charging" },
-    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e6", "source": "meter-auto", "target": "plug-out" },
-    { "id": "e7", "source": "plug-out", "target": "tx-stop" },
-    { "id": "e8", "source": "tx-stop", "target": "status-available" },
-    { "id": "e9", "source": "status-available", "target": "end-1" }
+    { "id": "e2", "source": "plug-in", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "meter-auto" },
+    { "id": "e4", "source": "meter-auto", "target": "plug-out" },
+    { "id": "e5", "source": "plug-out", "target": "tx-stop" },
+    { "id": "e6", "source": "tx-stop", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc010-remote-start.json
+++ b/src/utils/scenarios/cert16-tc010-remote-start.json
@@ -21,12 +21,6 @@
       "data": { "label": "Plug In", "action": "plugin" }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 250 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "trigger-remote-start",
       "type": "remoteStartTrigger",
       "position": { "x": 400, "y": 350 },
@@ -41,12 +35,6 @@
         "action": "start",
         "tagId": "CERT010"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 550 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -71,16 +59,18 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "connector-plug-1" },
-    { "id": "e2", "source": "connector-plug-1", "target": "status-preparing" },
     {
-      "id": "e3",
-      "source": "status-preparing",
+      "id": "e1",
+      "source": "start-1",
+      "target": "connector-plug-1"
+    },
+    {
+      "id": "e2",
+      "source": "connector-plug-1",
       "target": "trigger-remote-start"
     },
-    { "id": "e4", "source": "trigger-remote-start", "target": "tx-start" },
-    { "id": "e5", "source": "tx-start", "target": "status-charging" },
-    { "id": "e6", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e7", "source": "meter-auto", "target": "end-1" }
+    { "id": "e3", "source": "trigger-remote-start", "target": "tx-start" },
+    { "id": "e4", "source": "tx-start", "target": "meter-auto" },
+    { "id": "e5", "source": "meter-auto", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc011-remote-start-stop.json
+++ b/src/utils/scenarios/cert16-tc011-remote-start-stop.json
@@ -21,12 +21,6 @@
       "data": { "label": "Wait for RemoteStartTransaction", "timeout": 0 }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 250 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "tx-start",
       "type": "transaction",
       "position": { "x": 400, "y": 350 },
@@ -35,12 +29,6 @@
         "action": "start",
         "tagId": "CERT011"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 450 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -70,18 +58,6 @@
       "data": { "label": "Stop Transaction", "action": "stop" }
     },
     {
-      "id": "status-finishing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 850 },
-      "data": { "label": "Set Finishing", "status": "Finishing" }
-    },
-    {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 950 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "end-1",
       "type": "end",
       "position": { "x": 400, "y": 1050 },
@@ -90,18 +66,10 @@
   ],
   "edges": [
     { "id": "e1", "source": "start-1", "target": "trigger-remote-start" },
-    {
-      "id": "e2",
-      "source": "trigger-remote-start",
-      "target": "status-preparing"
-    },
-    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e4", "source": "tx-start", "target": "status-charging" },
-    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e6", "source": "meter-auto", "target": "trigger-remote-stop" },
-    { "id": "e7", "source": "trigger-remote-stop", "target": "tx-stop" },
-    { "id": "e8", "source": "tx-stop", "target": "status-finishing" },
-    { "id": "e9", "source": "status-finishing", "target": "status-available" },
-    { "id": "e10", "source": "status-available", "target": "end-1" }
+    { "id": "e2", "source": "trigger-remote-start", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "meter-auto" },
+    { "id": "e4", "source": "meter-auto", "target": "trigger-remote-stop" },
+    { "id": "e5", "source": "trigger-remote-stop", "target": "tx-stop" },
+    { "id": "e6", "source": "tx-stop", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc012-remote-stop.json
+++ b/src/utils/scenarios/cert16-tc012-remote-stop.json
@@ -27,12 +27,6 @@
       "data": { "label": "Plug In", "action": "plugin" }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 350 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "tx-start",
       "type": "transaction",
       "position": { "x": 400, "y": 450 },
@@ -41,12 +35,6 @@
         "action": "start",
         "tagId": "CERT012"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 550 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -76,18 +64,6 @@
       "data": { "label": "Stop Transaction", "action": "stop" }
     },
     {
-      "id": "status-finishing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 950 },
-      "data": { "label": "Set Finishing", "status": "Finishing" }
-    },
-    {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 1050 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "end-1",
       "type": "end",
       "position": { "x": 400, "y": 1150 },
@@ -97,14 +73,10 @@
   "edges": [
     { "id": "e1", "source": "start-1", "target": "delay-connect" },
     { "id": "e2", "source": "delay-connect", "target": "plug-in" },
-    { "id": "e3", "source": "plug-in", "target": "status-preparing" },
-    { "id": "e4", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e5", "source": "tx-start", "target": "status-charging" },
-    { "id": "e6", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e7", "source": "meter-auto", "target": "trigger-remote-stop" },
-    { "id": "e8", "source": "trigger-remote-stop", "target": "tx-stop" },
-    { "id": "e9", "source": "tx-stop", "target": "status-finishing" },
-    { "id": "e10", "source": "status-finishing", "target": "status-available" },
-    { "id": "e11", "source": "status-available", "target": "end-1" }
+    { "id": "e3", "source": "plug-in", "target": "tx-start" },
+    { "id": "e4", "source": "tx-start", "target": "meter-auto" },
+    { "id": "e5", "source": "meter-auto", "target": "trigger-remote-stop" },
+    { "id": "e6", "source": "trigger-remote-stop", "target": "tx-stop" },
+    { "id": "e7", "source": "tx-stop", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc013-hard-reset.json
+++ b/src/utils/scenarios/cert16-tc013-hard-reset.json
@@ -21,12 +21,6 @@
       "data": { "label": "Plug In", "action": "plugin" }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 250 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "tx-start",
       "type": "transaction",
       "position": { "x": 400, "y": 350 },
@@ -35,12 +29,6 @@
         "action": "start",
         "tagId": "CERT013"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 450 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -76,11 +64,9 @@
   ],
   "edges": [
     { "id": "e1", "source": "start-1", "target": "plug-in" },
-    { "id": "e2", "source": "plug-in", "target": "status-preparing" },
-    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e4", "source": "tx-start", "target": "status-charging" },
-    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e6", "source": "meter-auto", "target": "trigger-reset" },
-    { "id": "e7", "source": "trigger-reset", "target": "end-1" }
+    { "id": "e2", "source": "plug-in", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "meter-auto" },
+    { "id": "e4", "source": "meter-auto", "target": "trigger-reset" },
+    { "id": "e5", "source": "trigger-reset", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc014-soft-reset.json
+++ b/src/utils/scenarios/cert16-tc014-soft-reset.json
@@ -21,12 +21,6 @@
       "data": { "label": "Plug In", "action": "plugin" }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 250 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "tx-start",
       "type": "transaction",
       "position": { "x": 400, "y": 350 },
@@ -35,12 +29,6 @@
         "action": "start",
         "tagId": "CERT014"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 450 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -76,11 +64,9 @@
   ],
   "edges": [
     { "id": "e1", "source": "start-1", "target": "plug-in" },
-    { "id": "e2", "source": "plug-in", "target": "status-preparing" },
-    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e4", "source": "tx-start", "target": "status-charging" },
-    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e6", "source": "meter-auto", "target": "trigger-reset" },
-    { "id": "e7", "source": "trigger-reset", "target": "end-1" }
+    { "id": "e2", "source": "plug-in", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "meter-auto" },
+    { "id": "e4", "source": "meter-auto", "target": "trigger-reset" },
+    { "id": "e5", "source": "trigger-reset", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc017-unlock-occupied.json
+++ b/src/utils/scenarios/cert16-tc017-unlock-occupied.json
@@ -27,12 +27,6 @@
       "data": { "label": "Plug In", "action": "plugin" }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 350 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "tx-start",
       "type": "transaction",
       "position": { "x": 400, "y": 450 },
@@ -41,12 +35,6 @@
         "action": "start",
         "tagId": "CERT017"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 550 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -88,18 +76,6 @@
       "data": { "label": "Stop Transaction", "action": "stop" }
     },
     {
-      "id": "status-finishing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 1050 },
-      "data": { "label": "Set Finishing", "status": "Finishing" }
-    },
-    {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 1150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "end-1",
       "type": "end",
       "position": { "x": 400, "y": 1250 },
@@ -109,15 +85,11 @@
   "edges": [
     { "id": "e1", "source": "start-1", "target": "delay-connect" },
     { "id": "e2", "source": "delay-connect", "target": "plug-in" },
-    { "id": "e3", "source": "plug-in", "target": "status-preparing" },
-    { "id": "e4", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e5", "source": "tx-start", "target": "status-charging" },
-    { "id": "e6", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e7", "source": "meter-auto", "target": "unlock-arm" },
-    { "id": "e8", "source": "unlock-arm", "target": "delay-unlock-window" },
-    { "id": "e9", "source": "delay-unlock-window", "target": "tx-stop" },
-    { "id": "e10", "source": "tx-stop", "target": "status-finishing" },
-    { "id": "e11", "source": "status-finishing", "target": "status-available" },
-    { "id": "e12", "source": "status-available", "target": "end-1" }
+    { "id": "e3", "source": "plug-in", "target": "tx-start" },
+    { "id": "e4", "source": "tx-start", "target": "meter-auto" },
+    { "id": "e5", "source": "meter-auto", "target": "unlock-arm" },
+    { "id": "e6", "source": "unlock-arm", "target": "delay-unlock-window" },
+    { "id": "e7", "source": "delay-unlock-window", "target": "tx-stop" },
+    { "id": "e8", "source": "tx-stop", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc018-unlock-failure.json
+++ b/src/utils/scenarios/cert16-tc018-unlock-failure.json
@@ -27,12 +27,6 @@
       "data": { "label": "Plug In", "action": "plugin" }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 350 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "tx-start",
       "type": "transaction",
       "position": { "x": 400, "y": 450 },
@@ -41,12 +35,6 @@
         "action": "start",
         "tagId": "CERT018"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 550 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -88,18 +76,6 @@
       "data": { "label": "Stop Transaction", "action": "stop" }
     },
     {
-      "id": "status-finishing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 1050 },
-      "data": { "label": "Set Finishing", "status": "Finishing" }
-    },
-    {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 1150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "end-1",
       "type": "end",
       "position": { "x": 400, "y": 1250 },
@@ -109,15 +85,11 @@
   "edges": [
     { "id": "e1", "source": "start-1", "target": "delay-connect" },
     { "id": "e2", "source": "delay-connect", "target": "plug-in" },
-    { "id": "e3", "source": "plug-in", "target": "status-preparing" },
-    { "id": "e4", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e5", "source": "tx-start", "target": "status-charging" },
-    { "id": "e6", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e7", "source": "meter-auto", "target": "unlock-arm" },
-    { "id": "e8", "source": "unlock-arm", "target": "delay-unlock-window" },
-    { "id": "e9", "source": "delay-unlock-window", "target": "tx-stop" },
-    { "id": "e10", "source": "tx-stop", "target": "status-finishing" },
-    { "id": "e11", "source": "status-finishing", "target": "status-available" },
-    { "id": "e12", "source": "status-available", "target": "end-1" }
+    { "id": "e3", "source": "plug-in", "target": "tx-start" },
+    { "id": "e4", "source": "tx-start", "target": "meter-auto" },
+    { "id": "e5", "source": "meter-auto", "target": "unlock-arm" },
+    { "id": "e6", "source": "unlock-arm", "target": "delay-unlock-window" },
+    { "id": "e7", "source": "delay-unlock-window", "target": "tx-stop" },
+    { "id": "e8", "source": "tx-stop", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc028-remote-stop-rejected.json
+++ b/src/utils/scenarios/cert16-tc028-remote-stop-rejected.json
@@ -21,12 +21,6 @@
       "data": { "label": "Plug In", "action": "plugin" }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 250 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "tx-start",
       "type": "transaction",
       "position": { "x": 400, "y": 350 },
@@ -35,12 +29,6 @@
         "action": "start",
         "tagId": "CERT028"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 450 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -97,18 +85,6 @@
       }
     },
     {
-      "id": "status-finishing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 1050 },
-      "data": { "label": "Set Finishing", "status": "Finishing" }
-    },
-    {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 1150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "end-1",
       "type": "end",
       "position": { "x": 400, "y": 1250 },
@@ -117,16 +93,12 @@
   ],
   "edges": [
     { "id": "e1", "source": "start-1", "target": "plug-in" },
-    { "id": "e2", "source": "plug-in", "target": "status-preparing" },
-    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e4", "source": "tx-start", "target": "status-charging" },
-    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e6", "source": "meter-auto", "target": "arm-override" },
-    { "id": "e7", "source": "arm-override", "target": "trigger-remote-stop" },
-    { "id": "e8", "source": "trigger-remote-stop", "target": "delay-continue" },
-    { "id": "e9", "source": "delay-continue", "target": "tx-stop" },
-    { "id": "e10", "source": "tx-stop", "target": "status-finishing" },
-    { "id": "e11", "source": "status-finishing", "target": "status-available" },
-    { "id": "e12", "source": "status-available", "target": "end-1" }
+    { "id": "e2", "source": "plug-in", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "meter-auto" },
+    { "id": "e4", "source": "meter-auto", "target": "arm-override" },
+    { "id": "e5", "source": "arm-override", "target": "trigger-remote-stop" },
+    { "id": "e6", "source": "trigger-remote-stop", "target": "delay-continue" },
+    { "id": "e7", "source": "delay-continue", "target": "tx-stop" },
+    { "id": "e8", "source": "tx-stop", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc056-central-smart-charging-txdefault.json
+++ b/src/utils/scenarios/cert16-tc056-central-smart-charging-txdefault.json
@@ -21,12 +21,6 @@
       "data": { "label": "Plug In", "action": "plugin" }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 250 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "tx-start",
       "type": "transaction",
       "position": { "x": 400, "y": 350 },
@@ -35,12 +29,6 @@
         "action": "start",
         "tagId": "CERT056"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 450 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -83,18 +71,6 @@
       }
     },
     {
-      "id": "status-finishing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 950 },
-      "data": { "label": "Set Finishing", "status": "Finishing" }
-    },
-    {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 1050 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "end-1",
       "type": "end",
       "position": { "x": 400, "y": 1150 },
@@ -103,19 +79,15 @@
   ],
   "edges": [
     { "id": "e1", "source": "start-1", "target": "plug-in" },
-    { "id": "e2", "source": "plug-in", "target": "status-preparing" },
-    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e4", "source": "tx-start", "target": "status-charging" },
-    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e2", "source": "plug-in", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "meter-auto" },
     {
-      "id": "e6",
+      "id": "e4",
       "source": "meter-auto",
       "target": "csms-set-charging-profile"
     },
-    { "id": "e7", "source": "csms-set-charging-profile", "target": "delay-10" },
-    { "id": "e8", "source": "delay-10", "target": "tx-stop" },
-    { "id": "e9", "source": "tx-stop", "target": "status-finishing" },
-    { "id": "e10", "source": "status-finishing", "target": "status-available" },
-    { "id": "e11", "source": "status-available", "target": "end-1" }
+    { "id": "e5", "source": "csms-set-charging-profile", "target": "delay-10" },
+    { "id": "e6", "source": "delay-10", "target": "tx-stop" },
+    { "id": "e7", "source": "tx-stop", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc057-central-smart-charging-txprofile.json
+++ b/src/utils/scenarios/cert16-tc057-central-smart-charging-txprofile.json
@@ -21,12 +21,6 @@
       "data": { "label": "Plug In", "action": "plugin" }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 250 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "tx-start",
       "type": "transaction",
       "position": { "x": 400, "y": 350 },
@@ -35,12 +29,6 @@
         "action": "start",
         "tagId": "CERT057"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 450 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -83,18 +71,6 @@
       }
     },
     {
-      "id": "status-finishing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 950 },
-      "data": { "label": "Set Finishing", "status": "Finishing" }
-    },
-    {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 1050 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "end-1",
       "type": "end",
       "position": { "x": 400, "y": 1150 },
@@ -103,19 +79,15 @@
   ],
   "edges": [
     { "id": "e1", "source": "start-1", "target": "plug-in" },
-    { "id": "e2", "source": "plug-in", "target": "status-preparing" },
-    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e4", "source": "tx-start", "target": "status-charging" },
-    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
+    { "id": "e2", "source": "plug-in", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "meter-auto" },
     {
-      "id": "e6",
+      "id": "e4",
       "source": "meter-auto",
       "target": "csms-set-charging-profile"
     },
-    { "id": "e7", "source": "csms-set-charging-profile", "target": "delay-10" },
-    { "id": "e8", "source": "delay-10", "target": "tx-stop" },
-    { "id": "e9", "source": "tx-stop", "target": "status-finishing" },
-    { "id": "e10", "source": "status-finishing", "target": "status-available" },
-    { "id": "e11", "source": "status-available", "target": "end-1" }
+    { "id": "e5", "source": "csms-set-charging-profile", "target": "delay-10" },
+    { "id": "e6", "source": "delay-10", "target": "tx-stop" },
+    { "id": "e7", "source": "tx-stop", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc059-remote-start-with-profile.json
+++ b/src/utils/scenarios/cert16-tc059-remote-start-with-profile.json
@@ -21,12 +21,6 @@
       "data": { "label": "Wait for RemoteStartTransaction", "timeout": 0 }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 250 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "tx-start",
       "type": "transaction",
       "position": { "x": 400, "y": 350 },
@@ -35,12 +29,6 @@
         "action": "start",
         "tagId": "CERT059"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 450 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -67,18 +55,6 @@
       }
     },
     {
-      "id": "status-finishing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 750 },
-      "data": { "label": "Set Finishing", "status": "Finishing" }
-    },
-    {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 850 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "end-1",
       "type": "end",
       "position": { "x": 400, "y": 950 },
@@ -87,17 +63,9 @@
   ],
   "edges": [
     { "id": "e1", "source": "start-1", "target": "remote-start-trigger" },
-    {
-      "id": "e2",
-      "source": "remote-start-trigger",
-      "target": "status-preparing"
-    },
-    { "id": "e3", "source": "status-preparing", "target": "tx-start" },
-    { "id": "e4", "source": "tx-start", "target": "status-charging" },
-    { "id": "e5", "source": "status-charging", "target": "meter-auto" },
-    { "id": "e6", "source": "meter-auto", "target": "tx-stop" },
-    { "id": "e7", "source": "tx-stop", "target": "status-finishing" },
-    { "id": "e8", "source": "status-finishing", "target": "status-available" },
-    { "id": "e9", "source": "status-available", "target": "end-1" }
+    { "id": "e2", "source": "remote-start-trigger", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "meter-auto" },
+    { "id": "e4", "source": "meter-auto", "target": "tx-stop" },
+    { "id": "e5", "source": "tx-stop", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/full-charging-cycle.json
+++ b/src/utils/scenarios/full-charging-cycle.json
@@ -21,12 +21,6 @@
       "data": { "label": "Set Available", "status": "Available" }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 250 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "transaction-start",
       "type": "transaction",
       "position": { "x": 400, "y": 350 },
@@ -37,12 +31,6 @@
         "batteryCapacityKwh": 60,
         "initialSoc": 20
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 450 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -72,18 +60,6 @@
       "data": { "label": "Stop Transaction", "action": "stop" }
     },
     {
-      "id": "status-finishing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 850 },
-      "data": { "label": "Set Finishing", "status": "Finishing" }
-    },
-    {
-      "id": "status-available2",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 950 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "end-1",
       "type": "end",
       "position": { "x": 400, "y": 1050 },
@@ -97,23 +73,13 @@
       "target": "status-available"
     },
     {
-      "id": "e-available-preparing",
+      "id": "e-available-txstart",
       "source": "status-available",
-      "target": "status-preparing"
-    },
-    {
-      "id": "e-preparing-txstart",
-      "source": "status-preparing",
       "target": "transaction-start"
     },
     {
-      "id": "e-txstart-charging",
+      "id": "e-txstart-meter",
       "source": "transaction-start",
-      "target": "status-charging"
-    },
-    {
-      "id": "e-charging-meter",
-      "source": "status-charging",
       "target": "meter-auto"
     },
     {
@@ -127,18 +93,8 @@
       "target": "transaction-stop"
     },
     {
-      "id": "e-txstop-finishing",
+      "id": "e-txstop-end",
       "source": "transaction-stop",
-      "target": "status-finishing"
-    },
-    {
-      "id": "e-finishing-available2",
-      "source": "status-finishing",
-      "target": "status-available2"
-    },
-    {
-      "id": "e-available2-end",
-      "source": "status-available2",
       "target": "end-1"
     }
   ]

--- a/src/utils/scenarios/remote-start-auto-meter.json
+++ b/src/utils/scenarios/remote-start-auto-meter.json
@@ -21,12 +21,6 @@
       "data": { "label": "Wait RemoteStart", "timeout": 0 }
     },
     {
-      "id": "status-preparing",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 250 },
-      "data": { "label": "Set Preparing", "status": "Preparing" }
-    },
-    {
       "id": "transaction-start",
       "type": "transaction",
       "position": { "x": 400, "y": 350 },
@@ -35,12 +29,6 @@
         "action": "start",
         "tagId": "REMOTE001"
       }
-    },
-    {
-      "id": "status-charging",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 450 },
-      "data": { "label": "Set Charging", "status": "Charging" }
     },
     {
       "id": "meter-auto",
@@ -67,23 +55,13 @@
   "edges": [
     { "id": "e-start-remote", "source": "start-1", "target": "trigger-remote" },
     {
-      "id": "e-remote-preparing",
+      "id": "e-remote-tx",
       "source": "trigger-remote",
-      "target": "status-preparing"
-    },
-    {
-      "id": "e-preparing-tx",
-      "source": "status-preparing",
       "target": "transaction-start"
     },
     {
-      "id": "e-tx-charging",
+      "id": "e-tx-meter",
       "source": "transaction-start",
-      "target": "status-charging"
-    },
-    {
-      "id": "e-charging-meter",
-      "source": "status-charging",
       "target": "meter-auto"
     },
     { "id": "e-meter-end", "source": "meter-auto", "target": "end-1" }


### PR DESCRIPTION
## Summary

Fixes #176

The observed duplicate StatusNotifications came from built-in scenarios carrying explicit `statusChange` nodes (Preparing/Charging/Finishing/Available) for transitions the domain **already** drives inside `startTransaction`/`stopTransaction`. Rather than add machinery to suppress the domain cascade (an earlier attempt broke the default `essential-cp-behavior` scenario, which has no status nodes and relies entirely on the cascade), this makes the **domain cascade the single source of truth** for the standard lifecycle statuses and removes the redundant nodes.

### Changes
1. **Domain wire-order fix** — `ChargePoint.startTransaction` now drives `Preparing` **before** enqueuing `StartTransaction.req`. The outbound CALL queue is serial FIFO, so previously the domain's own Preparing only reached the wire *after* `StartTransaction.conf`; the scenarios' explicit Preparing nodes were the only reason the OCPP-conformant "Preparing → StartTransaction" order held. This makes the correct order intrinsic for every start path (scenario, remote, and manual/CLI).
2. **Removed 59 redundant lifecycle status nodes across 17 scenarios** — Preparing/Charging/Finishing/Available nodes sitting adjacent to a transaction start/stop node, healed with simple linear edge splices. **Load-bearing nodes are kept**: `Reserved` (the domain never sends a StatusNotification for it — see #186), non-lifecycle `Faulted`/`Unavailable`, and Preparing/Available nodes that aren't transaction-adjacent.
3. **Exactly-once regression test** — runs `essential-cp-behavior` (zero status nodes; domain-only) and an edited cert scenario through the real `ScenarioExecutor` + `ChargePoint`, asserting each of Preparing/Charging/Finishing/Available is emitted **exactly once** (no duplicates, no missing transitions). This is the coverage that was missing.

`essential-cp-behavior`, the scenario editor, and user-authored scenarios are unchanged — no new authoring contract, no footgun.

### Deferred (filed separately, same audit)
- #185 — boot-time `Available` is duplicated by ~25 scenarios' leading "Set Available" node (same class, different mechanism; out of this PR's transaction-cascade scope).
- #186 — `ReserveNow`/`CancelReservation` set `connector.status` directly and never send a `StatusNotification.req`.

## Testing
- vitest 1039/1039 (excluding an unrelated local worktree's dom tests), `bun test bun.test` 153/153, eslint + prettier clean, `tsc -b --noEmit --force` = 478 (unchanged).
- **Live re-verification against real SteVe via the TS runner: 44/44 PASS** (`run-all --parallel`) — confirms the domain cascade emits every lifecycle transition correctly with the redundant nodes gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Charging transactions now report **Preparing** before the transaction starts, ensuring correct lifecycle event ordering.
  * Lifecycle statuses are emitted exactly once, preventing duplicate or missing connector status updates.

* **Improvements**
  * Charging, remote-start, reset, unlock, reservation, and smart-charging scenarios now use streamlined flows while preserving transaction, meter, and stop behaviors.
  * Remote-start handling now transitions reliably through Preparing and Charging states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->