### PR TITLE
feat: Authorize before local transaction start + TC_023 authorize-outcome scenarios (#181)

### DIFF
--- a/scripts/steve-verify/02-provision.sh
+++ b/scripts/steve-verify/02-provision.sh
@@ -71,6 +71,42 @@ ON DUPLICATE KEY UPDATE max_active_transaction_count = 5;
 " >/dev/null
 
 # ---------------------------------------------------------------------------
+# 2b. TC_023 Authorize-outcome tags (issue #181): CERT023-{INV,EXP,BLK} come
+#     out of the general auto-discovery loop above as ordinary accepted tags
+#     (max_active_transaction_count=5, no expiry) -- that's wrong for two of
+#     the three, and CERT023-INV must not be a row in ocpp_tag at all. Fix
+#     up all three explicitly here so SteVe's Authorize.conf actually
+#     returns the outcome each scenario's name promises.
+#
+#     Confirmed directly against SteVe's decision logic (running
+#     steve-app-1 container, src/main/java/de/rwth/idsg/steve/service/
+#     AuthTagServiceLocal.java + OcppTagActivityRecordUtils.java):
+#       - record == null (no ocpp_tag row for the idTag)      -> INVALID
+#       - isBlocked(record): max_active_transaction_count = 0 -> BLOCKED
+#       - isExpired(record, now): expiry_date < NOW()         -> EXPIRED
+#       - otherwise                                            -> ACCEPTED
+#     Blocked is checked before Expired, so the two conditions can't be
+#     accidentally conflated by setting both on one row.
+# ---------------------------------------------------------------------------
+
+log_info "fixing up TC_023 Authorize-outcome tag states (CERT023-INV/EXP/BLK)"
+
+# CERT023-INV must stay UNKNOWN (no ocpp_tag row) so SteVe's
+# AuthTagServiceLocal.decideStatus() returns INVALID -- undo the general
+# loop's insert. Safe to re-run: ocpp_tag.id_tag is referenced by
+# transaction_start.id_tag with ON DELETE CASCADE (confirmed via
+# information_schema.REFERENTIAL_CONSTRAINTS), so this never fails on a
+# leftover FK even if a prior run's transaction referenced this tag; correct
+# behavior never creates such a row for CERT023-INV in the first place.
+db "DELETE FROM ocpp_tag WHERE id_tag = 'CERT023-INV';" >/dev/null
+
+# CERT023-EXP: expiry_date in the past -> isExpired() -> EXPIRED.
+db "UPDATE ocpp_tag SET expiry_date = NOW() - INTERVAL 1 DAY WHERE id_tag = 'CERT023-EXP';" >/dev/null
+
+# CERT023-BLK: max_active_transaction_count = 0 -> isBlocked() -> BLOCKED.
+db "UPDATE ocpp_tag SET max_active_transaction_count = 0 WHERE id_tag = 'CERT023-BLK';" >/dev/null
+
+# ---------------------------------------------------------------------------
 # 3. Charging-profile entities for SmartCharging ops (TC_056/057/059/066/067)
 #    -- SetChargingProfile/ClearChargingProfile/RemoteStartTransaction all
 #    key off a pre-existing "Charging Profile" entity in SteVe (no ad hoc

--- a/scripts/steve-verify/runner/main.ts
+++ b/scripts/steve-verify/runner/main.ts
@@ -28,6 +28,7 @@ import { defaultSimConfig, startSim } from "./sim";
 import { defaultSteveConfig, SteveClient, SteveDb } from "./steve";
 import {
   AUTHLIST_RESERVATION_SPECS,
+  AUTHORIZE_SPECS,
   CORE_SPECS,
   FIRMWARE_SPECS,
   REMOTETRIGGER_SMARTCHARGING_SPECS,
@@ -193,6 +194,11 @@ async function runScenario<D>(
 // Spec registry -- groups mirror run-all.sh's group names and array
 // membership/order exactly (44 scenarios total: 15 core + 13
 // authlist-reservation + 12 remotetrigger-smartcharging + 4 firmware).
+//
+// "authorize" (issue #181's 3 TC_023 Authorize-outcome scenarios) is a
+// separate group, deliberately NOT folded into "all" -- run-all --parallel
+// stays at its existing 44-scenario baseline; run `run-all --group
+// authorize` (3 scenarios) as its own sweep.
 // ---------------------------------------------------------------------------
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -201,6 +207,7 @@ const GROUPS: Record<string, ScenarioSpec<any>[]> = {
   "authlist-reservation": AUTHLIST_RESERVATION_SPECS,
   "remotetrigger-smartcharging": REMOTETRIGGER_SMARTCHARGING_SPECS,
   firmware: FIRMWARE_SPECS,
+  authorize: AUTHORIZE_SPECS,
   // Concatenation order mirrors run-all.sh's `all)` case exactly: CORE +
   // AUTHLIST_RESERVATION + REMOTETRIGGER_SMARTCHARGING + FIRMWARE.
   all: [
@@ -211,9 +218,15 @@ const GROUPS: Record<string, ScenarioSpec<any>[]> = {
   ],
 };
 
+// Built from every group (not just "all") so `run <template-id>` also
+// resolves specs from groups intentionally excluded from "all" (e.g.
+// "authorize" -- see the GROUPS comment above). Map construction dedupes
+// the same spec object appearing under both its own group and "all".
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const SPECS_BY_TEMPLATE_ID = new Map<string, ScenarioSpec<any>>(
-  GROUPS.all.map((spec) => [spec.templateId, spec]),
+  Object.values(GROUPS)
+    .flat()
+    .map((spec) => [spec.templateId, spec]),
 );
 
 // Round-robins scenarios across CERTCP1..3 so adjacent scenarios in a group

--- a/scripts/steve-verify/runner/specs/authorize.ts
+++ b/scripts/steve-verify/runner/specs/authorize.ts
@@ -1,0 +1,201 @@
+/**
+ * specs/authorize.ts -- TC_023 Authorize Outcome scenarios (issue #181's
+ * local-start Authorize gate, default ON: every local transaction-start
+ * node now sends Authorize.req and awaits Authorize.conf BEFORE
+ * StartTransaction.req). These three specs exercise the three denial
+ * outcomes (Invalid/Expired/Blocked); each asserts the CP sends Authorize
+ * with the tag, receives the expected idTagInfo.status (uniqueId-paired,
+ * not a log-window grep), does NOT send StartTransaction.req, and that no
+ * transaction row lands in SteVe's DB for that tag -- pinning the #181
+ * "denial is a logged skip, not an error" design decision end-to-end
+ * against a real CSMS.
+ *
+ * Provisioning (02-provision.sh) sets each tag's SteVe state:
+ *   - CERT023-INV: NOT present in ocpp_tag (deleted after the general
+ *     auto-discovery insert) -- SteVe's AuthTagServiceLocal.decideStatus()
+ *     returns INVALID when `ocppTagRepository.getRecord(idTag)` is null.
+ *   - CERT023-EXP: ocpp_tag.expiry_date set in the past -- decideStatus()
+ *     checks isExpired() (expiry_date < now) before ACCEPTED.
+ *   - CERT023-BLK: ocpp_tag.max_active_transaction_count = 0 -- decideStatus()
+ *     checks isBlocked() (max_active_transaction_count == 0) first, ahead of
+ *     the expiry check.
+ * (See scripts/steve-verify/02-provision.sh's "TC_023 Authorize outcome
+ * tags" section for the exact SQL; verified directly against SteVe's
+ * OcppTagService/AuthTagServiceLocal/OcppTagActivityRecordUtils source
+ * inside the running steve-app-1 container.)
+ */
+
+import {
+  assertEq,
+  assertIdTagInfoStatus,
+  assertLineMatches,
+  assertNotSent,
+  type AssertRecorder,
+} from "../assert";
+import type { ScenarioSpec } from "../spec-types";
+import type { SteveDb } from "../steve";
+
+async function assertNoTransactionForTag(
+  cpId: string,
+  idTag: string,
+  db: SteveDb,
+  rec: AssertRecorder,
+): Promise<void> {
+  const count = await db.scalar(
+    `SELECT COUNT(*) FROM transaction t JOIN evse e ON e.evse_pk = t.evse_pk WHERE e.charge_box_id = '${cpId}' AND t.id_tag = '${idTag}';`,
+  );
+  assertEq(
+    rec,
+    count,
+    "0",
+    `DB: no transaction row created for ${idTag} (Authorize denied)`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TC_023.1 Authorize Outcome (Invalid) -- unknown idTag.
+// ---------------------------------------------------------------------------
+
+export const tc0231AuthorizeInvalidSpec: ScenarioSpec<void> = {
+  templateId: "cert16-tc023-1-authorize-invalid",
+  description:
+    "TC_023.1 Authorize Outcome (Invalid): unknown idTag CERT023-INV -> Authorize.conf Invalid, no StartTransaction.",
+  connector: 1,
+  bootWaitSecs: 4,
+  // plug-in (instant) + Authorize round-trip (~1s) + delay-1(2s) + plug-out + tail.
+  holdSecs: 15,
+  async assert({ cpId, frames, lines, rec, db }) {
+    assertLineMatches(
+      rec,
+      lines,
+      /Sent: \[2,.*"Authorize".*"idTag":"CERT023-INV"/,
+      "Authorize.req sent with idTag CERT023-INV",
+    );
+    assertIdTagInfoStatus(
+      rec,
+      frames,
+      "Authorize",
+      "Invalid",
+      "Authorize.conf idTagInfo.status is Invalid",
+    );
+    assertNotSent(
+      rec,
+      frames,
+      "StartTransaction",
+      "sent",
+      "no StartTransaction sent (Authorize denied)",
+    );
+    // Load-bearing proof of the #181 "denied start is a logged skip, not an
+    // error" design decision: the executor must fall through to plug-out/end
+    // instead of throwing/hanging. (The warn-level "Transaction start
+    // denied" log line itself isn't checkable here -- Logger routes WARN to
+    // console.warn, which sim.ts captures as stderr, never merged into the
+    // stdout `lines` this spec sees; see sim.ts's readLines(proc.stdout, …)
+    // vs stderrLines.)
+    assertLineMatches(
+      rec,
+      lines,
+      /"event":"scenario_completed"/,
+      "scenario ran to completion despite the denied transaction start",
+    );
+
+    await assertNoTransactionForTag(cpId, "CERT023-INV", db, rec);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// TC_023.2 Authorize Outcome (Expired) -- expiry_date in the past.
+// ---------------------------------------------------------------------------
+
+export const tc0232AuthorizeExpiredSpec: ScenarioSpec<void> = {
+  templateId: "cert16-tc023-2-authorize-expired",
+  description:
+    "TC_023.2 Authorize Outcome (Expired): idTag CERT023-EXP has expiry_date in the past -> Authorize.conf Expired, no StartTransaction.",
+  connector: 1,
+  bootWaitSecs: 4,
+  holdSecs: 15,
+  async assert({ cpId, frames, lines, rec, db }) {
+    assertLineMatches(
+      rec,
+      lines,
+      /Sent: \[2,.*"Authorize".*"idTag":"CERT023-EXP"/,
+      "Authorize.req sent with idTag CERT023-EXP",
+    );
+    assertIdTagInfoStatus(
+      rec,
+      frames,
+      "Authorize",
+      "Expired",
+      "Authorize.conf idTagInfo.status is Expired",
+    );
+    assertNotSent(
+      rec,
+      frames,
+      "StartTransaction",
+      "sent",
+      "no StartTransaction sent (Authorize denied)",
+    );
+    // See TC_023.1's spec above for why this checks scenario_completed
+    // rather than the (stderr-only) warn log line.
+    assertLineMatches(
+      rec,
+      lines,
+      /"event":"scenario_completed"/,
+      "scenario ran to completion despite the denied transaction start",
+    );
+
+    await assertNoTransactionForTag(cpId, "CERT023-EXP", db, rec);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// TC_023.3 Authorize Outcome (Blocked) -- max_active_transaction_count = 0.
+// ---------------------------------------------------------------------------
+
+export const tc0233AuthorizeBlockedSpec: ScenarioSpec<void> = {
+  templateId: "cert16-tc023-3-authorize-blocked",
+  description:
+    "TC_023.3 Authorize Outcome (Blocked): idTag CERT023-BLK is blocked -> Authorize.conf Blocked, no StartTransaction.",
+  connector: 1,
+  bootWaitSecs: 4,
+  holdSecs: 15,
+  async assert({ cpId, frames, lines, rec, db }) {
+    assertLineMatches(
+      rec,
+      lines,
+      /Sent: \[2,.*"Authorize".*"idTag":"CERT023-BLK"/,
+      "Authorize.req sent with idTag CERT023-BLK",
+    );
+    assertIdTagInfoStatus(
+      rec,
+      frames,
+      "Authorize",
+      "Blocked",
+      "Authorize.conf idTagInfo.status is Blocked",
+    );
+    assertNotSent(
+      rec,
+      frames,
+      "StartTransaction",
+      "sent",
+      "no StartTransaction sent (Authorize denied)",
+    );
+    // See TC_023.1's spec above for why this checks scenario_completed
+    // rather than the (stderr-only) warn log line.
+    assertLineMatches(
+      rec,
+      lines,
+      /"event":"scenario_completed"/,
+      "scenario ran to completion despite the denied transaction start",
+    );
+
+    await assertNoTransactionForTag(cpId, "CERT023-BLK", db, rec);
+  },
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const AUTHORIZE_SPECS: ScenarioSpec<any>[] = [
+  tc0231AuthorizeInvalidSpec,
+  tc0232AuthorizeExpiredSpec,
+  tc0233AuthorizeBlockedSpec,
+];

--- a/scripts/steve-verify/runner/specs/index.ts
+++ b/scripts/steve-verify/runner/specs/index.ts
@@ -1,11 +1,17 @@
 /**
  * specs/index.ts -- re-exports the ported spec groups. main.ts builds its
  * own registry (GROUPS/ALL_SPECS/SPECS_BY_TEMPLATE_ID) directly from these
- * four group modules; this file exists as the single public entry point for
+ * group modules; this file exists as the single public entry point for
  * the specs/ directory.
+ *
+ * AUTHORIZE_SPECS (issue #181's TC_023 Authorize-outcome scenarios) is
+ * deliberately NOT folded into main.ts's "all" group -- run-all --parallel
+ * stays at its existing 44-scenario baseline; run the 3 authorize specs via
+ * `run-all --group authorize` (or `run <template-id>`) as a separate sweep.
  */
 
 export { CORE_SPECS } from "./core";
 export { AUTHLIST_RESERVATION_SPECS } from "./authlist-reservation";
 export { REMOTETRIGGER_SMARTCHARGING_SPECS } from "./remotetrigger-smartcharging";
 export { FIRMWARE_SPECS } from "./firmware";
+export { AUTHORIZE_SPECS } from "./authorize";

--- a/src/cli/server/__tests__/startupScenarioBootGate.bun.test.ts
+++ b/src/cli/server/__tests__/startupScenarioBootGate.bun.test.ts
@@ -17,6 +17,12 @@ import { runStartupScenario } from "../startServer";
  * the mock CSMS from stalling the pipeline while we control the timing
  * of the two calls we actually care about (BootNotification,
  * StartTransaction).
+ *
+ * Issue #181: the scenario's Start Transaction node is a plain local
+ * start (AuthorizeBeforeLocalStart defaults true), so it now also sends
+ * Authorize.req and awaits Authorize.conf before StartTransaction.req —
+ * auto-ack that too (Accepted) so the boot-gate timing this test actually
+ * cares about isn't obscured by an unrelated pending Authorize.
  */
 function autoAckStatusNotifications(csms: MockCsms): () => void {
   const acked = new Set<string>();
@@ -27,6 +33,9 @@ function autoAckStatusNotifications(csms: MockCsms): () => void {
       if (frame[2] === "StatusNotification" && !acked.has(messageId)) {
         acked.add(messageId);
         csms.replyCallResult(messageId, {});
+      } else if (frame[2] === "Authorize" && !acked.has(messageId)) {
+        acked.add(messageId);
+        csms.replyCallResult(messageId, { idTagInfo: { status: "Accepted" } });
       }
     }
   }, 5);

--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -724,18 +724,27 @@ export class ScenarioExecutor {
         const options = this.remoteStartOptions;
         this.remoteStartTagId = null;
         this.remoteStartOptions = null;
-        if (options) {
-          await this.callbacks.onStartTransaction(
-            tagId,
-            data.batteryCapacityKwh,
-            data.initialSoc,
-            options,
-          );
-        } else {
-          await this.callbacks.onStartTransaction(
-            tagId,
-            data.batteryCapacityKwh,
-            data.initialSoc,
+        const outcome = options
+          ? await this.callbacks.onStartTransaction(
+              tagId,
+              data.batteryCapacityKwh,
+              data.initialSoc,
+              options,
+            )
+          : await this.callbacks.onStartTransaction(
+              tagId,
+              data.batteryCapacityKwh,
+              data.initialSoc,
+            );
+        // Issue #181: a denied local-authorize gate is a LOGGED SKIP, not
+        // an error — the scenario continues to its next node (e.g. plugout
+        // / end) exactly like TC_023's Authorize-Invalid/Expired/Blocked
+        // graphs expect. `outcome` is `void` for callback implementations
+        // that don't report one, so only act on it when present.
+        if (outcome && outcome.started === false) {
+          this.callbacks.log?.(
+            `Transaction start denied (${outcome.denialStatus ?? "refused"}); continuing scenario`,
+            "warn",
           );
         }
       }

--- a/src/cp/application/scenario/ScenarioRuntime.ts
+++ b/src/cp/application/scenario/ScenarioRuntime.ts
@@ -470,7 +470,11 @@ export const createScenarioExecutorCallbacks = (
       initialSoc,
       options,
     ) => {
-      chargePoint.startTransaction(
+      // Issue #181: surface the domain outcome (denied vs started) instead
+      // of discarding it — ScenarioExecutor.executeTransaction uses this to
+      // log-and-continue on a denied local-authorize gate rather than
+      // erroring the scenario.
+      return chargePoint.startTransaction(
         tagId,
         connector.id,
         batteryCapacityKwh,

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -6,6 +6,7 @@ import type {
   TransactionStartTriggerReason,
   TransactionStopTriggerReason,
 } from "../../domain/connector/Transaction";
+import type { StartTransactionOutcome } from "../../domain/charge-point/ChargePoint";
 
 /**
  * Scenario execution mode
@@ -446,12 +447,18 @@ export interface ConnectorScenariosCollection {
  */
 export interface ScenarioExecutorCallbacks {
   onStatusChange?: (status: OCPPStatus) => Promise<void>;
+  /**
+   * Returns the domain's `StartTransactionOutcome` (issue #181) so the
+   * executor can distinguish a denied local-authorize gate from a real
+   * start without a thrown error — `void` return remains valid for any
+   * implementation that doesn't need to report an outcome.
+   */
   onStartTransaction?: (
     tagId: string,
     batteryCapacityKwh?: number,
     initialSoc?: number,
     options?: StartTransactionOptions,
-  ) => Promise<void>;
+  ) => Promise<StartTransactionOutcome | void>;
   onStopTransaction?: (
     /** Optional OCPP §6.21 reason string. When a preceding
      *  RemoteStopTrigger node captured a CSMS-initiated stop, the

--- a/src/cp/application/scenario/__tests__/ScenarioLifecycle.wave1.test.ts
+++ b/src/cp/application/scenario/__tests__/ScenarioLifecycle.wave1.test.ts
@@ -234,6 +234,11 @@ function newChargePoint(id: string): ChargePoint {
     {},
   );
   cp.events.on("error", () => undefined);
+  // These WAVE 1 tests exercise pre-#181 transaction-lifecycle guards
+  // (duplicate start, cleaned-retry, Inoperative), not the #181
+  // local-authorize gate — disable it so startTransaction() keeps its
+  // synchronous behavior here.
+  cp.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
   return cp;
 }
 

--- a/src/cp/application/scenario/__tests__/cert16CoreScenarios.test.ts
+++ b/src/cp/application/scenario/__tests__/cert16CoreScenarios.test.ts
@@ -41,6 +41,13 @@ function newChargePoint(id: string): ChargePoint {
     {},
   );
   cp.events.on("error", () => undefined);
+  // TC_013's "Start Transaction" node is a plain local start, not a
+  // RemoteStartTrigger — the #181 local-authorize gate would otherwise
+  // park it awaiting an Authorize.conf this test never sends. These specs
+  // predate #181 and aren't about authorize semantics; the TC_023
+  // Authorize-outcome scenarios (issue #181 Task 4) exercise the gate
+  // itself.
+  cp.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
   return cp;
 }
 

--- a/src/cp/application/scenario/__tests__/deniedTransactionStart181.test.ts
+++ b/src/cp/application/scenario/__tests__/deniedTransactionStart181.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { ScenarioExecutor } from "../ScenarioExecutor";
+import { createScenarioExecutorCallbacks } from "../ScenarioRuntime";
+import { ScenarioDefinition, ScenarioNodeType } from "../ScenarioTypes";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+
+/**
+ * Issue #181 Task 3: a denied local-authorize gate (Task 1) must be a
+ * LOGGED SKIP at the scenario layer, not a thrown error — this is what
+ * makes TC_023-style graphs expressible (plugin → tx-start(bad tag) →
+ * [denied, logged] → plugout → end) without the executor halting.
+ *
+ * Authorize is a CP→CSMS call with no live transport in this unit test
+ * (see ChargePoint construction below), so the denial is driven directly
+ * via the `authorizeResult` test seam — the same seam
+ * AuthorizeResultHandler uses once a real Authorize.conf arrives.
+ */
+
+function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+async function waitUntil(predicate: () => boolean, ms = 500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > ms) {
+      throw new Error("Timed out waiting for predicate");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function newChargePoint(id: string): ChargePoint {
+  // wsUrl points at an unused local port — no real transport connection is
+  // ever attempted; AuthorizeBeforeLocalStart stays at its default (true)
+  // so this test exercises the real default wiring end-to-end.
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    "ws://127.0.0.1:9/",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  return cp;
+}
+
+function deniedTxStartScenario(tagId: string): ScenarioDefinition {
+  return {
+    id: "w181-denied-tx-start",
+    name: "w181-denied-tx-start",
+    targetType: "connector",
+    targetId: 1,
+    nodes: [
+      {
+        id: "start",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "tx-start",
+        type: ScenarioNodeType.TRANSACTION,
+        position: { x: 0, y: 100 },
+        data: { label: "Transaction Start", action: "start", tagId },
+      },
+      {
+        id: "end",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 200 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e-start-tx", source: "start", target: "tx-start" },
+      { id: "e-tx-end", source: "tx-start", target: "end" },
+    ],
+    createdAt: "2026-07-12T00:00:00.000Z",
+    updatedAt: "2026-07-12T00:00:00.000Z",
+    defaultExecutionMode: "oneshot",
+    enabled: true,
+    trigger: { type: "manual" },
+  };
+}
+
+describe("scenario continuation on a denied transaction start (#181)", () => {
+  it("logs a skip and completes the scenario instead of erroring when Authorize.conf denies the tag", async () => {
+    const tagId = "TC023-INVALID-TAG";
+    const cp = newChargePoint("CP-W181-DENY");
+    const connector = cp.getConnector(1)!;
+    const scenario = deniedTxStartScenario(tagId);
+
+    const logs: Array<{ message: string; level?: string }> = [];
+    const errors: Error[] = [];
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector,
+      hooks: {
+        log: (message, level) => logs.push({ message, level }),
+        onError: (error) => errors.push(error),
+      },
+    });
+    const executor = new ScenarioExecutor(scenario, callbacks);
+    const execution = executor.start();
+
+    try {
+      // The tx-start node is awaiting Authorize.conf — deny it via the
+      // same event AuthorizeResultHandler emits for a real CALLRESULT.
+      await waitUntil(() => cp.events.listenerCount("authorizeResult") > 0);
+      cp.notifyAuthorizeResult(tagId, "Invalid");
+
+      await timeout(execution, 2000);
+
+      expect(errors).toEqual([]);
+      expect(connector.transaction).toBeNull();
+      expect(
+        logs.some(
+          (l) =>
+            l.message.toLowerCase().includes("denied") && l.level === "warn",
+        ),
+      ).toBe(true);
+    } finally {
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      ).catch(() => undefined);
+    }
+  });
+
+  it("still starts the transaction normally when Authorize.conf accepts the tag", async () => {
+    const tagId = "TC023-GOOD-TAG";
+    const cp = newChargePoint("CP-W181-ACCEPT");
+    const connector = cp.getConnector(1)!;
+    const scenario = deniedTxStartScenario(tagId);
+
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector,
+    });
+    const executor = new ScenarioExecutor(scenario, callbacks);
+    const execution = executor.start();
+
+    try {
+      await waitUntil(() => cp.events.listenerCount("authorizeResult") > 0);
+      cp.notifyAuthorizeResult(tagId, "Accepted");
+
+      await timeout(execution, 2000);
+
+      expect(connector.transaction).not.toBeNull();
+      expect(connector.transaction?.tagId).toBe(tagId);
+    } finally {
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      ).catch(() => undefined);
+    }
+  });
+});

--- a/src/cp/application/scenario/__tests__/transactionStopReason.test.ts
+++ b/src/cp/application/scenario/__tests__/transactionStopReason.test.ts
@@ -41,6 +41,10 @@ function newChargePoint(id: string): ChargePoint {
     {},
   );
   cp.events.on("error", () => undefined);
+  // This suite is about stop-reason propagation (issue #110), not the
+  // #181 local-authorize gate — disable it so the scenario's "Start Tx"
+  // node doesn't park awaiting an Authorize.conf this test never sends.
+  cp.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
   return cp;
 }
 

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -1297,11 +1297,13 @@ export class ChargePoint {
     const isLocalStart = options.triggerReason !== "RemoteStart";
     if (isLocalStart && this._configuration.authorizeBeforeLocalStart()) {
       const status = await this.authorizeAndWait(tagId);
-      if (
-        status === "Invalid" ||
-        status === "Expired" ||
-        status === "Blocked"
-      ) {
+      // Any non-"Accepted" idTagInfo/idTokenInfo status denies the local
+      // start. Deliberately NOT an allowlist of specific denial strings —
+      // OCPP 2.0.1/2.1's AuthorizationStatusEnumType has more denial values
+      // than 1.6's AuthorizationStatus (ConcurrentTx, NoCredit,
+      // NotAllowedTypeEVSE, NotAtThisLocation, NotAtThisTime, Unknown), and
+      // a hardcoded 1.6-shaped list would silently let those through.
+      if (status !== "Accepted") {
         this._logger.warn(
           `Authorize.conf ${status} for ${tagId}; refusing local transaction start on connector ${connectorId}`,
           LogType.TRANSACTION,

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -62,6 +62,19 @@ interface StartTransactionOptions {
   remoteStartId?: number;
 }
 
+/**
+ * Result of `ChargePoint.startTransaction` (issue #181). Non-throwing: a
+ * denied local-authorize gate is reported here rather than as a thrown
+ * error, so scenario-layer callers can log-and-continue instead of
+ * aborting. `denialStatus` is only set when `started` is `false` because
+ * Authorize.conf came back non-Accepted; the other early-return guards
+ * (connector missing/busy/inoperative) leave it `undefined`.
+ */
+export interface StartTransactionOutcome {
+  started: boolean;
+  denialStatus?: string;
+}
+
 interface StopTransactionOptions {
   triggerReason?: TransactionStopTriggerReason;
 }
@@ -612,6 +625,81 @@ export class ChargePoint {
 
   notifyIncomingCall(action: string, payload: unknown): void {
     this._events.emit("incomingCallReceived", { action, payload });
+  }
+
+  /** Called by StartTransactionResultHandler when StartTransaction.conf
+   *  carries a non-Accepted idTagInfo.status (issue #181). */
+  notifyStartTransactionNotAccepted(
+    connectorId: number,
+    status: string,
+    stopped: boolean,
+  ): void {
+    this._events.emit("startTransactionNotAccepted", {
+      connectorId,
+      status,
+      stopped,
+    });
+  }
+
+  /** Called by AuthorizeResultHandler when Authorize.conf arrives
+   *  (issue #181). Fans out to any in-flight `authorizeAndWait` callers
+   *  tagId-matched via the `authorizeResult` event. */
+  notifyAuthorizeResult(tagId: string, status: string): void {
+    this._events.emit("authorizeResult", { tagId, status });
+  }
+
+  /**
+   * Send Authorize.req for `tagId` and await the matching Authorize.conf
+   * (issue #181). Resolves with `idTagInfo.status` ("Accepted", "Invalid",
+   * "Expired", "Blocked", ...). Tag-matched against the `authorizeResult`
+   * event so concurrent Authorize calls for different tags don't cross
+   * streams. Bounded by `timeoutMs`; on timeout OR disconnect while
+   * waiting, warns and resolves as "Accepted" (warn-and-proceed — mirrors
+   * the boot-wait philosophy; a real LocalAuthorizeOffline cache is future
+   * work). Never rejects.
+   */
+  authorizeAndWait(tagId: string, timeoutMs = 10000): Promise<string> {
+    this.authorize(tagId);
+
+    return new Promise<string>((resolve) => {
+      let settled = false;
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+      const cleanup = () => {
+        if (settled) return;
+        settled = true;
+        if (timeoutId) clearTimeout(timeoutId);
+        this._events.off("authorizeResult", handler);
+        this._events.off("disconnected", disconnectHandler);
+      };
+
+      const handler = (data: { tagId: string; status: string }) => {
+        if (data.tagId !== tagId) return;
+        cleanup();
+        resolve(data.status);
+      };
+
+      const disconnectHandler = () => {
+        cleanup();
+        this._logger.warn(
+          `Disconnected while awaiting Authorize.conf for ${tagId}; proceeding as Accepted`,
+          LogType.TRANSACTION,
+        );
+        resolve("Accepted");
+      };
+
+      this._events.on("authorizeResult", handler);
+      this._events.on("disconnected", disconnectHandler);
+
+      timeoutId = setTimeout(() => {
+        cleanup();
+        this._logger.warn(
+          `Timeout (${timeoutMs}ms) awaiting Authorize.conf for ${tagId}; proceeding as Accepted`,
+          LogType.TRANSACTION,
+        );
+        resolve("Accepted");
+      }, timeoutMs);
+    });
   }
 
   armResponseOverride(action: string, status: string): void {
@@ -1166,20 +1254,20 @@ export class ChargePoint {
     });
   }
 
-  startTransaction(
+  async startTransaction(
     tagId: string,
     connectorId: number,
     batteryCapacityKwh?: number,
     initialSoc?: number,
     options: StartTransactionOptions = {},
-  ): void {
+  ): Promise<StartTransactionOutcome> {
     const connector = this.getConnector(connectorId);
     if (!connector) {
       this._logger.error(
         `Connector ${connectorId} not found`,
         LogType.TRANSACTION,
       );
-      return;
+      return { started: false };
     }
 
     if (connector.transaction && connector.transaction.stopTime === null) {
@@ -1190,7 +1278,7 @@ export class ChargePoint {
         `Connector ${connectorId} already has an active transaction; ignoring duplicate start`,
         LogType.TRANSACTION,
       );
-      return;
+      return { started: false };
     }
 
     if (connector.availability !== "Operative") {
@@ -1198,7 +1286,33 @@ export class ChargePoint {
         `Connector ${connectorId} is ${connector.availability}; refusing to start transaction`,
         LogType.TRANSACTION,
       );
-      return;
+      return { started: false };
+    }
+
+    // Issue #181: gate LOCAL (non-remote-start) starts on Authorize.conf.
+    // "RemoteStart" means either RemoteStartTransactionHandler's direct
+    // path (which already applies AuthorizeRemoteTxRequests semantics) or
+    // a scenario that captured a RemoteStartTrigger node — both already
+    // went through CSMS-driven authorization, so they're excluded here.
+    const isLocalStart = options.triggerReason !== "RemoteStart";
+    if (isLocalStart && this._configuration.authorizeBeforeLocalStart()) {
+      const status = await this.authorizeAndWait(tagId);
+      if (
+        status === "Invalid" ||
+        status === "Expired" ||
+        status === "Blocked"
+      ) {
+        this._logger.warn(
+          `Authorize.conf ${status} for ${tagId}; refusing local transaction start on connector ${connectorId}`,
+          LogType.TRANSACTION,
+        );
+        this._events.emit("authorizeDenied", {
+          connectorId,
+          tagId,
+          status,
+        });
+        return { started: false, denialStatus: status };
+      }
     }
 
     // §5.13: if the connector was Reserved (or the reservation is for
@@ -1255,6 +1369,8 @@ export class ChargePoint {
       transactionId: 0,
       tagId,
     });
+
+    return { started: true };
   }
 
   stopTransaction(

--- a/src/cp/domain/charge-point/ChargePointEvents.ts
+++ b/src/cp/domain/charge-point/ChargePointEvents.ts
@@ -72,6 +72,33 @@ export interface ChargePointEvents {
     transactionId: number;
     reason?: string;
   };
+  /** Emitted by AuthorizeResultHandler whenever an Authorize.conf arrives,
+   *  tagId-correlated via the original Authorize.req payload (issue #181).
+   *  `ChargePoint.authorizeAndWait` listens for this to resolve the
+   *  local-start authorize gate; scenarios/tests may also observe it. */
+  authorizeResult: {
+    tagId: string;
+    status: string;
+  };
+  /** Emitted when a LOCAL transaction start is refused because
+   *  Authorize.conf came back Invalid/Expired/Blocked (issue #181). The
+   *  connector status is left untouched and no StartTransaction.req is
+   *  sent. */
+  authorizeDenied: {
+    connectorId: number;
+    tagId: string;
+    status: string;
+  };
+  /** Emitted by StartTransactionResultHandler when StartTransaction.conf
+   *  carries a non-Accepted idTagInfo.status (issue #181). `stopped`
+   *  reflects whether `StopTransactionOnInvalidId` caused an automatic
+   *  DeAuthorized stop (`true`) or the transaction was left running
+   *  (`false`). */
+  startTransactionNotAccepted: {
+    connectorId: number;
+    status: string;
+    stopped: boolean;
+  };
 
   // Message events
   messageSent: {

--- a/src/cp/domain/charge-point/Configuration.ts
+++ b/src/cp/domain/charge-point/Configuration.ts
@@ -413,6 +413,17 @@ export const ConfigurationKeys = {
       readonly: false,
       type: "string",
     } as StringConfigurationKey,
+    // Issue #181: when true (default), a LOCAL (self-initiated, non-
+    // remote-start) transaction start sends Authorize.req and awaits
+    // Authorize.conf before StartTransaction.req; Invalid/Expired/Blocked
+    // refuses the start. Mirrors the official OCTT TC_003/004 flows. Set
+    // to false to restore the pre-#181 wire (StartTransaction.req only).
+    AuthorizeBeforeLocalStart: {
+      name: "AuthorizeBeforeLocalStart",
+      required: false,
+      readonly: false,
+      type: "boolean",
+    } as BooleanConfigurationKey,
   },
 };
 
@@ -571,5 +582,6 @@ export const defaultConfiguration: (cp: ChargePoint) => Configuration = (
     // ── Custom (non-standard) ──────────────────────────────────────────
     strVal(ConfigurationKeys.Custom.OcppServer, cp.wsUrl),
     strVal(ConfigurationKeys.Custom.SimulatedFirmwareUpdateFailure, ""),
+    boolVal(ConfigurationKeys.Custom.AuthorizeBeforeLocalStart, true),
   ];
 };

--- a/src/cp/domain/charge-point/ConfigurationStore.ts
+++ b/src/cp/domain/charge-point/ConfigurationStore.ts
@@ -178,6 +178,21 @@ export class ConfigurationStore {
     return this.getBoolean("AuthorizeRemoteTxRequests") ?? false;
   }
 
+  /** Canonical key `StopTransactionOnInvalidId`; default `true`. §7.22:
+   *  whether the CP stops an ongoing transaction when StartTransaction.conf
+   *  carries a non-Accepted idTagInfo.status (issue #181). */
+  stopTransactionOnInvalidId(): boolean {
+    return this.getBoolean("StopTransactionOnInvalidId") ?? true;
+  }
+
+  /** Custom key `AuthorizeBeforeLocalStart`; default `true`. Gates whether
+   *  `ChargePoint.startTransaction` sends Authorize.req and awaits the
+   *  result before a LOCAL (non-remote-start) transaction start
+   *  (issue #181). */
+  authorizeBeforeLocalStart(): boolean {
+    return this.getBoolean("AuthorizeBeforeLocalStart") ?? true;
+  }
+
   /** Canonical key `LocalAuthListEnabled`; default `true`. */
   localAuthListEnabled(): boolean {
     return this.getBoolean("LocalAuthListEnabled") ?? true;

--- a/src/cp/domain/charge-point/__tests__/ChargePoint.authorizeGate.test.ts
+++ b/src/cp/domain/charge-point/__tests__/ChargePoint.authorizeGate.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChargePoint } from "../ChargePoint";
+import { OCPPStatus } from "../../types/OcppTypes";
+import type { BootNotification } from "../../types/OcppTypes";
+import { DefaultBootNotification } from "../../types/OcppTypes";
+
+/**
+ * Issue #181: `ChargePoint.authorizeAndWait` gives `startTransaction` a way
+ * to send Authorize.req and await the matching Authorize.conf before a
+ * LOCAL (non-remote-start) transaction begins. AuthorizeResultHandler has
+ * no direct handle on the request's tagId (AuthorizeResponseV16 carries
+ * none), so correlation happens via the `authorizeResult` event — emitted
+ * here directly (`cp.notifyAuthorizeResult`) as the test seam, mirroring
+ * what AuthorizeResultHandler does once the real CALLRESULT arrives.
+ */
+
+const bootNotification: BootNotification = DefaultBootNotification;
+
+function buildChargePoint(): ChargePoint {
+  return new ChargePoint(
+    "test-cp-181",
+    bootNotification,
+    1,
+    "ws://localhost:8080",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+}
+
+describe("ChargePoint.authorizeAndWait (#181)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves with the idTagInfo.status from the tagId-matched authorizeResult event", async () => {
+    const cp = buildChargePoint();
+    const promise = cp.authorizeAndWait("TAG-A", 5000);
+    cp.notifyAuthorizeResult("TAG-A", "Blocked");
+    await expect(promise).resolves.toBe("Blocked");
+  });
+
+  it("ignores authorizeResult events for a different tagId", async () => {
+    const cp = buildChargePoint();
+    const promise = cp.authorizeAndWait("TAG-A", 5000);
+    cp.notifyAuthorizeResult("TAG-OTHER", "Accepted");
+    cp.notifyAuthorizeResult("TAG-A", "Expired");
+    await expect(promise).resolves.toBe("Expired");
+  });
+
+  it("cleans up its listeners once resolved via the event", async () => {
+    const cp = buildChargePoint();
+    const promise = cp.authorizeAndWait("TAG-A", 5000);
+    cp.notifyAuthorizeResult("TAG-A", "Accepted");
+    await promise;
+    expect(cp.events.listenerCount("authorizeResult")).toBe(0);
+    expect(cp.events.listenerCount("disconnected")).toBe(0);
+  });
+
+  it("times out and resolves 'Accepted' (warn-and-proceed) when no Authorize.conf arrives", async () => {
+    vi.useFakeTimers();
+    const cp = buildChargePoint();
+    const promise = cp.authorizeAndWait("TAG-A", 1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(promise).resolves.toBe("Accepted");
+    expect(cp.events.listenerCount("authorizeResult")).toBe(0);
+  });
+
+  it("resolves 'Accepted' (warn-and-proceed) if disconnected while waiting", async () => {
+    const cp = buildChargePoint();
+    const promise = cp.authorizeAndWait("TAG-A", 5000);
+    cp.events.emit("disconnected", { code: 1006, reason: "test" });
+    await expect(promise).resolves.toBe("Accepted");
+    expect(cp.events.listenerCount("authorizeResult")).toBe(0);
+  });
+});
+
+describe("ChargePoint.startTransaction — local-authorize gate (#181)", () => {
+  it("denies the local start on Invalid Authorize.conf: no transaction begun, authorizeDenied emitted", async () => {
+    const cp = buildChargePoint();
+    const connector = cp.getConnector(1)!;
+    const denied: Array<{
+      connectorId: number;
+      tagId: string;
+      status: string;
+    }> = [];
+    cp.events.on("authorizeDenied", (e) => denied.push(e));
+
+    const promise = cp.startTransaction("BAD-TAG", 1);
+    cp.notifyAuthorizeResult("BAD-TAG", "Invalid");
+    const outcome = await promise;
+
+    expect(outcome).toEqual({ started: false, denialStatus: "Invalid" });
+    expect(connector.transaction).toBeNull();
+    expect(denied).toEqual([
+      { connectorId: 1, tagId: "BAD-TAG", status: "Invalid" },
+    ]);
+  });
+
+  it.each(["Expired", "Blocked"] as const)(
+    "denies the local start on %s Authorize.conf",
+    async (status) => {
+      const cp = buildChargePoint();
+      const promise = cp.startTransaction("BAD-TAG", 1);
+      cp.notifyAuthorizeResult("BAD-TAG", status);
+      const outcome = await promise;
+      expect(outcome).toEqual({ started: false, denialStatus: status });
+    },
+  );
+
+  it("proceeds to start the transaction on Accepted Authorize.conf", async () => {
+    const cp = buildChargePoint();
+    const connector = cp.getConnector(1)!;
+
+    const promise = cp.startTransaction("GOOD-TAG", 1);
+    cp.notifyAuthorizeResult("GOOD-TAG", "Accepted");
+    const outcome = await promise;
+
+    expect(outcome).toEqual({ started: true });
+    expect(connector.transaction).not.toBeNull();
+    expect(connector.status).toBe(OCPPStatus.Preparing);
+  });
+
+  it("AuthorizeBeforeLocalStart=false: sends no Authorize.req and starts immediately", async () => {
+    const cp = buildChargePoint();
+    const applyStatus = cp.configuration.applyChange(
+      "AuthorizeBeforeLocalStart",
+      "false",
+    );
+    expect(applyStatus).toBe("Accepted");
+    const authorizeSpy = vi.spyOn(cp, "authorize");
+    const connector = cp.getConnector(1)!;
+
+    const outcome = await cp.startTransaction("ANY-TAG", 1);
+
+    expect(authorizeSpy).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ started: true });
+    expect(connector.transaction).not.toBeNull();
+    expect(connector.status).toBe(OCPPStatus.Preparing);
+  });
+
+  it("skips the gate for a RemoteStart-triggered start (triggerReason='RemoteStart')", async () => {
+    const cp = buildChargePoint();
+    const authorizeSpy = vi.spyOn(cp, "authorize");
+    const connector = cp.getConnector(1)!;
+
+    const outcome = await cp.startTransaction(
+      "REMOTE-TAG",
+      1,
+      undefined,
+      undefined,
+      { triggerReason: "RemoteStart" },
+    );
+
+    expect(authorizeSpy).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ started: true });
+    expect(connector.transaction).not.toBeNull();
+  });
+});

--- a/src/cp/infrastructure/transport/OCPPMessageHandler.ts
+++ b/src/cp/infrastructure/transport/OCPPMessageHandler.ts
@@ -88,6 +88,7 @@ import {
   StartTransactionResultHandler,
   StopTransactionResultHandler,
   MeterValuesResultHandler,
+  AuthorizeResultHandler,
   DataTransferHandler,
 } from "./handlers";
 
@@ -904,6 +905,10 @@ export class OCPPMessageHandler {
       } else if (action === OCPPAction.MeterValues) {
         handler = new MeterValuesResultHandler(
           request.payload as MeterValuesRequestV16,
+        );
+      } else if (action === OCPPAction.Authorize) {
+        handler = new AuthorizeResultHandler(
+          request.payload as AuthorizeRequestV16,
         );
       }
     }

--- a/src/cp/infrastructure/transport/OCPPMessageHandler.ts
+++ b/src/cp/infrastructure/transport/OCPPMessageHandler.ts
@@ -963,6 +963,18 @@ export class OCPPMessageHandler {
       );
     }
 
+    // Issue #181: a CALLERROR answering Authorize.req is a definite
+    // protocol failure (unlike the authorizeAndWait timeout/disconnect
+    // paths, which proceed fail-OPEN as "Accepted" because the CSMS said
+    // nothing at all). Here the CSMS *did* respond, and what it said was
+    // "I couldn't process this" — so treat it as fail-CLOSED: synthesize
+    // a denial ("Invalid") rather than let authorizeAndWait burn its full
+    // timeout waiting for a CALLRESULT that will never arrive.
+    if (request?.action === OCPPAction.Authorize) {
+      const idTag = (request.payload as AuthorizeRequestV16).idTag;
+      this._chargePoint.notifyAuthorizeResult(idTag, "Invalid");
+    }
+
     this._requests.remove(messageId);
     // §4.1.1: CALLERROR also settles the in-flight CALL.
     this.settleSerialInFlight(messageId);

--- a/src/cp/infrastructure/transport/OCPPMessageHandlerV201.ts
+++ b/src/cp/infrastructure/transport/OCPPMessageHandlerV201.ts
@@ -129,6 +129,15 @@ export class OCPPMessageHandlerV201 implements IChargePointMessageHandler {
   private readonly _dataTransferHandler: DataTransferHandler =
     new DataTransferHandler();
   private readonly _inbound: V201InboundRegistry;
+  /** Tracks in-flight CP→CSMS CALLs by messageId so `handleCallResult` can
+   *  correlate a CALLRESULT back to the request that provoked it (issue
+   *  #181) — e.g. Authorize.conf carries no idToken of its own, so the
+   *  idToken has to come from the original Authorize.req. Entries are
+   *  removed once the matching CALLRESULT/CALLERROR arrives. */
+  private readonly _pendingRequests = new Map<
+    string,
+    { action: V201Action; payload: V201RequestPayload }
+  >();
   private _bootStatus:
     | { status: "Idle" }
     | { status: "Accepted" }
@@ -173,6 +182,7 @@ export class OCPPMessageHandlerV201 implements IChargePointMessageHandler {
     }
     const sent = this._webSocket.sendAction(messageId, action, payload);
     if (sent) {
+      this._pendingRequests.set(messageId, { action, payload });
       this._chargePoint.notifyOutgoingCall(action === "Heartbeat");
     }
   }
@@ -218,14 +228,41 @@ export class OCPPMessageHandlerV201 implements IChargePointMessageHandler {
     } else if (messageType === OCPPMessageType.CALLRESULT) {
       this.handleCallResult(messageId, payload as V201ResponsePayload);
     } else if (messageType === OCPPMessageType.CALLERROR) {
+      this._pendingRequests.delete(messageId);
       this._logger.warn(`[v2.0.1] CALLERROR for ${messageId}`, LogType.OCPP);
     }
   }
 
   private handleCallResult(
-    _messageId: string,
+    messageId: string,
     payload: V201ResponsePayload,
   ): void {
+    const pending = this._pendingRequests.get(messageId);
+    this._pendingRequests.delete(messageId);
+
+    // Issue #181: correlate Authorize.conf back to the idToken from the
+    // original Authorize.req (AuthorizeResponseV201 itself carries none)
+    // and fan it out via the same `authorizeResult` event/notify path the
+    // v16 AuthorizeResultHandler uses, so `ChargePoint.authorizeAndWait`
+    // (the #181 local-authorize gate) resolves promptly for v2.0.1/2.1
+    // local starts instead of always timing out.
+    if (pending?.action === "Authorize") {
+      const authorizeResult = payload as AuthorizeResponseV201;
+      const authorizeRequest = pending.payload as AuthorizeRequestV201;
+      const status = authorizeResult.idTokenInfo?.status;
+      if (status !== undefined) {
+        this._logger.info(
+          `[v2.0.1] Authorize response: ${status}`,
+          LogType.OCPP,
+        );
+        this._chargePoint.notifyAuthorizeResult(
+          authorizeRequest.idToken.idToken,
+          status,
+        );
+      }
+      return;
+    }
+
     const bootResult = payload as BootNotificationResponseV201;
     if (
       bootResult.status !== undefined &&

--- a/src/cp/infrastructure/transport/OCPPMessageHandlerV201.ts
+++ b/src/cp/infrastructure/transport/OCPPMessageHandlerV201.ts
@@ -228,8 +228,25 @@ export class OCPPMessageHandlerV201 implements IChargePointMessageHandler {
     } else if (messageType === OCPPMessageType.CALLRESULT) {
       this.handleCallResult(messageId, payload as V201ResponsePayload);
     } else if (messageType === OCPPMessageType.CALLERROR) {
+      const pending = this._pendingRequests.get(messageId);
       this._pendingRequests.delete(messageId);
       this._logger.warn(`[v2.0.1] CALLERROR for ${messageId}`, LogType.OCPP);
+
+      // Issue #181: a CALLERROR answering Authorize.req is a definite
+      // protocol failure (unlike the authorizeAndWait timeout/disconnect
+      // paths, which proceed fail-OPEN as "Accepted" because the CSMS
+      // said nothing at all). Here the CSMS *did* respond, and what it
+      // said was "I couldn't process this" — so treat it as fail-CLOSED:
+      // synthesize a denial ("Invalid") rather than let authorizeAndWait
+      // burn its full timeout waiting for a CALLRESULT that will never
+      // arrive.
+      if (pending?.action === "Authorize") {
+        const authorizeRequest = pending.payload as AuthorizeRequestV201;
+        this._chargePoint.notifyAuthorizeResult(
+          authorizeRequest.idToken.idToken,
+          "Invalid",
+        );
+      }
     }
   }
 

--- a/src/cp/infrastructure/transport/__tests__/v16AuthorizeGate.bun.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/v16AuthorizeGate.bun.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "bun:test";
+import { startMockCsms, type MockCsms, type OcppFrame } from "./mockCsms";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+
+/**
+ * Issue #181 CodeRabbit follow-up: `OCPPMessageHandler.handleCallError`
+ * (the v1.6 counterpart of `OCPPMessageHandlerV201`'s CALLERROR branch)
+ * used to just drop the pending-request entry and log a warning, ignoring
+ * `request.action`. When the CSMS answered Authorize.req with a CALLERROR
+ * (e.g. FormationViolation), nothing ever resolved the in-flight
+ * `ChargePoint.authorizeAndWait`, so it burned the full 10s timeout before
+ * warn-and-proceeding — the exact stall issue #181 fixes for the happy
+ * (CALLRESULT) path. This suite pins the wire-level fix: a CALLERROR
+ * answering Authorize.req now resolves `authorizeAndWait` immediately with
+ * a synthesized fail-CLOSED denial ("Invalid").
+ */
+
+async function replyStatusNotification(
+  csms: MockCsms,
+  connectorId: number,
+  status: string,
+): Promise<void> {
+  const frame = await csms.waitForFrame(
+    (candidate) =>
+      candidate[0] === 2 &&
+      candidate[2] === "StatusNotification" &&
+      (candidate[3] as { connectorId?: number; status?: string })
+        .connectorId === connectorId &&
+      (candidate[3] as { connectorId?: number; status?: string }).status ===
+        status,
+  );
+  csms.replyCallResult(frame[1] as string, {});
+}
+
+async function expectNoFrame(
+  csms: MockCsms,
+  pred: (frame: OcppFrame) => boolean,
+): Promise<void> {
+  try {
+    const frame = await csms.waitForFrame(pred, 200);
+    throw new Error(`Unexpected frame: ${JSON.stringify(frame)}`);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "Timed out waiting for frame"
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function connectAndBoot(csms: MockCsms, cp: ChargePoint): Promise<void> {
+  cp.connect();
+  const boot = await csms.waitForCall("BootNotification");
+  csms.replyCallResult(boot.messageId, {
+    status: "Accepted",
+    currentTime: "2026-06-24T00:00:00.000Z",
+    interval: 300,
+  });
+  // §4.1.1 serializes outgoing CALLs FIFO, so the initial post-boot
+  // StatusNotifications for connectors 0 and 1 must be acked before
+  // Authorize.req (issued by startTransaction below) can go out.
+  await replyStatusNotification(csms, 0, "Available");
+  await replyStatusNotification(csms, 1, "Available");
+}
+
+function newV16ChargePoint(id: string, url: string): ChargePoint {
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    url,
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  // Deliberately NOT disabling AuthorizeBeforeLocalStart — this suite
+  // exists specifically to exercise the gate at its real-world default.
+  return cp;
+}
+
+describe("OCPP 1.6 local-authorize gate — CALLERROR handling (#181)", () => {
+  it("gate ON + CSMS answers Authorize with a CALLERROR: resolves PROMPTLY (no ~10s stall) and denies fail-CLOSED", async () => {
+    const csms = startMockCsms();
+    const cp = newV16ChargePoint("CP016-AUTHGATE-CALLERROR", csms.url);
+    const tagId = "TAG-16-AUTHGATE-CALLERROR";
+
+    try {
+      await connectAndBoot(csms, cp);
+
+      const startedAt = Date.now();
+      const startPromise = cp.startTransaction(tagId, 1);
+
+      const authCall = await csms.waitForCall("Authorize");
+      expect(authCall.payload).toEqual({ idTag: tagId });
+      // OCPP-J CALLERROR: [4, messageId, errorCode, errorDescription, errorDetails]
+      csms.send([
+        4,
+        authCall.messageId,
+        "FormationViolation",
+        "bad payload",
+        {},
+      ]);
+
+      const outcome = await startPromise;
+      const elapsedMs = Date.now() - startedAt;
+
+      // Before this fix, handleCallError ignored request.action entirely,
+      // so this only ever resolved via authorizeAndWait's 10_000ms
+      // timeout. A generous 3s ceiling proves resolution rode the
+      // CALLERROR, not the timeout.
+      expect(elapsedMs).toBeLessThan(3000);
+      // Fail-CLOSED: a CALLERROR is a definite protocol failure (unlike
+      // silence, which fails open per authorizeAndWait's timeout/
+      // disconnect paths), so the synthesized denial status is "Invalid"
+      // and the local start does not proceed.
+      expect(outcome).toEqual({ started: false, denialStatus: "Invalid" });
+      expect(cp.getConnector(1)?.transaction).toBeNull();
+      await expectNoFrame(
+        csms,
+        (frame) => frame[0] === 2 && frame[2] === "StartTransaction",
+      );
+    } finally {
+      cp.disconnect();
+      await csms.stop();
+    }
+  }, 5000);
+});

--- a/src/cp/infrastructure/transport/__tests__/v16Transaction.bun.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/v16Transaction.bun.test.ts
@@ -56,6 +56,12 @@ describe("OCPP 1.6 transaction lifecycle (golden)", () => {
       {},
     );
     cp.events.on("error", () => undefined);
+    // This test pins the #176 Preparing-before-StartTransaction wire
+    // order, not the #181 local-authorize gate — disable it so
+    // startTransaction() below doesn't wait on an Authorize.conf this
+    // mock CSMS never answers. The #181 Authorize-first wire is covered
+    // by the TC_023 scenario specs (issue #181 Task 4).
+    cp.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
 
     try {
       cp.connect();

--- a/src/cp/infrastructure/transport/__tests__/v201AuthorizeGate.bun.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/v201AuthorizeGate.bun.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "bun:test";
+import type {
+  AuthorizeRequestV201,
+  TransactionEventRequestV201,
+} from "../../../../ocpp";
+import { startMockCsms, type MockCsms, type OcppFrame } from "./mockCsms";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+
+/**
+ * Issue #181 (review follow-up): the local-authorize gate in
+ * `ChargePoint.startTransaction` defaults ON for every OCPP version, but
+ * until this fix `OCPPMessageHandlerV201.handleCallResult` never correlated
+ * Authorize.conf back to the ChargePoint — it only handled BootNotification.
+ * Every v201 local start therefore always burned the full 10s
+ * `authorizeAndWait` timeout and then proceeded as "Accepted" regardless of
+ * what the CSMS actually said.
+ *
+ * Every OTHER v201 bun suite disables the gate
+ * (`AuthorizeBeforeLocalStart=false`) specifically to dodge this — that's
+ * what let the bug hide. This suite is the one place it must stay at its
+ * real-world default (true) and exercise the actual wire correlation via
+ * the mock CSMS, not the `notifyAuthorizeResult` test seam.
+ */
+
+function transactionEventFrame(
+  eventType: TransactionEventRequestV201["eventType"],
+): (frame: OcppFrame) => boolean {
+  return (frame) =>
+    frame[0] === 2 &&
+    frame[2] === "TransactionEvent" &&
+    (frame[3] as { eventType?: string }).eventType === eventType;
+}
+
+async function expectNoFrame(
+  csms: MockCsms,
+  pred: (frame: OcppFrame) => boolean,
+): Promise<void> {
+  try {
+    const frame = await csms.waitForFrame(pred, 200);
+    throw new Error(`Unexpected frame: ${JSON.stringify(frame)}`);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "Timed out waiting for frame"
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function connectAndBoot(csms: MockCsms, cp: ChargePoint): Promise<void> {
+  cp.connect();
+  const boot = await csms.waitForCall("BootNotification");
+  csms.replyCallResult(boot.messageId, {
+    status: "Accepted",
+    currentTime: "2026-06-24T00:00:00.000Z",
+    interval: 300,
+  });
+  await csms.waitForFrame(
+    (frame) =>
+      frame[0] === 2 &&
+      frame[2] === "StatusNotification" &&
+      (frame[3] as { evseId?: number; connectorId?: number }).evseId === 1 &&
+      (frame[3] as { evseId?: number; connectorId?: number }).connectorId === 1,
+  );
+}
+
+function newV201ChargePoint(id: string, url: string): ChargePoint {
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    url,
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-2.0.1",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  // Deliberately NOT disabling AuthorizeBeforeLocalStart here (every other
+  // v201 bun suite does) — this suite exists specifically to exercise the
+  // gate at its real default.
+  return cp;
+}
+
+describe("OCPP 2.0.1 local-authorize gate (#181)", () => {
+  it("gate ON + CSMS Accepts: sends Authorize.req and starts PROMPTLY (no ~10s stall)", async () => {
+    const csms = startMockCsms();
+    const cp = newV201ChargePoint("CP201-AUTHGATE-OK", csms.url);
+    const tagId = "TAG-201-AUTHGATE-OK";
+
+    try {
+      await connectAndBoot(csms, cp);
+
+      const startedAt = Date.now();
+      const startPromise = cp.startTransaction(tagId, 1);
+
+      const authCall = await csms.waitForCall("Authorize");
+      expect(authCall.payload).toEqual({
+        idToken: { idToken: tagId, type: "ISO14443" },
+      } satisfies AuthorizeRequestV201);
+      csms.replyCallResult(authCall.messageId, {
+        idTokenInfo: { status: "Accepted" },
+      });
+
+      const outcome = await startPromise;
+      const elapsedMs = Date.now() - startedAt;
+
+      expect(outcome).toEqual({ started: true });
+      // authorizeAndWait's default timeout is 10_000ms. Before this fix,
+      // handleCallResult never correlated Authorize.conf, so this only
+      // ever resolved via that timeout. A generous 3s ceiling proves
+      // resolution rode the immediate Authorize.conf, not the timeout.
+      expect(elapsedMs).toBeLessThan(3000);
+
+      const startedFrame = await csms.waitForFrame(
+        transactionEventFrame("Started"),
+      );
+      expect((startedFrame[3] as TransactionEventRequestV201).idToken).toEqual({
+        idToken: tagId,
+        type: "ISO14443",
+      });
+      expect(cp.getConnector(1)?.transaction).not.toBeNull();
+    } finally {
+      cp.disconnect();
+      await csms.stop();
+    }
+  }, 5000);
+
+  it("gate ON + CSMS denies (Blocked): no transaction starts", async () => {
+    const csms = startMockCsms();
+    const cp = newV201ChargePoint("CP201-AUTHGATE-BLOCKED", csms.url);
+    const tagId = "TAG-201-AUTHGATE-BLOCKED";
+
+    try {
+      await connectAndBoot(csms, cp);
+
+      const startPromise = cp.startTransaction(tagId, 1);
+
+      const authCall = await csms.waitForCall("Authorize");
+      csms.replyCallResult(authCall.messageId, {
+        idTokenInfo: { status: "Blocked" },
+      });
+
+      const outcome = await startPromise;
+
+      expect(outcome).toEqual({ started: false, denialStatus: "Blocked" });
+      expect(cp.getConnector(1)?.transaction).toBeNull();
+      await expectNoFrame(csms, transactionEventFrame("Started"));
+    } finally {
+      cp.disconnect();
+      await csms.stop();
+    }
+  });
+
+  it("gate ON + CSMS denies (Invalid): no transaction starts", async () => {
+    const csms = startMockCsms();
+    const cp = newV201ChargePoint("CP201-AUTHGATE-INVALID", csms.url);
+    const tagId = "TAG-201-AUTHGATE-INVALID";
+
+    try {
+      await connectAndBoot(csms, cp);
+
+      const startPromise = cp.startTransaction(tagId, 1);
+
+      const authCall = await csms.waitForCall("Authorize");
+      csms.replyCallResult(authCall.messageId, {
+        idTokenInfo: { status: "Invalid" },
+      });
+
+      const outcome = await startPromise;
+
+      expect(outcome).toEqual({ started: false, denialStatus: "Invalid" });
+      expect(cp.getConnector(1)?.transaction).toBeNull();
+      await expectNoFrame(csms, transactionEventFrame("Started"));
+    } finally {
+      cp.disconnect();
+      await csms.stop();
+    }
+  });
+});

--- a/src/cp/infrastructure/transport/__tests__/v201AuthorizeGate.bun.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/v201AuthorizeGate.bun.test.ts
@@ -183,4 +183,46 @@ describe("OCPP 2.0.1 local-authorize gate (#181)", () => {
       await csms.stop();
     }
   });
+
+  it("gate ON + CSMS answers Authorize with a CALLERROR: resolves PROMPTLY (no ~10s stall) and denies fail-CLOSED", async () => {
+    const csms = startMockCsms();
+    const cp = newV201ChargePoint("CP201-AUTHGATE-CALLERROR", csms.url);
+    const tagId = "TAG-201-AUTHGATE-CALLERROR";
+
+    try {
+      await connectAndBoot(csms, cp);
+
+      const startedAt = Date.now();
+      const startPromise = cp.startTransaction(tagId, 1);
+
+      const authCall = await csms.waitForCall("Authorize");
+      // OCPP-J CALLERROR: [4, messageId, errorCode, errorDescription, errorDetails]
+      csms.send([
+        4,
+        authCall.messageId,
+        "FormationViolation",
+        "bad payload",
+        {},
+      ]);
+
+      const outcome = await startPromise;
+      const elapsedMs = Date.now() - startedAt;
+
+      // Before this fix, a CALLERROR was never correlated back to the
+      // pending Authorize.req: `handleIncomingMessage`'s CALLERROR branch
+      // only deleted the pending entry and logged, so `authorizeAndWait`
+      // burned its full 10_000ms timeout. A generous 3s ceiling proves
+      // resolution rode the CALLERROR, not the timeout.
+      expect(elapsedMs).toBeLessThan(3000);
+      // Fail-CLOSED: a CALLERROR is a definite protocol failure (unlike
+      // silence, which fails open), so the synthesized denial status is
+      // "Invalid" and the local start does not proceed.
+      expect(outcome).toEqual({ started: false, denialStatus: "Invalid" });
+      expect(cp.getConnector(1)?.transaction).toBeNull();
+      await expectNoFrame(csms, transactionEventFrame("Started"));
+    } finally {
+      cp.disconnect();
+      await csms.stop();
+    }
+  }, 5000);
 });

--- a/src/cp/infrastructure/transport/__tests__/v201Reservation.bun.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/v201Reservation.bun.test.ts
@@ -101,6 +101,10 @@ function newChargePoint(id: string): {
     {},
   );
   cp.events.on("error", () => undefined);
+  // This suite exercises Reservation semantics, not the #181 local-
+  // authorize gate — disable it so the setup `startTransaction()` calls
+  // below don't wait on an Authorize.conf the mock CSMS never answers.
+  cp.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
   return { csms, cp };
 }
 

--- a/src/cp/infrastructure/transport/__tests__/v201Reset.bun.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/v201Reset.bun.test.ts
@@ -126,6 +126,10 @@ function newChargePoint(
     {},
   );
   cp.events.on("error", () => undefined);
+  // This suite exercises Reset semantics, not the #181 local-authorize
+  // gate — disable it so the setup `startTransaction()` calls below don't
+  // wait on an Authorize.conf the mock CSMS never answers.
+  cp.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
   return { csms, cp };
 }
 

--- a/src/cp/infrastructure/transport/__tests__/v201ScenarioParity.bun.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/v201ScenarioParity.bun.test.ts
@@ -80,6 +80,11 @@ function newChargePoint(id: string): {
     {},
   );
   chargePoint.events.on("error", () => undefined);
+  // This suite exercises RequestStopTransaction/scenario-parity semantics,
+  // not the #181 local-authorize gate — disable it so the helper
+  // `startTransaction()` calls below don't wait on an Authorize.conf the
+  // mock CSMS never answers.
+  chargePoint.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
   return { csms, chargePoint };
 }
 

--- a/src/cp/infrastructure/transport/__tests__/v201Transaction.bun.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/v201Transaction.bun.test.ts
@@ -146,6 +146,10 @@ describe("OCPP 2.0.1 transaction events", () => {
       {},
     );
     cp.events.on("error", () => undefined);
+    // This suite exercises TransactionEvent wire-building, not the #181
+    // local-authorize gate — disable it so startTransaction() below
+    // doesn't wait on an Authorize.conf the mock CSMS never answers.
+    cp.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
 
     try {
       cp.connect();
@@ -258,6 +262,10 @@ describe("OCPP 2.0.1 transaction events", () => {
       {},
     );
     cp.events.on("error", () => undefined);
+    // This suite exercises TransactionEvent wire-building, not the #181
+    // local-authorize gate — disable it so startTransaction() below
+    // doesn't wait on an Authorize.conf the mock CSMS never answers.
+    cp.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
 
     try {
       cp.connect();
@@ -430,6 +438,10 @@ describe("OCPP 2.0.1 transaction events", () => {
       {},
     );
     cp.events.on("error", () => undefined);
+    // This suite exercises TransactionEvent wire-building, not the #181
+    // local-authorize gate — disable it so startTransaction() below
+    // doesn't wait on an Authorize.conf the mock CSMS never answers.
+    cp.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
 
     try {
       cp.connect();
@@ -503,6 +515,10 @@ describe("OCPP 2.0.1 transaction events", () => {
       {},
     );
     cp.events.on("error", () => undefined);
+    // This suite exercises TransactionEvent wire-building, not the #181
+    // local-authorize gate — disable it so startTransaction() below
+    // doesn't wait on an Authorize.conf the mock CSMS never answers.
+    cp.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
 
     const knownCpTransactionId = "cp-tx-known";
     const restoredTransaction: Transaction = {
@@ -589,6 +605,10 @@ describe("OCPP 2.0.1 transaction events", () => {
         {},
       );
       cp.events.on("error", () => undefined);
+      // This suite exercises TransactionEvent wire-building, not the #181
+      // local-authorize gate — disable it so startTransaction() below
+      // doesn't wait on an Authorize.conf the mock CSMS never answers.
+      cp.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
       return cp;
     };
 

--- a/src/cp/infrastructure/transport/__tests__/v201UnlockConnector.bun.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/v201UnlockConnector.bun.test.ts
@@ -80,6 +80,10 @@ function newChargePoint(id: string): {
     {},
   );
   cp.events.on("error", () => undefined);
+  // This suite exercises UnlockConnector semantics, not the #181 local-
+  // authorize gate — disable it so the setup `startTransaction()` call
+  // below doesn't wait on an Authorize.conf the mock CSMS never answers.
+  cp.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
   return { csms, cp };
 }
 

--- a/src/cp/infrastructure/transport/handlers/__tests__/buildV16CallHandlerRegistry.test.ts
+++ b/src/cp/infrastructure/transport/handlers/__tests__/buildV16CallHandlerRegistry.test.ts
@@ -106,13 +106,12 @@ describe("buildV16CallHandlerRegistry", () => {
   });
 
   describe("CALLRESULT handlers", () => {
-    it("registers all OCPP 1.6 CALLRESULT handlers", () => {
+    it("registers the stateless OCPP 1.6 CALLRESULT handlers", () => {
       const registry = buildV16CallHandlerRegistry();
 
       expect(
         registry.getCallResultHandler(OCPPAction.BootNotification),
       ).toBeDefined();
-      expect(registry.getCallResultHandler(OCPPAction.Authorize)).toBeDefined();
       expect(registry.getCallResultHandler(OCPPAction.Heartbeat)).toBeDefined();
       expect(
         registry.getCallResultHandler(OCPPAction.StatusNotification),
@@ -120,6 +119,17 @@ describe("buildV16CallHandlerRegistry", () => {
       expect(
         registry.getCallResultHandler(OCPPAction.DataTransfer),
       ).toBeDefined();
+    });
+
+    it("does NOT register Authorize CALLRESULT handler (per-request, needs the request's idTag — #181)", () => {
+      const registry = buildV16CallHandlerRegistry();
+      // Mirrors StartTransaction/StopTransaction/MeterValues below:
+      // OCPPMessageHandler.handleCallResult constructs it dynamically from
+      // request.payload so it can correlate the `authorizeResult` event
+      // with the tagId Authorize.conf itself doesn't carry.
+      expect(
+        registry.getCallResultHandler(OCPPAction.Authorize),
+      ).toBeUndefined();
     });
 
     it("returns undefined for unregistered CALLRESULT actions", () => {

--- a/src/cp/infrastructure/transport/handlers/buildV16CallHandlerRegistry.ts
+++ b/src/cp/infrastructure/transport/handlers/buildV16CallHandlerRegistry.ts
@@ -27,7 +27,6 @@ import {
   GetLogHandler,
   SignedUpdateFirmwareHandler,
   BootNotificationResultHandler,
-  AuthorizeResultHandler,
   HeartbeatResultHandler,
   StatusNotificationResultHandler,
   DataTransferResultHandler,
@@ -179,10 +178,11 @@ export function buildV16CallHandlerRegistry(): MessageHandlerRegistry {
     OCPPAction.BootNotification,
     new BootNotificationResultHandler(),
   );
-  registry.registerCallResultHandler(
-    OCPPAction.Authorize,
-    new AuthorizeResultHandler(),
-  );
+  // NOTE: Authorize CALLRESULT handler is intentionally NOT registered
+  // here (issue #181). It needs the original Authorize.req's idTag to
+  // correlate the `authorizeResult` event, so OCPPMessageHandler.
+  // handleCallResult constructs it per-request from `request.payload`,
+  // mirroring StartTransaction/StopTransaction/MeterValues below.
   registry.registerCallResultHandler(
     OCPPAction.Heartbeat,
     new HeartbeatResultHandler(),

--- a/src/cp/infrastructure/transport/handlers/call/RemoteStartTransactionHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/RemoteStartTransactionHandler.ts
@@ -47,7 +47,19 @@ export class RemoteStartTransactionHandler implements CallHandler<
       // Scenario is waiting for RemoteStart - let it handle the transaction flow
       context.chargePoint.notifyRemoteStartReceived(resolvedConnectorId, idTag);
     } else {
-      context.chargePoint.startTransaction(idTag, resolvedConnectorId);
+      // triggerReason: "RemoteStart" marks this as CSMS-initiated so
+      // ChargePoint.startTransaction's #181 local-authorize gate doesn't
+      // double-authorize on top of the AuthorizeRemoteTxRequests handling
+      // above (parity with the OCPP 2.0.1 RequestStartTransaction path).
+      context.chargePoint.startTransaction(
+        idTag,
+        resolvedConnectorId,
+        undefined,
+        undefined,
+        {
+          triggerReason: "RemoteStart",
+        },
+      );
     }
     return { status: "Accepted" };
   }

--- a/src/cp/infrastructure/transport/handlers/callresult/TransactionResultHandlers.ts
+++ b/src/cp/infrastructure/transport/handlers/callresult/TransactionResultHandlers.ts
@@ -1,5 +1,6 @@
 import { CallResultHandler, HandlerContext } from "../MessageHandlerRegistry";
 import type {} from "../../../../../ocpp";
+import type { AuthorizeRequestV16 } from "../../../../../ocpp";
 import { OCPPStatus } from "../../../../domain/types/OcppTypes";
 import { LogType } from "../../../../shared/Logger";
 
@@ -36,23 +37,38 @@ export class StartTransactionResultHandler implements CallResultHandler<StartTra
         }
       }
     } else {
-      context.logger.error("Failed to start transaction", LogType.TRANSACTION);
+      // Issue #181: §4.8 StopTransactionOnInvalidId — a non-Accepted
+      // idTagInfo on StartTransaction.conf either administratively stops
+      // the transaction (DeAuthorized, default) or is logged and the
+      // transaction keeps running, per the key's value.
+      const status = idTagInfo.status;
+      const stopOnInvalid =
+        context.chargePoint.configuration.stopTransactionOnInvalidId();
+      context.logger.warn(
+        `StartTransaction not accepted (${status}) for connector ${this.connectorId}; StopTransactionOnInvalidId=${stopOnInvalid}`,
+        LogType.TRANSACTION,
+      );
       if (connector) {
-        connector.status = OCPPStatus.Faulted;
-        if (connector.transaction && connector.transaction.meterSent) {
-          context.chargePoint.stopTransaction(connector);
-        } else {
-          context.chargePoint.cleanTransaction(connector);
+        // Record the CSMS-assigned transactionId regardless of outcome —
+        // §4.8 guarantees it's present even on rejection, and the
+        // DeAuthorized StopTransaction.req below needs it to correlate.
+        connector.transactionId = transactionId;
+        if (stopOnInvalid) {
+          context.chargePoint.stopTransaction(connector, "DeAuthorized");
+        } else if (connector.status !== OCPPStatus.Charging) {
+          // StopTransactionOnInvalidId=false: the CP doesn't stop on its
+          // own initiative — the transaction proceeds as if accepted.
+          context.chargePoint.updateConnectorStatus(
+            this.connectorId,
+            OCPPStatus.Charging,
+          );
         }
-      } else {
-        context.chargePoint.cleanTransaction(this.connectorId);
       }
-      if (!connector || connector.status !== OCPPStatus.Available) {
-        context.chargePoint.updateConnectorStatus(
-          this.connectorId,
-          OCPPStatus.Available,
-        );
-      }
+      context.chargePoint.notifyStartTransactionNotAccepted(
+        this.connectorId,
+        status,
+        stopOnInvalid,
+      );
     }
   }
 }
@@ -89,12 +105,25 @@ export class StopTransactionResultHandler implements CallResultHandler<StopTrans
 }
 
 export class AuthorizeResultHandler implements CallResultHandler<AuthorizeResponseV16> {
+  /** `requestPayload` is the original Authorize.req this CALLRESULT answers
+   *  — AuthorizeResponseV16 itself carries no idTag, so the handler needs
+   *  it from the request to correlate the `authorizeResult` event
+   *  (issue #181). Constructed dynamically per-request by
+   *  OCPPMessageHandler.handleCallResult, mirroring MeterValuesResultHandler. */
+  constructor(private requestPayload?: AuthorizeRequestV16) {}
+
   handle(payload: AuthorizeResponseV16, context: HandlerContext): void {
     const { idTagInfo } = payload;
     if (idTagInfo.status === "Accepted") {
       context.logger.info("Authorization successful", LogType.TRANSACTION);
     } else {
       context.logger.warn("Authorization failed", LogType.TRANSACTION);
+    }
+    if (this.requestPayload) {
+      context.chargePoint.notifyAuthorizeResult(
+        this.requestPayload.idTag,
+        idTagInfo.status,
+      );
     }
   }
 }

--- a/src/cp/infrastructure/transport/handlers/callresult/__tests__/TransactionResultHandlers.test.ts
+++ b/src/cp/infrastructure/transport/handlers/callresult/__tests__/TransactionResultHandlers.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  AuthorizeResultHandler,
   StartTransactionResultHandler,
   StopTransactionResultHandler,
 } from "../TransactionResultHandlers";
@@ -36,7 +37,7 @@ import type { HandlerContext } from "../../MessageHandlerRegistry";
 const bootNotification: BootNotification = DefaultBootNotification;
 
 function buildChargePoint(): ChargePoint {
-  return new ChargePoint(
+  const cp = new ChargePoint(
     "test-cp-175",
     bootNotification,
     1,
@@ -49,6 +50,13 @@ function buildChargePoint(): ChargePoint {
     "OCPP-1.6J",
     {},
   );
+  // These are #175/#176 status-cascade tests, not #181 authorize-gate
+  // tests — disable the (default-on) local-authorize gate so
+  // startTransaction() keeps its pre-#181 fully-synchronous behavior here.
+  // Tests that specifically exercise the #181 gate use their own
+  // ChargePoint instance (see buildGatedChargePoint below).
+  cp.configuration.applyChange("AuthorizeBeforeLocalStart", "false");
+  return cp;
 }
 
 function buildContext(cp: ChargePoint): HandlerContext {
@@ -204,5 +212,136 @@ describe("StopTransactionResultHandler (#175)", () => {
 
     expect(changes).toEqual([OCPPStatus.Finishing]);
     expect(connector.status).toBe(OCPPStatus.Finishing);
+  });
+});
+
+/**
+ * Issue #181: StartTransaction.conf with a non-Accepted idTagInfo.status is
+ * now acted on per §4.8 `StopTransactionOnInvalidId` — default true stops
+ * the transaction with reason "DeAuthorized" (delegating to
+ * ChargePoint.stopTransaction, so the #175/#176 Finishing/Available
+ * cascade applies exactly as a normal stop would); false leaves the
+ * transaction running. Either way a `startTransactionNotAccepted` event is
+ * emitted for observability.
+ */
+describe("StartTransactionResultHandler (#181) — StopTransactionOnInvalidId", () => {
+  it("stops the transaction with reason DeAuthorized when StopTransactionOnInvalidId=true (default)", () => {
+    const cp = buildChargePoint();
+    const connector = cp.getConnector(1)!;
+    cp.startTransaction("TAG-181-A", 1);
+
+    const stopSpy = vi.spyOn(cp, "stopTransaction");
+    const stopped: Array<{ connectorId: number; transactionId: number }> = [];
+    cp.events.on("transactionStopped", (e) => stopped.push(e));
+    const notAccepted: Array<{
+      connectorId: number;
+      status: string;
+      stopped: boolean;
+    }> = [];
+    cp.events.on("startTransactionNotAccepted", (e) => notAccepted.push(e));
+
+    new StartTransactionResultHandler(1).handle(
+      { transactionId: 555, idTagInfo: { status: "Invalid" } },
+      buildContext(cp),
+    );
+
+    // ChargePoint.stopTransaction() clears connector.transaction as part of
+    // its normal cascade — the CSMS-assigned id is only observable via the
+    // stopTransaction() call itself and the transactionStopped event.
+    expect(stopSpy).toHaveBeenCalledWith(connector, "DeAuthorized");
+    expect(stopped).toEqual([{ connectorId: 1, transactionId: 555 }]);
+    expect(connector.transaction).toBeNull();
+    expect(connector.status).toBe(OCPPStatus.Available);
+    expect(notAccepted).toEqual([
+      { connectorId: 1, status: "Invalid", stopped: true },
+    ]);
+  });
+
+  it("keeps the transaction running (Charging) and only logs+emits when StopTransactionOnInvalidId=false", () => {
+    const cp = buildChargePoint();
+    const applyStatus = cp.configuration.applyChange(
+      "StopTransactionOnInvalidId",
+      "false",
+    );
+    expect(applyStatus).toBe("Accepted");
+    const connector = cp.getConnector(1)!;
+    cp.startTransaction("TAG-181-B", 1);
+
+    const stopped: unknown[] = [];
+    cp.events.on("transactionStopped", (e) => stopped.push(e));
+    const notAccepted: Array<{
+      connectorId: number;
+      status: string;
+      stopped: boolean;
+    }> = [];
+    cp.events.on("startTransactionNotAccepted", (e) => notAccepted.push(e));
+
+    new StartTransactionResultHandler(1).handle(
+      { transactionId: 777, idTagInfo: { status: "Expired" } },
+      buildContext(cp),
+    );
+
+    expect(stopped).toEqual([]);
+    expect(connector.transaction).not.toBeNull();
+    expect(connector.transaction?.id).toBe(777);
+    expect(connector.status).toBe(OCPPStatus.Charging);
+    expect(notAccepted).toEqual([
+      { connectorId: 1, status: "Expired", stopped: false },
+    ]);
+  });
+
+  it("StopTransactionOnInvalidId=false does not re-drive Charging when already there (idempotent)", () => {
+    const cp = buildChargePoint();
+    cp.configuration.applyChange("StopTransactionOnInvalidId", "false");
+    const connector = cp.getConnector(1)!;
+    cp.startTransaction("TAG-181-C", 1);
+    cp.updateConnectorStatus(1, OCPPStatus.Charging);
+
+    const changes: OCPPStatus[] = [];
+    cp.events.on("connectorStatusChange", (e) => changes.push(e.status));
+
+    new StartTransactionResultHandler(1).handle(
+      { transactionId: 888, idTagInfo: { status: "Blocked" } },
+      buildContext(cp),
+    );
+
+    expect(changes).toEqual([]);
+    expect(connector.status).toBe(OCPPStatus.Charging);
+  });
+});
+
+/**
+ * Issue #181: AuthorizeResultHandler now emits `authorizeResult` (tagId +
+ * idTagInfo.status) so ChargePoint.authorizeAndWait can resolve. tagId
+ * comes from the original Authorize.req payload the handler is
+ * constructed with — OCPPMessageHandler.handleCallResult builds it
+ * per-request (mirroring MeterValuesResultHandler), so `handle()` itself
+ * stays pure/stateless when constructed without one.
+ */
+describe("AuthorizeResultHandler (#181)", () => {
+  it("emits authorizeResult with the request's idTag and the response status", () => {
+    const cp = buildChargePoint();
+    const events: Array<{ tagId: string; status: string }> = [];
+    cp.events.on("authorizeResult", (e) => events.push(e));
+
+    new AuthorizeResultHandler({ idTag: "TAG-9" }).handle(
+      { idTagInfo: { status: "Blocked" } },
+      buildContext(cp),
+    );
+
+    expect(events).toEqual([{ tagId: "TAG-9", status: "Blocked" }]);
+  });
+
+  it("does not emit when constructed without a request payload", () => {
+    const cp = buildChargePoint();
+    const events: unknown[] = [];
+    cp.events.on("authorizeResult", (e) => events.push(e));
+
+    new AuthorizeResultHandler().handle(
+      { idTagInfo: { status: "Accepted" } },
+      buildContext(cp),
+    );
+
+    expect(events).toEqual([]);
   });
 });

--- a/src/cp/infrastructure/transport/soap/OCPPSoapHandler.ts
+++ b/src/cp/infrastructure/transport/soap/OCPPSoapHandler.ts
@@ -759,7 +759,7 @@ export class OCPPSoapHandler implements IChargePointMessageHandler {
   public authorize(tagId: string): void {
     const payload: AuthorizeRequestV16 = { idTag: tagId };
     this.enqueueRequest("Authorize", soapPayload(payload), (env) => {
-      new AuthorizeResultHandler().handle(
+      new AuthorizeResultHandler(payload).handle(
         this.authorizeResponseFromPayload(env.payload),
         this.handlerContext(),
       );

--- a/src/utils/scenarioTemplates.test.ts
+++ b/src/utils/scenarioTemplates.test.ts
@@ -59,6 +59,9 @@ const EXPECTED_CERT16_IDS = [
   "cert16-tc044-2-firmware-download-failed",
   "cert16-tc044-3-firmware-install-failed",
   "cert16-tc045-1-get-diagnostics",
+  "cert16-tc023-1-authorize-invalid",
+  "cert16-tc023-2-authorize-expired",
+  "cert16-tc023-3-authorize-blocked",
 ];
 
 /** BFS from the single start node; true if any END node is reachable. */

--- a/src/utils/scenarioTemplates.ts
+++ b/src/utils/scenarioTemplates.ts
@@ -64,6 +64,14 @@ import cert16Tc044_2FirmwareDownloadFailedJson from "./scenarios/cert16-tc044-2-
 import cert16Tc044_3FirmwareInstallFailedJson from "./scenarios/cert16-tc044-3-firmware-install-failed.json";
 import cert16Tc045_1GetDiagnosticsJson from "./scenarios/cert16-tc045-1-get-diagnostics.json";
 
+// OCPP 1.6 Authorize outcome certification scenarios (issue #181): the
+// local-start Authorize gate landed in #181 makes these newly expressible
+// (a denied Authorize.conf is now a non-throwing scenario skip instead of
+// an unmodeled no-op) — see the README's Out-of-Scope section history.
+import cert16Tc023_1AuthorizeInvalidJson from "./scenarios/cert16-tc023-1-authorize-invalid.json";
+import cert16Tc023_2AuthorizeExpiredJson from "./scenarios/cert16-tc023-2-authorize-expired.json";
+import cert16Tc023_3AuthorizeBlockedJson from "./scenarios/cert16-tc023-3-authorize-blocked.json";
+
 export interface ScenarioTemplate {
   id: string;
   name: string;
@@ -212,6 +220,12 @@ export const scenarioTemplates: ScenarioTemplate[] = [
     cert16Tc044_3FirmwareInstallFailedJson as ScenarioDefinition,
   ),
   templateFromJson(cert16Tc045_1GetDiagnosticsJson as ScenarioDefinition),
+
+  // OCPP 1.6 Authorize outcome certification scenarios (issue #181) —
+  // grouped together so they surface as a block in the template picker.
+  templateFromJson(cert16Tc023_1AuthorizeInvalidJson as ScenarioDefinition),
+  templateFromJson(cert16Tc023_2AuthorizeExpiredJson as ScenarioDefinition),
+  templateFromJson(cert16Tc023_3AuthorizeBlockedJson as ScenarioDefinition),
 ];
 
 export function getTemplateById(

--- a/src/utils/scenarios/README.md
+++ b/src/utils/scenarios/README.md
@@ -56,6 +56,9 @@ These built-in JSON templates implement the Charge Point side of OCPP 1.6 certif
 | cert16-tc044-2-firmware-download-failed             | TC_044.2 | Firmware Update — Download Failed         | Firmware      | Pre-arms SimulatedFirmwareUpdateFailure=DownloadFailed (one-shot config auto-cleared after next UpdateFirmware). CSMS sends UpdateFirmware.req. Verify CP sends Downloading then DownloadFailed.                                               |
 | cert16-tc044-3-firmware-install-failed              | TC_044.3 | Firmware Update — Installation Failed     | Firmware      | Pre-arms SimulatedFirmwareUpdateFailure=InstallationFailed (one-shot config auto-cleared after next UpdateFirmware). CSMS sends UpdateFirmware.req. Verify CP progresses Downloading → Downloaded → Installing → InstallationFailed.           |
 | cert16-tc045-1-get-diagnostics                      | TC_045.1 | Get Diagnostics                           | Firmware      | CSMS sends GetDiagnostics.req with an upload location. CP responds with fileName and sends DiagnosticsStatusNotification (Uploading, then Uploaded or UploadFailed depending on HTTP response).                                                |
+| cert16-tc023-1-authorize-invalid                    | TC_023.1 | Authorize Outcome (Invalid)               | Core          | Ensure idTag CERT023-INV is unknown to the CSMS. Plug in. Verify the CP sends Authorize.req, receives idTagInfo.status Invalid, and does NOT send StartTransaction.req. Plug out.                                                              |
+| cert16-tc023-2-authorize-expired                    | TC_023.2 | Authorize Outcome (Expired)               | Core          | Ensure idTag CERT023-EXP is registered with an expiry_date in the past. Plug in. Verify the CP sends Authorize.req, receives idTagInfo.status Expired, and does NOT send StartTransaction.req. Plug out.                                       |
+| cert16-tc023-3-authorize-blocked                    | TC_023.3 | Authorize Outcome (Blocked)               | Core          | Ensure idTag CERT023-BLK is registered as blocked. Plug in. Verify the CP sends Authorize.req, receives idTagInfo.status Blocked, and does NOT send StartTransaction.req. Plug out.                                                            |
 
 ## Numbering Note
 
@@ -91,8 +94,7 @@ When using the `responseOverride` node to arm a one-shot response override for a
 
 The following test cases are not covered by scenarios:
 
-- **TC_007** (Cached Authorization) — No scenario-drivable Authorize flow with cache orchestration.
-- **TC_023** (Authorize Outcome Variants) — No scenario-drivable Authorize request/response orchestration.
+- **TC_007** (Cached Authorization) — the local auth list is write-only in this simulator today (SendLocalList populates it, but nothing consults it on a local start — see issue #181's core report); there's no auth-cache seam to drive a "cached idTag" scenario against without adding cache-consultation logic, which is out of scope here. Follow-up: LocalPreAuthorize (see #181's PR body).
 - **TC_032, TC_037, TC_039** (Offline Power Failure, Offline Transactions) — No offline transaction queue or transaction replication in the scenario engine.
 - **TC_047** (Reservation Expiry) — CP expires reservations passively on TTL; transition is internal, not observable as a status change.
 - **TC_049** (Charge-Point-Wide Reservation) — CP has no connector 0; ReserveNow(connectorId=0) is rejected by core; no distinct behavior to verify.

--- a/src/utils/scenarios/cert16-tc023-1-authorize-invalid.json
+++ b/src/utils/scenarios/cert16-tc023-1-authorize-invalid.json
@@ -1,0 +1,59 @@
+{
+  "id": "cert16-tc023-1-authorize-invalid",
+  "name": "Cert 1.6 Core: TC_023.1 Authorize Outcome (Invalid)",
+  "description": "Operator ensures idTag CERT023-INV is unknown to the CSMS. Plug in; CP sends Authorize.req before starting a transaction (issue #181); CSMS responds Invalid; CP does not send StartTransaction.req and the scenario continues to plug-out.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "plug-in",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Plug In", "action": "plugin" }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Start Transaction (Invalid idTag)",
+        "action": "start",
+        "tagId": "CERT023-INV"
+      }
+    },
+    {
+      "id": "delay-1",
+      "type": "delay",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Wait 2s", "delaySeconds": 2 }
+    },
+    {
+      "id": "plug-out",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 450 },
+      "data": { "label": "Plug Out", "action": "plugout" }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 550 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "plug-in" },
+    { "id": "e2", "source": "plug-in", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "delay-1" },
+    { "id": "e4", "source": "delay-1", "target": "plug-out" },
+    { "id": "e5", "source": "plug-out", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc023-2-authorize-expired.json
+++ b/src/utils/scenarios/cert16-tc023-2-authorize-expired.json
@@ -1,0 +1,59 @@
+{
+  "id": "cert16-tc023-2-authorize-expired",
+  "name": "Cert 1.6 Core: TC_023.2 Authorize Outcome (Expired)",
+  "description": "Operator ensures idTag CERT023-EXP is registered on the CSMS with an expiry_date in the past. Plug in; CP sends Authorize.req before starting a transaction (issue #181); CSMS responds Expired; CP does not send StartTransaction.req and the scenario continues to plug-out.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "plug-in",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Plug In", "action": "plugin" }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Start Transaction (Expired idTag)",
+        "action": "start",
+        "tagId": "CERT023-EXP"
+      }
+    },
+    {
+      "id": "delay-1",
+      "type": "delay",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Wait 2s", "delaySeconds": 2 }
+    },
+    {
+      "id": "plug-out",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 450 },
+      "data": { "label": "Plug Out", "action": "plugout" }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 550 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "plug-in" },
+    { "id": "e2", "source": "plug-in", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "delay-1" },
+    { "id": "e4", "source": "delay-1", "target": "plug-out" },
+    { "id": "e5", "source": "plug-out", "target": "end-1" }
+  ]
+}

--- a/src/utils/scenarios/cert16-tc023-3-authorize-blocked.json
+++ b/src/utils/scenarios/cert16-tc023-3-authorize-blocked.json
@@ -1,0 +1,59 @@
+{
+  "id": "cert16-tc023-3-authorize-blocked",
+  "name": "Cert 1.6 Core: TC_023.3 Authorize Outcome (Blocked)",
+  "description": "Operator ensures idTag CERT023-BLK is registered on the CSMS as blocked. Plug in; CP sends Authorize.req before starting a transaction (issue #181); CSMS responds Blocked; CP does not send StartTransaction.req and the scenario continues to plug-out.",
+  "targetType": "connector",
+  "targetId": 1,
+  "trigger": { "type": "manual" },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": { "x": 400, "y": 50 },
+      "data": { "label": "Start", "triggerOn": "connect" }
+    },
+    {
+      "id": "plug-in",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 150 },
+      "data": { "label": "Plug In", "action": "plugin" }
+    },
+    {
+      "id": "tx-start",
+      "type": "transaction",
+      "position": { "x": 400, "y": 250 },
+      "data": {
+        "label": "Start Transaction (Blocked idTag)",
+        "action": "start",
+        "tagId": "CERT023-BLK"
+      }
+    },
+    {
+      "id": "delay-1",
+      "type": "delay",
+      "position": { "x": 400, "y": 350 },
+      "data": { "label": "Wait 2s", "delaySeconds": 2 }
+    },
+    {
+      "id": "plug-out",
+      "type": "connectorPlug",
+      "position": { "x": 400, "y": 450 },
+      "data": { "label": "Plug Out", "action": "plugout" }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": { "x": 400, "y": 550 },
+      "data": { "label": "End" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start-1", "target": "plug-in" },
+    { "id": "e2", "source": "plug-in", "target": "tx-start" },
+    { "id": "e3", "source": "tx-start", "target": "delay-1" },
+    { "id": "e4", "source": "delay-1", "target": "plug-out" },
+    { "id": "e5", "source": "plug-out", "target": "end-1" }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #181

`Authorize.conf` was behaviorally inert: the self-initiated transaction path never sent `Authorize.req`, and `AuthorizeResultHandler` only logged — so a CSMS rejecting a tag (Invalid/Expired/Blocked) still saw the simulator charge. This makes Authorize meaningful and unlocks the TC_023 certification cases that were documented as out of scope precisely because of this gap.

### Behavior change (default on)
- New config key **`AuthorizeBeforeLocalStart` (default `true`)**: `ChargePoint.startTransaction` now sends `Authorize.req` and awaits `Authorize.conf` before starting a local transaction. On **Invalid/Expired/Blocked** it does **not** start the transaction; on **Accepted** (or an authorize timeout — warn-and-proceed) it proceeds. The remote-start path keeps its existing `AuthorizeRemoteTxRequests` semantics. Turn the gate off with `AuthorizeBeforeLocalStart=false` to restore the old wire.
- **`StopTransactionOnInvalidId` (default `true`)**: a non-Accepted `idTagInfo` in `StartTransaction.conf` now stops the transaction with reason `DeAuthorized` (or keeps charging + logs when the key is false).
- **Graceful scenario continuation**: a denied authorize is **non-throwing** — the scenario's transaction-start node logs a skip and continues to its next node, which is what makes the TC_023 graphs (plug-in → tx-start(bad tag) → [denied] → plug-out → end) work without failing the run.

### Implementation note
`Authorize.conf` (1.6) carries no idTag, so correlating the result to the awaiting caller requires the original request's idTag — the Authorize CALLRESULT handler is now constructed per-request in `OCPPMessageHandler.handleCallResult` (mirroring StartTransaction/StopTransaction/MeterValues), emitting an `authorizeResult { tagId, status }` event that `authorizeAndWait` matches. Touched v16/v201 handler-construction test sites are parameter additions only (no logic change).

### New scenarios
- `cert16-tc023-1-authorize-invalid`, `-2-expired`, `-3-blocked` — the operator sets the tag's state on the CSMS; the CP sends Authorize, receives the status, and does not start a transaction. README rows added and TC_023 removed from the out-of-scope list (TC_007 cached-id stays out — no auth cache).

## Testing
- vitest 1574/1574, `bun test bun.test` 153/153 (incl. all touched v16/v201 suites), eslint + prettier clean, `tsc -b --noEmit --force` = 478 (unchanged).
- **Live SteVe (real CSMS): 47/47** — the 44 existing scenarios all still PASS with `Authorize` now preceding `StartTransaction` on the wire (order-assertions unaffected), and the 3 new TC_023 specs PASS (Authorize sent, idTagInfo Invalid/Expired/Blocked uniqueId-paired, StartTransaction NOT sent, DB shows no transaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable local-start authorization gating (AuthorizeBeforeLocalStart).
  * Introduced certification scenarios for invalid, expired, and blocked authorization outcomes.
  * Verification CLI supports an additional “authorize” run group for these scenarios.
* **Bug Fixes**
  * Denied transaction starts now warn and continue scenario execution without starting a transaction.
  * Authorization results are correlated to the originating request, including CALLERROR cases.
  * Non-accepted StartTransaction outcomes now follow configured stop behavior and emit “not accepted” signals.
* **Documentation**
  * Updated scenario documentation for the new authorization outcome behavior.
* **Tests**
  * Expanded unit, integration, and end-to-end coverage for authorization denial outcomes and handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->