### PR TITLE
fix: SOAP endpoint/response + connection-state + modal bugs from v0.7.0 feedback (#178)

### DIFF
--- a/src/components/ChargePointConfigModal.dom.test.tsx
+++ b/src/components/ChargePointConfigModal.dom.test.tsx
@@ -472,13 +472,16 @@ describe("ChargePointConfigModal — OCPP-1.5 + Security Profile UI", () => {
     const wsURLValue = () =>
       (document.getElementById("wsURL") as HTMLInputElement).value;
 
-    // JSON -> SOAP: ws:// becomes http://; host/port/path preserved.
+    // JSON -> SOAP: ws:// becomes http://; host/port preserved. The SteVe
+    // default path is transport-specific, so the well-known /websocket/
+    // boilerplate is also rewritten to the SOAP /services/ path (#178).
     await selectOption("ocppVersion", "OCPP 1.2 (SOAP)");
     expect(wsURLValue()).toBe(
-      "http://localhost:8080/steve/websocket/CentralSystemService/",
+      "http://localhost:8080/steve/services/CentralSystemService",
     );
 
-    // SOAP -> JSON: http:// converts back to ws://.
+    // SOAP -> JSON: http:// converts back to ws://, and the SteVe /services/
+    // path is rewritten back to /websocket/.
     await selectOption("ocppVersion", "OCPP 1.6 (JSON)");
     expect(wsURLValue()).toBe(
       "ws://localhost:8080/steve/websocket/CentralSystemService/",

--- a/src/components/scenario/ScenarioEditor.tsx
+++ b/src/components/scenario/ScenarioEditor.tsx
@@ -1623,7 +1623,7 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
           open={isSettingsModalOpen}
           onOpenChange={(open) => !open && setIsSettingsModalOpen(false)}
         >
-          <DialogContent className="max-w-2xl">
+          <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
             <DialogHeader>
               <DialogTitle>Scenario Settings</DialogTitle>
             </DialogHeader>

--- a/src/cp/infrastructure/transport/soap/OCPPSoapHandler.ts
+++ b/src/cp/infrastructure/transport/soap/OCPPSoapHandler.ts
@@ -1032,10 +1032,26 @@ export class OCPPSoapHandler implements IChargePointMessageHandler {
       .catch(() => undefined)
       .then(run)
       .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
         this._logger.error(
-          `SOAP ${operation} failed: ${error instanceof Error ? error.message : String(error)}`,
+          `SOAP ${operation} failed: ${message}`,
           LogType.OCPP,
         );
+        if (operation === "BootNotification") {
+          // SOAP has no persistent connection, so there's no `onclose`
+          // handler to fall back on the way the WebSocket path has —
+          // `connect()` emits "connected" optimistically (before
+          // BootNotification round-trips), and without this, a failed
+          // round-trip would leave that "connected" state stuck forever,
+          // with Connect/Disconnect UI never recovering (#178 C). Mirror
+          // the WebSocket path's onclose transition: surface the failure
+          // via `error` and flip back with a "disconnected" event.
+          this._chargePoint.error = message;
+          this._chargePoint.events.emit("disconnected", {
+            code: 1006,
+            reason: message,
+          });
+        }
       });
   }
 

--- a/src/cp/infrastructure/transport/soap/OCPPSoapHandler.ts
+++ b/src/cp/infrastructure/transport/soap/OCPPSoapHandler.ts
@@ -354,6 +354,17 @@ const OPERATION_ACTION: Record<SoapOperation, OCPPAction | null> = {
 
 export const DEFAULT_SOAP_REQUEST_TIMEOUT_MS = 30_000;
 
+// Raw HTTP response bodies (e.g. an HTML error page from a misbehaving
+// proxy/CSMS) are embedded in error messages/log lines for diagnosis (#178
+// B-i) — truncate them to a sane length so a large body doesn't blow up logs.
+const RAW_RESPONSE_LOG_LIMIT = 240;
+
+function truncateForLog(text: string): string {
+  return text.length > RAW_RESPONSE_LOG_LIMIT
+    ? `${text.slice(0, RAW_RESPONSE_LOG_LIMIT)}…`
+    : text;
+}
+
 function textValue(value: SoapParsedValue | undefined): string | undefined {
   if (typeof value === "string") return value;
   if (typeof value === "number" || typeof value === "boolean") {
@@ -1083,7 +1094,7 @@ export class OCPPSoapHandler implements IChargePointMessageHandler {
 
     if (!response.ok) {
       throw new Error(
-        `HTTP ${response.status} ${response.statusText}: ${responseText.slice(0, 240)}`,
+        `HTTP ${response.status} ${response.statusText}: ${truncateForLog(responseText)}`,
       );
     }
     this._logger.info(
@@ -1122,7 +1133,21 @@ export class OCPPSoapHandler implements IChargePointMessageHandler {
       const fault = parseSoapFaultEnvelope(responseText);
       return fault ? new SoapFaultError(fault, status) : null;
     } catch (error) {
-      if (status >= 200 && status < 300) throw error;
+      if (status >= 200 && status < 300) {
+        // The response body itself failed to parse as SOAP (e.g. the
+        // DOCTYPE/ENTITY XXE guard tripped on a non-SOAP HTML error page
+        // from SteVe/a proxy). Previously the raw body was captured in a
+        // local variable and then discarded here, leaving the failure
+        // undiagnosable (#178 B-i). Fold the HTTP status, the parse error,
+        // and a truncated copy of the raw response into the thrown error so
+        // it reaches the caller's log line (`enqueueRequest`'s catch).
+        const parseMessage =
+          error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `SOAP response parse failed (HTTP ${status}): ${parseMessage} — raw response: ${truncateForLog(responseText)}`,
+          { cause: error },
+        );
+      }
       return null;
     }
   }

--- a/src/cp/infrastructure/transport/soap/__tests__/OCPPSoapHandler.bun.test.ts
+++ b/src/cp/infrastructure/transport/soap/__tests__/OCPPSoapHandler.bun.test.ts
@@ -397,6 +397,18 @@ function withFakeFaultFetch(status: number, reason: string): () => void {
   };
 }
 
+function withFakeRawBodyFetch(status: number, body: string): () => void {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(body, {
+      status,
+      headers: { "content-type": "text/html" },
+    })) as unknown as typeof fetch;
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
 describe("OCPPSoapHandler CP-to-CSMS client", () => {
   it("posts OCPP 1.5 SOAP Boot, Heartbeat, Status, transaction, and MeterValues requests", async () => {
     await withGlobalFetch(async () => {
@@ -788,6 +800,91 @@ describe("OCPPSoapHandler CP-to-CSMS client", () => {
           code: "s:Receiver",
           reason: "CSMS rejected request",
         });
+      } finally {
+        restoreFetch();
+      }
+    });
+  });
+
+  it("preserves the raw HTTP response when a 200 body fails SOAP parsing (#178 B-i)", async () => {
+    await withGlobalFetch(async () => {
+      const centralSystemUrl = "http://csms.example/CentralSystemService";
+      const callbackUrl =
+        "http://127.0.0.1:9700/ocpp/soap/CP-XXE-200/ChargePointService";
+      const cp = createSoapChargePoint(
+        "CP-XXE-200",
+        centralSystemUrl,
+        callbackUrl,
+      );
+      const handler = new OCPPSoapHandler(cp, new Logger(), {
+        centralSystemUrl,
+        soapCallbackUrl: callbackUrl,
+        requestTimeoutMs: 100,
+      });
+      // A 200-OK-but-non-SOAP body (e.g. a proxy's HTML error page). The
+      // DOCTYPE/ENTITY XXE guard in soapEnvelope.ts rejects it before any
+      // SOAP-specific parsing runs — this must not silently discard the
+      // body that caused the failure.
+      const htmlBody = `<!DOCTYPE html><html><body>${"x".repeat(2000)}</body></html>`;
+      const restoreFetch = withFakeRawBodyFetch(200, htmlBody);
+
+      try {
+        let error: unknown;
+        try {
+          await soapPostForTest(handler).postSoap("Heartbeat", {});
+        } catch (err) {
+          error = err;
+        }
+        expect(error).toBeInstanceOf(Error);
+        const message = (error as Error).message;
+        expect(message).toContain("HTTP 200");
+        expect(message).toContain(
+          "SOAP XML containing DOCTYPE or ENTITY is not supported",
+        );
+        // The raw body must survive in the surfaced error (truncated, not
+        // dropped) so the failure is diagnosable.
+        expect(message).toContain("<!DOCTYPE html>");
+        // ... and it must actually be truncated, not the full 300+ char body.
+        expect(message.length).toBeLessThan(htmlBody.length);
+      } finally {
+        restoreFetch();
+      }
+    });
+  });
+
+  it("preserves the raw HTTP response when a non-2xx body fails SOAP parsing (#178 B-i)", async () => {
+    await withGlobalFetch(async () => {
+      const centralSystemUrl = "http://csms.example/CentralSystemService";
+      const callbackUrl =
+        "http://127.0.0.1:9700/ocpp/soap/CP-XXE-502/ChargePointService";
+      const cp = createSoapChargePoint(
+        "CP-XXE-502",
+        centralSystemUrl,
+        callbackUrl,
+      );
+      const handler = new OCPPSoapHandler(cp, new Logger(), {
+        centralSystemUrl,
+        soapCallbackUrl: callbackUrl,
+        requestTimeoutMs: 100,
+      });
+      // Non-2xx bodies already flow through the `!response.ok` branch, which
+      // already embedded the raw (truncated) body — guard that this
+      // continues to hold with the shared truncation helper.
+      const htmlBody = `<!DOCTYPE html><html><body>Bad Gateway ${"x".repeat(2000)}</body></html>`;
+      const restoreFetch = withFakeRawBodyFetch(502, htmlBody);
+
+      try {
+        let error: unknown;
+        try {
+          await soapPostForTest(handler).postSoap("Heartbeat", {});
+        } catch (err) {
+          error = err;
+        }
+        expect(error).toBeInstanceOf(Error);
+        const message = (error as Error).message;
+        expect(message).toContain("HTTP 502");
+        expect(message).toContain("<!DOCTYPE html>");
+        expect(message.length).toBeLessThan(htmlBody.length);
       } finally {
         restoreFetch();
       }

--- a/src/cp/infrastructure/transport/soap/__tests__/OCPPSoapHandler.bun.test.ts
+++ b/src/cp/infrastructure/transport/soap/__tests__/OCPPSoapHandler.bun.test.ts
@@ -891,6 +891,53 @@ describe("OCPPSoapHandler CP-to-CSMS client", () => {
     });
   });
 
+  it("emits disconnected and sets error when the initial SOAP BootNotification round-trip fails (#178 C)", async () => {
+    await withGlobalFetch(async () => {
+      const centralSystemUrl = "http://csms.example/CentralSystemService";
+      const callbackUrl =
+        "http://127.0.0.1:9700/ocpp/soap/CP-BOOT-FAIL/ChargePointService";
+      const cp = createSoapChargePoint(
+        "CP-BOOT-FAIL",
+        centralSystemUrl,
+        callbackUrl,
+        100,
+      );
+      const connectedEvents: unknown[] = [];
+      const disconnectedEvents: { code: number; reason: string }[] = [];
+      cp.events.on("connected", () => connectedEvents.push(undefined));
+      cp.events.on("disconnected", (data) => disconnectedEvents.push(data));
+
+      // A 200-OK-but-non-SOAP body trips the DOCTYPE guard, so the
+      // BootNotification round-trip itself fails as a transport/parse
+      // error — not a business-level Rejected response.
+      const htmlBody = `<!DOCTYPE html><html><body>${"x".repeat(50)}</body></html>`;
+      const restoreFetch = withFakeRawBodyFetch(200, htmlBody);
+
+      try {
+        // connect() emits "connected" optimistically, before the boot
+        // round-trip resolves — mirrors the WebSocket path, which also
+        // emits "connected" as soon as the socket opens (#103).
+        cp.connect();
+        expect(connectedEvents.length).toBe(1);
+        expect(cp.error).toBe("");
+
+        // Previously nothing ever emitted "disconnected" for a SOAP
+        // charge point, so the UI's Connect/Disconnect state stayed
+        // stuck at "connected" forever after a failed boot (#178 C).
+        await waitUntil(() => disconnectedEvents.length === 1);
+
+        expect(disconnectedEvents[0].reason).toContain(
+          "SOAP XML containing DOCTYPE or ENTITY is not supported",
+        );
+        expect(cp.error).toContain(
+          "SOAP XML containing DOCTYPE or ENTITY is not supported",
+        );
+      } finally {
+        restoreFetch();
+      }
+    });
+  });
+
   it("sends OCPP 1.2 StatusNotification with exactly 3 fields and collapsed status", async () => {
     await withGlobalFetch(async () => {
       const csms = startFakeCentralSystemService();

--- a/src/utils/__tests__/ocppUrlScheme.test.ts
+++ b/src/utils/__tests__/ocppUrlScheme.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import { adaptCentralSystemUrlScheme } from "../ocppUrlScheme";
 
 describe("adaptCentralSystemUrlScheme (#164)", () => {
-  const STEVE = "localhost:8080/steve/websocket/CentralSystemService/";
+  // A generic, non-SteVe-boilerplate host/path, used to verify the plain
+  // "scheme flips, everything else is preserved" invariant in isolation from
+  // the SteVe-specific path rewrite (#178, tested separately below).
+  const STEVE = "example.com:8080/ocpp/CentralSystemService/";
 
   describe("switching to a SOAP transport", () => {
     it("maps ws:// -> http:// and keeps host/port/path", () => {
@@ -78,5 +81,42 @@ describe("adaptCentralSystemUrlScheme (#164)", () => {
     expect(
       adaptCentralSystemUrlScheme("wss://ocpp.example.com:443/path?q=1", true),
     ).toBe("https://ocpp.example.com:443/path?q=1");
+  });
+
+  describe("SteVe default path rewrite (#178)", () => {
+    const STEVE_JSON = "localhost:8080/steve/websocket/CentralSystemService/";
+    const STEVE_SOAP = "localhost:8080/steve/services/CentralSystemService";
+
+    it("rewrites the SteVe JSON/websocket path to the SOAP services path when switching to SOAP", () => {
+      expect(adaptCentralSystemUrlScheme(`ws://${STEVE_JSON}`, true)).toBe(
+        `http://${STEVE_SOAP}`,
+      );
+      expect(adaptCentralSystemUrlScheme(`wss://${STEVE_JSON}`, true)).toBe(
+        `https://${STEVE_SOAP}`,
+      );
+    });
+
+    it("rewrites the SteVe SOAP services path back to the websocket path when switching to JSON", () => {
+      expect(adaptCentralSystemUrlScheme(`http://${STEVE_SOAP}`, false)).toBe(
+        `ws://${STEVE_JSON}`,
+      );
+      expect(adaptCentralSystemUrlScheme(`https://${STEVE_SOAP}`, false)).toBe(
+        `wss://${STEVE_JSON}`,
+      );
+    });
+
+    it("does not rewrite a customized path that isn't the exact SteVe boilerplate", () => {
+      expect(
+        adaptCentralSystemUrlScheme(
+          "ws://localhost:8080/steve/websocket/CentralSystemService/extra",
+          true,
+        ),
+      ).toBe(
+        "http://localhost:8080/steve/websocket/CentralSystemService/extra",
+      );
+      expect(
+        adaptCentralSystemUrlScheme("ws://otherhost/some/custom/path", true),
+      ).toBe("http://otherhost/some/custom/path");
+    });
   });
 });

--- a/src/utils/ocppUrlScheme.ts
+++ b/src/utils/ocppUrlScheme.ts
@@ -1,12 +1,36 @@
+// The default SteVe path segments for the two transports (#178). SteVe's
+// JSON/WebSocket endpoint lives under `/websocket/`; its SOAP endpoint lives
+// under `/services/` — different paths, not just a scheme change. We only
+// ever rewrite the path when it is *exactly* this well-known boilerplate, so
+// a URL the operator has customized (any other path) is left untouched.
+const STEVE_JSON_PATH = "/steve/websocket/CentralSystemService/";
+const STEVE_SOAP_PATH = "/steve/services/CentralSystemService";
+
+function swapStevePath(url: string, toSoap: boolean): string {
+  if (toSoap && url.endsWith(STEVE_JSON_PATH)) {
+    return url.slice(0, -STEVE_JSON_PATH.length) + STEVE_SOAP_PATH;
+  }
+  if (!toSoap && url.endsWith(STEVE_SOAP_PATH)) {
+    return url.slice(0, -STEVE_SOAP_PATH.length) + STEVE_JSON_PATH;
+  }
+  return url;
+}
+
 /**
  * Adapt a Central System URL's scheme to the selected OCPP transport (#164).
  *
  * SOAP dialects (1.2 / 1.5 / 1.6-SOAP) speak HTTP; JSON dialects speak
  * WebSocket. When the operator switches transport we flip only an
  * *incompatible* scheme and leave everything after it — host, port, path —
- * untouched, since the correct SOAP endpoint path can't be inferred. A URL that
- * is already compatible, or uses some other scheme the user typed on purpose,
- * is returned unchanged. Secure stays secure: `wss` <-> `https`, `ws` <-> `http`.
+ * untouched, since the correct SOAP endpoint path can't be inferred in the
+ * general case. A URL that is already compatible, or uses some other scheme
+ * the user typed on purpose, is returned unchanged. Secure stays secure:
+ * `wss` <-> `https`, `ws` <-> `http`.
+ *
+ * One exception (#178): the well-known SteVe default path is transport-
+ * specific (`/websocket/...` for JSON vs `/services/...` for SOAP), so when
+ * an incompatible-scheme URL's path is exactly that boilerplate, the path is
+ * rewritten alongside the scheme. Any other path is left alone.
  */
 export function adaptCentralSystemUrlScheme(
   url: string,
@@ -15,11 +39,15 @@ export function adaptCentralSystemUrlScheme(
   // URL schemes are case-insensitive (RFC 3986), so match accordingly. Each
   // prefix has the same length regardless of case, so the slice offsets hold.
   if (toSoap) {
-    if (/^ws:\/\//i.test(url)) return `http://${url.slice(5)}`;
-    if (/^wss:\/\//i.test(url)) return `https://${url.slice(6)}`;
+    if (/^ws:\/\//i.test(url))
+      return swapStevePath(`http://${url.slice(5)}`, true);
+    if (/^wss:\/\//i.test(url))
+      return swapStevePath(`https://${url.slice(6)}`, true);
     return url;
   }
-  if (/^http:\/\//i.test(url)) return `ws://${url.slice(7)}`;
-  if (/^https:\/\//i.test(url)) return `wss://${url.slice(8)}`;
+  if (/^http:\/\//i.test(url))
+    return swapStevePath(`ws://${url.slice(7)}`, false);
+  if (/^https:\/\//i.test(url))
+    return swapStevePath(`wss://${url.slice(8)}`, false);
   return url;
 }


### PR DESCRIPTION
## Summary

The pure-bug subset of @juherr's #178 v0.7.0 testing feedback (thank you for the thorough SteVe-based pass). Four self-contained fixes; the UX-improvement and product-shaped items (log viewer, Basic Auth consolidation, URL-scheme coupling, SOAP callback derivation) follow in separate PRs.

Refs #178

| Item | Fix |
|---|---|
| **A** — default SOAP Central System URL used a `/steve/websocket/…` (JSON/WS) path | `adaptCentralSystemUrlScheme()` now also swaps the SteVe boilerplate path `/steve/websocket/CentralSystemService/` ↔ `/steve/services/CentralSystemService` alongside the ws/wss↔http/https flip, so switching to SOAP yields the correct `/services/` endpoint |
| **B(i)** — SOAP response lost on a parse failure (e.g. the "DOCTYPE or ENTITY not supported" XXE rejection), making the failure undiagnosable | `parseFaultResponse` now embeds the HTTP status + a truncated raw response body + the parse error into the re-thrown error, so the raw (often non-SOAP, e.g. an HTML error page) response reaches the log. XXE protection is unchanged (DOCTYPE/ENTITY still rejected) |
| **C** — after a SOAP BootNotification/connection failure the UI's Connect/Disconnect buttons and status stayed stuck | the SOAP request path now emits `"disconnected"` + sets the error on a transport failure (the WS path already did this), so the UI refreshes to the correct state |
| **D** — Scenario Settings modal overflowed and the background scrolled | its `DialogContent` gained `max-h-[85vh] overflow-y-auto`, matching the pattern `ChargePointConfigModal` already uses |

### Deferred (kept on the #178 checklist)
- **B(ii)** — *why* SteVe/proxy returns a DOCTYPE body over SOAP 1.5 needs a live SOAP-1.5 repro to diagnose; B(i) above makes that raw response visible, which is the precondition for diagnosing it.

## Testing
- vitest 1076/1076, `bun test bun.test` 207/207, eslint + prettier clean, `tsc -b --noEmit --force` = 478 (unchanged). New tests: URL-scheme+path swap cases, and a SOAP-handler suite asserting the raw response is preserved on a parse failure.
- Note: D's in-browser screenshot check couldn't run (the shared devtools browser profile was locked by another session); verified at the code level against the identical, already-shipped Dialog pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic conversion between JSON/WebSocket and SOAP endpoint URLs, including recognized SteVe default paths.
  * Custom endpoint paths remain unchanged during transport conversion.

* **Bug Fixes**
  * SOAP errors now include HTTP status details and a safely truncated response preview.
  * Improved connection failure reporting for initial boot notifications.

* **Usability**
  * Scenario Settings now support scrolling within a constrained modal for easier access to larger configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->