### PR TITLE
feat(ui): log viewer — horizontal scroll, action/direction columns, filters (#178)

### DIFF
--- a/src/components/ui/__tests__/logEntryParsing.test.ts
+++ b/src/components/ui/__tests__/logEntryParsing.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import { annotateOcppLogs } from "../logEntryParsing";
+
+function msg(message: string) {
+  return { message };
+}
+
+describe("annotateOcppLogs (#178 item E)", () => {
+  describe("WebSocket transport frames", () => {
+    it("parses an outgoing CALL as sent + action", () => {
+      const logs = [
+        msg(
+          `Sent: ${JSON.stringify([2, "1", "BootNotification", { chargePointVendor: "Acme" }])}`,
+        ),
+      ];
+      expect(annotateOcppLogs(logs)).toEqual([
+        { action: "BootNotification", direction: "sent" },
+      ]);
+    });
+
+    it("parses an incoming CALL as received + action", () => {
+      const logs = [
+        msg(
+          `Received: ${JSON.stringify([2, "9", "RemoteStartTransaction", {}])}`,
+        ),
+      ];
+      expect(annotateOcppLogs(logs)).toEqual([
+        { action: "RemoteStartTransaction", direction: "received" },
+      ]);
+    });
+
+    it("leaves a CALLRESULT with no prior CALL as direction-only", () => {
+      const logs = [msg(`Sent: ${JSON.stringify([3, "unknown-id", {}])}`)];
+      expect(annotateOcppLogs(logs)).toEqual([{ direction: "sent" }]);
+    });
+
+    it("correlates a CALLRESULT to the CP's own earlier CALL by message id", () => {
+      // CP sends BootNotification (id "1"), CSMS replies with a CALLRESULT
+      // carrying the same id. OCPP-J CALLRESULT frames never repeat the
+      // action name, so the viewer must resolve it via correlation.
+      const logs = [
+        msg(
+          `Sent: ${JSON.stringify([2, "1", "BootNotification", { chargePointVendor: "Acme" }])}`,
+        ),
+        msg(`Received: ${JSON.stringify([3, "1", { status: "Accepted" }])}`),
+      ];
+      expect(annotateOcppLogs(logs)).toEqual([
+        { action: "BootNotification", direction: "sent" },
+        { action: "BootNotification", direction: "received" },
+      ]);
+    });
+
+    it("correlates a CALLERROR to the CP's own earlier CALL by message id", () => {
+      const logs = [
+        msg(`Sent: ${JSON.stringify([2, "5", "Heartbeat", {}])}`),
+        msg(
+          `Received: ${JSON.stringify([4, "5", "InternalError", "boom", {}])}`,
+        ),
+      ];
+      expect(annotateOcppLogs(logs)).toEqual([
+        { action: "Heartbeat", direction: "sent" },
+        { action: "Heartbeat", direction: "received" },
+      ]);
+    });
+
+    it("correlates the CP's own CALLRESULT back to a CSMS-initiated CALL it received", () => {
+      // CSMS calls RemoteStartTransaction (id "77"), CP answers with a
+      // CALLRESULT of its own (sent) carrying the same id.
+      const logs = [
+        msg(
+          `Received: ${JSON.stringify([2, "77", "RemoteStartTransaction", {}])}`,
+        ),
+        msg(`Sent: ${JSON.stringify([3, "77", { status: "Accepted" }])}`),
+      ];
+      expect(annotateOcppLogs(logs)).toEqual([
+        { action: "RemoteStartTransaction", direction: "received" },
+        { action: "RemoteStartTransaction", direction: "sent" },
+      ]);
+    });
+
+    it("does not cross-correlate distinct message ids", () => {
+      const logs = [
+        msg(`Sent: ${JSON.stringify([2, "1", "Heartbeat", {}])}`),
+        msg(`Received: ${JSON.stringify([3, "2", {}])}`),
+      ];
+      expect(annotateOcppLogs(logs)).toEqual([
+        { action: "Heartbeat", direction: "sent" },
+        { direction: "received" },
+      ]);
+    });
+
+    it("ignores a numeric message id array element but still stringifies for correlation", () => {
+      const logs = [
+        msg(`Sent: ${JSON.stringify([2, 42, "Heartbeat", {}])}`),
+        msg(`Received: ${JSON.stringify([3, 42, {}])}`),
+      ];
+      expect(annotateOcppLogs(logs)).toEqual([
+        { action: "Heartbeat", direction: "sent" },
+        { action: "Heartbeat", direction: "received" },
+      ]);
+    });
+
+    it("returns {} for malformed JSON after the Sent/Received prefix", () => {
+      const logs = [msg("Sent: not-json"), msg("Received: {broken")];
+      expect(annotateOcppLogs(logs)).toEqual([{}, {}]);
+    });
+
+    it("returns {} for a non-array JSON payload", () => {
+      const logs = [msg(`Received: ${JSON.stringify({ foo: "bar" })}`)];
+      expect(annotateOcppLogs(logs)).toEqual([{}]);
+    });
+
+    it("returns {} for the WebSocket error/diagnostic lines", () => {
+      const logs = [
+        msg("WebSocket connected successfully"),
+        msg("Invalid message format: [1]"),
+        msg("Error parsing message: SyntaxError"),
+      ];
+      expect(annotateOcppLogs(logs)).toEqual([{}, {}, {}]);
+    });
+  });
+
+  describe("SOAP transport frames", () => {
+    it("parses a SOAP POST as sent + operation", () => {
+      const logs = [
+        msg("SOAP POST BootNotification: <soap:Envelope>...</soap:Envelope>"),
+      ];
+      expect(annotateOcppLogs(logs)).toEqual([
+        { action: "BootNotification", direction: "sent" },
+      ]);
+    });
+
+    it("parses a SOAP response as received + operation", () => {
+      const logs = [
+        msg(
+          "SOAP response BootNotification: <soap:Envelope>...</soap:Envelope>",
+        ),
+      ];
+      expect(annotateOcppLogs(logs)).toEqual([
+        { action: "BootNotification", direction: "received" },
+      ]);
+    });
+
+    it("does not require correlation for SOAP (operation is always inline)", () => {
+      const logs = [
+        msg("SOAP POST Heartbeat: <soap:Envelope/>"),
+        msg("SOAP response Heartbeat: <soap:Envelope/>"),
+      ];
+      expect(annotateOcppLogs(logs)).toEqual([
+        { action: "Heartbeat", direction: "sent" },
+        { action: "Heartbeat", direction: "received" },
+      ]);
+    });
+  });
+
+  describe("non-wire log lines", () => {
+    it("returns {} for generic/diagnostic OCPP log lines", () => {
+      const logs = [
+        msg("Suppressing Heartbeat: blocked by the boot gate"),
+        msg("Handling incoming message: 2, 1, BootNotification"),
+        msg("Recovering connector 1 after StartTransaction CALLERROR"),
+        msg("Scenario step completed: Connect to CSMS"),
+      ];
+      expect(annotateOcppLogs(logs)).toEqual([{}, {}, {}, {}]);
+    });
+
+    it("handles an empty log list", () => {
+      expect(annotateOcppLogs([])).toEqual([]);
+    });
+  });
+});

--- a/src/components/ui/log-viewer.dom.test.tsx
+++ b/src/components/ui/log-viewer.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { LogViewer } from "./log-viewer";
 import { LogLevel, LogType, type LogEntry } from "@/cp/shared/Logger";
@@ -12,6 +12,53 @@ import { LogLevel, LogType, type LogEntry } from "@/cp/shared/Logger";
 afterEach(() => {
   cleanup();
 });
+
+/** Finds a sidebar filter section's `<label>` row by its option text (e.g.
+ *  section "Direction", option "Sent"). Scoped to the section because
+ *  option labels can collide across sections (e.g. "Heartbeat" is both a
+ *  LogType and an OCPP action name). Sidebar sections are
+ *  `<div class="border-b"><button><span>{heading}</span>...</button>
+ *  {options}</div>`. */
+function findFilterOptionRow(
+  sectionHeading: string,
+  optionLabel: string,
+): HTMLLabelElement {
+  const heading = screen.getByText(sectionHeading, {
+    exact: true,
+    selector: "span",
+  });
+  const section = heading.closest(".border-b");
+  if (!section) {
+    throw new Error(`No filter section found for heading "${sectionHeading}"`);
+  }
+  const labels = Array.from(section.querySelectorAll("label"));
+  // The direct-child text span, not `label querySelector("span")` generally
+  // — a *checked* Checkbox renders its own indicator <span> (wrapping a
+  // Check icon) nested inside the checkbox button, which would otherwise
+  // shadow the real label text once a row is toggled on.
+  const match = labels.find(
+    (l) => l.querySelector(":scope > div > span")?.textContent === optionLabel,
+  );
+  if (!match) {
+    throw new Error(
+      `No filter option "${optionLabel}" found in section "${sectionHeading}"`,
+    );
+  }
+  return match as HTMLLabelElement;
+}
+
+/** Clicks the checkbox inside a specific sidebar filter option. Goes via
+ *  the label's own checkbox button rather than relying on native label
+ *  click-delegation, which jsdom doesn't reliably forward onto a
+ *  `<button role="checkbox">`. */
+function clickFilterOption(sectionHeading: string, optionLabel: string) {
+  const row = findFilterOptionRow(sectionHeading, optionLabel);
+  const checkbox = row.querySelector('button[role="checkbox"]');
+  if (!checkbox) {
+    throw new Error(`No checkbox found for filter option "${optionLabel}"`);
+  }
+  fireEvent.click(checkbox);
+}
 
 function entry(message: string, overrides: Partial<LogEntry> = {}): LogEntry {
   return {
@@ -167,8 +214,11 @@ describe("LogViewer action + direction columns (#178 2.2/2.3)", () => {
       />,
     );
 
-    expect(screen.getByText("Direction")).toBeInTheDocument();
-    expect(screen.getByText("Action")).toBeInTheDocument();
+    // "Direction"/"Action" also label the #178 2.4 sidebar filter
+    // sections, so scope to the table's <thead>.
+    const headerRow = container.querySelector("thead tr");
+    expect(headerRow?.textContent).toContain("Direction");
+    expect(headerRow?.textContent).toContain("Action");
 
     // Even though the CALLRESULT row's message text doesn't contain
     // "BootNotification" itself, correlation still resolves its action
@@ -178,5 +228,95 @@ describe("LogViewer action + direction columns (#178 2.2/2.3)", () => {
       r.textContent?.includes("← Received"),
     );
     expect(receivedRow?.textContent).toContain("BootNotification");
+  });
+});
+
+describe("LogViewer direction/action filters (#178 2.4)", () => {
+  // "Heartbeat" deliberately doubles as both the OCPP action name and an
+  // existing LogType enum value, to prove the filter helpers (and the
+  // component) don't cross-match sections that happen to share a label.
+  function threeMixedLogs() {
+    return [
+      entry(`Sent: ${JSON.stringify([2, "1", "BootNotification", {}])}`),
+      entry(`Received: ${JSON.stringify([2, "9", "Heartbeat", {}])}`),
+      entry("unrelated general log line — no direction/action"),
+    ];
+  }
+
+  it("filters rows down to a single direction when its checkbox is checked", () => {
+    const { container } = render(<LogViewer logs={threeMixedLogs()} />);
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(3);
+
+    clickFilterOption("Direction", "Sent");
+
+    const rows = container.querySelectorAll("tbody tr");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain("BootNotification");
+    expect(rows[0].textContent).toContain("→ Sent");
+  });
+
+  it("filters rows down to a single OCPP action when its checkbox is checked", () => {
+    const { container } = render(<LogViewer logs={threeMixedLogs()} />);
+
+    clickFilterOption("Action", "Heartbeat");
+
+    const rows = container.querySelectorAll("tbody tr");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain("Heartbeat");
+    expect(rows[0].textContent).toContain("← Received");
+  });
+
+  it("filters to the '(none)' bucket for entries with no parsed direction/action", () => {
+    const { container } = render(<LogViewer logs={threeMixedLogs()} />);
+
+    clickFilterOption("Direction", "(none)");
+
+    const rows = container.querySelectorAll("tbody tr");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain(
+      "unrelated general log line — no direction/action",
+    );
+  });
+
+  it("un-checking a direction filter restores the other rows", () => {
+    const { container } = render(<LogViewer logs={threeMixedLogs()} />);
+
+    clickFilterOption("Direction", "Sent");
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(1);
+
+    clickFilterOption("Direction", "Sent");
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(3);
+  });
+
+  it("combines an Action filter with the existing free-text search", () => {
+    const { container } = render(<LogViewer logs={threeMixedLogs()} />);
+
+    clickFilterOption("Action", "BootNotification");
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(1);
+
+    const searchBox = screen.getByPlaceholderText("Search in messages...");
+    fireEvent.change(searchBox, { target: { value: "chargePointVendor" } });
+
+    // Action filter still selects the BootNotification row, but the free
+    // text filter now also requires "chargePointVendor" in the message,
+    // which this fixture's payload doesn't contain — so no data rows
+    // survive. The empty-state message is itself a <tr>, so scope to the
+    // table body's text rather than counting <tr> elements (and don't
+    // check page-wide text — the Action sidebar still lists
+    // "BootNotification" as an available filter option regardless of
+    // what's currently showing in the table).
+    const tbody = container.querySelector("tbody");
+    expect(tbody?.textContent).toContain("No logs match the current filters");
+    expect(tbody?.textContent).not.toContain("BootNotification");
+  });
+
+  it("shows per-value counts as badges next to each Direction/Action filter option", () => {
+    render(<LogViewer logs={threeMixedLogs()} />);
+
+    const sentRow = findFilterOptionRow("Direction", "Sent");
+    expect(sentRow.textContent).toContain("1");
+
+    const heartbeatRow = findFilterOptionRow("Action", "Heartbeat");
+    expect(heartbeatRow.textContent).toContain("1");
   });
 });

--- a/src/components/ui/log-viewer.dom.test.tsx
+++ b/src/components/ui/log-viewer.dom.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LogViewer } from "./log-viewer";
+import { LogLevel, LogType, type LogEntry } from "@/cp/shared/Logger";
+
+function entry(message: string, overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    timestamp: new Date("2026-07-12T10:00:00.000Z"),
+    level: LogLevel.INFO,
+    type: LogType.OCPP,
+    message,
+    ...overrides,
+  };
+}
+
+describe("LogViewer horizontal scroll (#178 2.1)", () => {
+  it("scrolls the table container horizontally instead of wrapping long messages", () => {
+    const longPayload = `Sent: ${JSON.stringify([
+      2,
+      "1",
+      "BootNotification",
+      { chargePointVendor: "Acme", chargePointModel: "X".repeat(200) },
+    ])}`;
+    const { container } = render(<LogViewer logs={[entry(longPayload)]} />);
+
+    const messageCell = screen.getByText(longPayload, { exact: false });
+    expect(messageCell.className).toContain("whitespace-nowrap");
+    expect(messageCell.className).not.toContain("break-all");
+
+    const scrollContainer = container.querySelector("table")?.parentElement;
+    expect(scrollContainer?.className).toContain("overflow-x-auto");
+    expect(scrollContainer?.className).toContain("overflow-y-auto");
+  });
+
+  it("keeps the scroll container inside a min-w-0 flex column so it can't blow out the page width", () => {
+    const { container } = render(<LogViewer logs={[entry("hello")]} />);
+    const scrollContainer = container.querySelector("table")?.parentElement;
+    const rightColumn = scrollContainer?.parentElement;
+    expect(rightColumn?.className).toContain("min-w-0");
+  });
+
+  it("still renders timestamp, level, and type as before (no regression)", () => {
+    const { container } = render(
+      <LogViewer
+        logs={[
+          entry("hello world", {
+            level: LogLevel.WARN,
+            type: LogType.HEARTBEAT,
+          }),
+        ]}
+      />,
+    );
+
+    // Scope to the row, not the sidebar filter lists which also render
+    // "WARN"/"Heartbeat" as filter option labels.
+    const row = container.querySelector("tbody tr");
+    expect(row?.textContent).toContain("WARN");
+    expect(row?.textContent).toContain("Heartbeat");
+    expect(row?.textContent).toContain("hello world");
+    expect(row?.textContent).toContain("10:00:00.000");
+  });
+});

--- a/src/components/ui/log-viewer.dom.test.tsx
+++ b/src/components/ui/log-viewer.dom.test.tsx
@@ -1,8 +1,17 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 import { LogViewer } from "./log-viewer";
 import { LogLevel, LogType, type LogEntry } from "@/cp/shared/Logger";
+
+// vitest doesn't run with `globals: true` in this repo, so
+// @testing-library/react's auto-cleanup-on-afterEach detection never fires
+// (it looks for a global `afterEach`). Without this, every `render()` in
+// this file would pile onto the same jsdom document, and later tests'
+// `screen.getByText` queries would match leftover nodes from earlier tests.
+afterEach(() => {
+  cleanup();
+});
 
 function entry(message: string, overrides: Partial<LogEntry> = {}): LogEntry {
   return {
@@ -59,5 +68,115 @@ describe("LogViewer horizontal scroll (#178 2.1)", () => {
     expect(row?.textContent).toContain("Heartbeat");
     expect(row?.textContent).toContain("hello world");
     expect(row?.textContent).toContain("10:00:00.000");
+  });
+});
+
+describe("LogViewer action + direction columns (#178 2.2/2.3)", () => {
+  it("shows the parsed action and a Sent badge for an outgoing CALL", () => {
+    const { container } = render(
+      <LogViewer
+        logs={[
+          entry(
+            `Sent: ${JSON.stringify([2, "1", "BootNotification", { chargePointVendor: "Acme" }])}`,
+          ),
+        ]}
+      />,
+    );
+
+    const row = container.querySelector("tbody tr");
+    expect(row?.textContent).toContain("BootNotification");
+    expect(row?.textContent).toContain("→ Sent");
+  });
+
+  it("shows the parsed action and a Received badge for an incoming CALL", () => {
+    const { container } = render(
+      <LogViewer
+        logs={[
+          entry(
+            `Received: ${JSON.stringify([2, "9", "RemoteStartTransaction", {}])}`,
+          ),
+        ]}
+      />,
+    );
+
+    const row = container.querySelector("tbody tr");
+    expect(row?.textContent).toContain("RemoteStartTransaction");
+    expect(row?.textContent).toContain("← Received");
+  });
+
+  it("correlates a CALLRESULT back to its CALL's action across rows", () => {
+    const { container } = render(
+      <LogViewer
+        logs={[
+          entry(
+            `Sent: ${JSON.stringify([2, "1", "BootNotification", { chargePointVendor: "Acme" }])}`,
+          ),
+          entry(
+            `Received: ${JSON.stringify([3, "1", { status: "Accepted" }])}`,
+          ),
+        ]}
+      />,
+    );
+
+    const rows = container.querySelectorAll("tbody tr");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].textContent).toContain("BootNotification");
+    expect(rows[0].textContent).toContain("→ Sent");
+    expect(rows[1].textContent).toContain("BootNotification");
+    expect(rows[1].textContent).toContain("← Received");
+  });
+
+  it("shows the SOAP operation as the action for SOAP wire log lines", () => {
+    const { container } = render(
+      <LogViewer
+        logs={[
+          entry("SOAP POST Heartbeat: <soap:Envelope/>"),
+          entry("SOAP response Heartbeat: <soap:Envelope/>"),
+        ]}
+      />,
+    );
+
+    const rows = container.querySelectorAll("tbody tr");
+    expect(rows[0].textContent).toContain("Heartbeat");
+    expect(rows[0].textContent).toContain("→ Sent");
+    expect(rows[1].textContent).toContain("Heartbeat");
+    expect(rows[1].textContent).toContain("← Received");
+  });
+
+  it("renders a dash placeholder for non-wire log lines (no action/direction)", () => {
+    const { container } = render(
+      <LogViewer logs={[entry("Scenario step completed: Connect to CSMS")]} />,
+    );
+
+    const row = container.querySelector("tbody tr");
+    expect(row?.textContent).toContain("—");
+    expect(row?.textContent).not.toContain("Sent");
+    expect(row?.textContent).not.toContain("Received");
+  });
+
+  it("still shows Direction/Action headers and preserves correlation when filtering by text", async () => {
+    const { container } = render(
+      <LogViewer
+        logs={[
+          entry(`Sent: ${JSON.stringify([2, "1", "BootNotification", {}])}`),
+          entry(
+            `Received: ${JSON.stringify([3, "1", { status: "Accepted" }])}`,
+          ),
+          entry("unrelated general log line"),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Direction")).toBeInTheDocument();
+    expect(screen.getByText("Action")).toBeInTheDocument();
+
+    // Even though the CALLRESULT row's message text doesn't contain
+    // "BootNotification" itself, correlation still resolves its action
+    // because logOcppInfo is computed over the full `logs` list.
+    const rows = container.querySelectorAll("tbody tr");
+    const receivedRow = [...rows].find((r) =>
+      r.textContent?.includes("← Received"),
+    );
+    expect(receivedRow?.textContent).toContain("BootNotification");
   });
 });

--- a/src/components/ui/log-viewer.tsx
+++ b/src/components/ui/log-viewer.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { LogEntry, LogLevel, LogType } from "@/cp/shared/Logger";
-import { annotateOcppLogs } from "@/components/ui/logEntryParsing";
+import {
+  annotateOcppLogs,
+  type LogDirection,
+} from "@/components/ui/logEntryParsing";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -30,6 +33,15 @@ interface LogViewerProps {
  * case so we can keep the filter list as `(number | null)[]`.
  */
 type ConnectorFilterValue = number | null;
+
+/**
+ * "(none)" pseudo-value for the Direction/Action filters, used for log
+ * entries {@link annotateOcppLogs} couldn't parse an OCPP direction/action
+ * out of (#178 2.4) — same `null`-means-"(none)" convention as
+ * {@link ConnectorFilterValue}.
+ */
+type DirectionFilterValue = LogDirection | null;
+type ActionFilterValue = string | null;
 
 /**
  * Best-effort: pull every connector id referenced by a log message.
@@ -68,13 +80,23 @@ export function LogViewer({
   const [logConnectorFilter, setLogConnectorFilter] = useState<
     ConnectorFilterValue[]
   >([]);
+  const [logDirectionFilter, setLogDirectionFilter] = useState<
+    DirectionFilterValue[]
+  >([]);
+  const [logActionFilter, setLogActionFilter] = useState<ActionFilterValue[]>(
+    [],
+  );
   const [autoScroll, setAutoScroll] = useState<boolean>(true);
   const [levelSearch, setLevelSearch] = useState("");
   const [typeSearch, setTypeSearch] = useState("");
   const [connectorSearch, setConnectorSearch] = useState("");
+  const [directionSearch, setDirectionSearch] = useState("");
+  const [actionSearch, setActionSearch] = useState("");
   const [levelExpanded, setLevelExpanded] = useState(true);
   const [typeExpanded, setTypeExpanded] = useState(true);
   const [connectorExpanded, setConnectorExpanded] = useState(true);
+  const [directionExpanded, setDirectionExpanded] = useState(true);
+  const [actionExpanded, setActionExpanded] = useState(true);
 
   // Each log's set of referenced connector ids — memoized so we don't
   // re-parse the message on every render or every filter toggle.
@@ -100,6 +122,8 @@ export function LogViewer({
     };
     const typeCounts: Record<LogType, number> = {} as Record<LogType, number>;
     const connectorCounts = new Map<ConnectorFilterValue, number>();
+    const directionCounts = new Map<DirectionFilterValue, number>();
+    const actionCounts = new Map<ActionFilterValue, number>();
 
     logs.forEach((log, idx) => {
       levelCounts[log.level] = (levelCounts[log.level] || 0) + 1;
@@ -113,10 +137,22 @@ export function LogViewer({
           connectorCounts.set(id, (connectorCounts.get(id) ?? 0) + 1);
         }
       }
+
+      const info = logOcppInfo[idx];
+      const direction = info.direction ?? null;
+      directionCounts.set(direction, (directionCounts.get(direction) ?? 0) + 1);
+      const action = info.action ?? null;
+      actionCounts.set(action, (actionCounts.get(action) ?? 0) + 1);
     });
 
-    return { levelCounts, typeCounts, connectorCounts };
-  }, [logs, logConnectors]);
+    return {
+      levelCounts,
+      typeCounts,
+      connectorCounts,
+      directionCounts,
+      actionCounts,
+    };
+  }, [logs, logConnectors, logOcppInfo]);
 
   // Pairs each surviving entry with its index in the original `logs` array
   // (not its position after filtering) so the row renderer can still look
@@ -145,6 +181,14 @@ export function LogViewer({
               : ids.some((id) => logConnectorFilter.includes(id));
           if (!match) return false;
         }
+        if (logDirectionFilter.length > 0) {
+          const direction = logOcppInfo[idx].direction ?? null;
+          if (!logDirectionFilter.includes(direction)) return false;
+        }
+        if (logActionFilter.length > 0) {
+          const action = logOcppInfo[idx].action ?? null;
+          if (!logActionFilter.includes(action)) return false;
+        }
         return true;
       });
   }, [
@@ -154,6 +198,9 @@ export function LogViewer({
     logTypeFilter,
     logConnectorFilter,
     logConnectors,
+    logDirectionFilter,
+    logActionFilter,
+    logOcppInfo,
   ]);
 
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -233,12 +280,33 @@ export function LogViewer({
     }
   };
 
+  const toggleLogDirection = (value: DirectionFilterValue) => {
+    if (logDirectionFilter.includes(value)) {
+      setLogDirectionFilter(logDirectionFilter.filter((v) => v !== value));
+    } else {
+      setLogDirectionFilter([...logDirectionFilter, value]);
+    }
+  };
+
+  const toggleLogAction = (value: ActionFilterValue) => {
+    if (logActionFilter.includes(value)) {
+      setLogActionFilter(logActionFilter.filter((v) => v !== value));
+    } else {
+      setLogActionFilter([...logActionFilter, value]);
+    }
+  };
+
   const connectorLabel = (value: ConnectorFilterValue): string =>
     value === null
       ? "(none)"
       : value === 0
         ? "0 (charge point)"
         : `Connector ${value}`;
+
+  const directionLabel = (value: DirectionFilterValue): string =>
+    value === null ? "(none)" : value === "sent" ? "Sent" : "Received";
+
+  const actionLabel = (value: ActionFilterValue): string => value ?? "(none)";
 
   // Surface every connector id that's appeared in logs so far, sorted with
   // (none) last. Filter by the search box (matches the rendered label).
@@ -254,6 +322,38 @@ export function LogViewer({
     const q = connectorSearch.toLowerCase();
     return all.filter((v) => connectorLabel(v).toLowerCase().includes(q));
   }, [stats.connectorCounts, connectorSearch]);
+
+  // Sent / Received / (none), with (none) last — same shape as the
+  // Connector filter above (#178 2.4).
+  const filteredDirections = useMemo(() => {
+    const all: DirectionFilterValue[] = [...stats.directionCounts.keys()].sort(
+      (a, b) => {
+        if (a === null) return 1;
+        if (b === null) return -1;
+        return a.localeCompare(b);
+      },
+    );
+    if (!directionSearch) return all;
+    const q = directionSearch.toLowerCase();
+    return all.filter((v) => directionLabel(v).toLowerCase().includes(q));
+  }, [stats.directionCounts, directionSearch]);
+
+  // Every OCPP action name that's appeared in logs so far, most-frequent
+  // first (mirrors the Type filter's sort), with (none) last (#178 2.4).
+  const filteredActions = useMemo(() => {
+    const all: ActionFilterValue[] = [...stats.actionCounts.keys()].sort(
+      (a, b) => {
+        if (a === null) return 1;
+        if (b === null) return -1;
+        return (
+          (stats.actionCounts.get(b) || 0) - (stats.actionCounts.get(a) || 0)
+        );
+      },
+    );
+    if (!actionSearch) return all;
+    const q = actionSearch.toLowerCase();
+    return all.filter((v) => actionLabel(v).toLowerCase().includes(q));
+  }, [stats.actionCounts, actionSearch]);
 
   // Filtered level and type lists for search
   const filteredLevels = useMemo(() => {
@@ -438,6 +538,120 @@ export function LogViewer({
                             className="ml-2 text-xs px-1.5 py-0"
                           >
                             {stats.connectorCounts.get(value) || 0}
+                          </Badge>
+                        </label>
+                      );
+                    })
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Direction Filter (#178 2.4) */}
+          <div className="border-b">
+            <button
+              onClick={() => setDirectionExpanded(!directionExpanded)}
+              className="w-full flex items-center justify-between p-3 hover:bg-muted/50 transition-colors"
+            >
+              <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Direction
+              </span>
+              {directionExpanded ? (
+                <ChevronDown className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              ) : (
+                <ChevronRight className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              )}
+            </button>
+            {directionExpanded && (
+              <div className="px-3 pb-3 space-y-2">
+                <Input
+                  placeholder="Filter values"
+                  value={directionSearch}
+                  onChange={(e) => setDirectionSearch(e.target.value)}
+                  className="h-8 text-xs"
+                />
+                <div className="space-y-1 max-h-48 overflow-y-auto">
+                  {filteredDirections.map((value) => {
+                    const key = value ?? "none";
+                    return (
+                      <label
+                        key={key}
+                        className="flex items-center justify-between p-1.5 hover:bg-muted/50 rounded cursor-pointer group"
+                      >
+                        <div className="flex items-center gap-2 flex-1 min-w-0">
+                          <Checkbox
+                            checked={logDirectionFilter.includes(value)}
+                            onCheckedChange={() => toggleLogDirection(value)}
+                          />
+                          <span className="text-xs text-gray-900 dark:text-gray-100 truncate">
+                            {directionLabel(value)}
+                          </span>
+                        </div>
+                        <Badge
+                          variant="outline"
+                          className="ml-2 text-xs px-1.5 py-0"
+                        >
+                          {stats.directionCounts.get(value) || 0}
+                        </Badge>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Action Filter (#178 2.4) */}
+          <div className="border-b">
+            <button
+              onClick={() => setActionExpanded(!actionExpanded)}
+              className="w-full flex items-center justify-between p-3 hover:bg-muted/50 transition-colors"
+            >
+              <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Action
+              </span>
+              {actionExpanded ? (
+                <ChevronDown className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              ) : (
+                <ChevronRight className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              )}
+            </button>
+            {actionExpanded && (
+              <div className="px-3 pb-3 space-y-2">
+                <Input
+                  placeholder="Filter values"
+                  value={actionSearch}
+                  onChange={(e) => setActionSearch(e.target.value)}
+                  className="h-8 text-xs"
+                />
+                <div className="space-y-1 max-h-64 overflow-y-auto">
+                  {filteredActions.length === 0 ? (
+                    <p className="text-xs text-muted-foreground italic px-1">
+                      No OCPP actions parsed yet
+                    </p>
+                  ) : (
+                    filteredActions.map((value) => {
+                      const key = value ?? "none";
+                      return (
+                        <label
+                          key={key}
+                          className="flex items-center justify-between p-1.5 hover:bg-muted/50 rounded cursor-pointer group"
+                        >
+                          <div className="flex items-center gap-2 flex-1 min-w-0">
+                            <Checkbox
+                              checked={logActionFilter.includes(value)}
+                              onCheckedChange={() => toggleLogAction(value)}
+                            />
+                            <span className="text-xs text-gray-900 dark:text-gray-100 truncate">
+                              {actionLabel(value)}
+                            </span>
+                          </div>
+                          <Badge
+                            variant="outline"
+                            className="ml-2 text-xs px-1.5 py-0"
+                          >
+                            {stats.actionCounts.get(value) || 0}
                           </Badge>
                         </label>
                       );

--- a/src/components/ui/log-viewer.tsx
+++ b/src/components/ui/log-viewer.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { LogEntry, LogLevel, LogType } from "@/cp/shared/Logger";
+import { annotateOcppLogs } from "@/components/ui/logEntryParsing";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -82,6 +83,13 @@ export function LogViewer({
     [logs],
   );
 
+  // Best-effort OCPP action + wire direction per entry (#178 2.2/2.3).
+  // Parsed from `logs` (the full, chronological list) rather than
+  // `filteredLogs` — see logEntryParsing.ts: CALLRESULT/CALLERROR frames
+  // need to correlate back to an earlier CALL frame by message id, which
+  // breaks if an active filter hides that earlier entry.
+  const logOcppInfo = useMemo(() => annotateOcppLogs(logs), [logs]);
+
   // Calculate statistics
   const stats = useMemo(() => {
     const levelCounts: Record<LogLevel, number> = {
@@ -110,27 +118,35 @@ export function LogViewer({
     return { levelCounts, typeCounts, connectorCounts };
   }, [logs, logConnectors]);
 
+  // Pairs each surviving entry with its index in the original `logs` array
+  // (not its position after filtering) so the row renderer can still look
+  // up per-entry data — like `logOcppInfo` — keyed against the full list.
   const filteredLogs = useMemo(() => {
-    return logs.filter((log, idx) => {
-      if (filter && !log.message.toLowerCase().includes(filter.toLowerCase())) {
-        return false;
-      }
-      if (logLevelFilter.length > 0 && !logLevelFilter.includes(log.level)) {
-        return false;
-      }
-      if (logTypeFilter.length > 0 && !logTypeFilter.includes(log.type)) {
-        return false;
-      }
-      if (logConnectorFilter.length > 0) {
-        const ids = logConnectors[idx];
-        const match =
-          ids.length === 0
-            ? logConnectorFilter.includes(null)
-            : ids.some((id) => logConnectorFilter.includes(id));
-        if (!match) return false;
-      }
-      return true;
-    });
+    return logs
+      .map((log, idx) => ({ log, idx }))
+      .filter(({ log, idx }) => {
+        if (
+          filter &&
+          !log.message.toLowerCase().includes(filter.toLowerCase())
+        ) {
+          return false;
+        }
+        if (logLevelFilter.length > 0 && !logLevelFilter.includes(log.level)) {
+          return false;
+        }
+        if (logTypeFilter.length > 0 && !logTypeFilter.includes(log.type)) {
+          return false;
+        }
+        if (logConnectorFilter.length > 0) {
+          const ids = logConnectors[idx];
+          const match =
+            ids.length === 0
+              ? logConnectorFilter.includes(null)
+              : ids.some((id) => logConnectorFilter.includes(id));
+          if (!match) return false;
+        }
+        return true;
+      });
   }, [
     logs,
     filter,
@@ -521,6 +537,12 @@ export function LogViewer({
                 <th className="h-10 px-2 text-left align-middle font-medium text-muted-foreground w-[140px]">
                   Type
                 </th>
+                <th className="h-10 px-2 text-left align-middle font-medium text-muted-foreground w-[100px]">
+                  Direction
+                </th>
+                <th className="h-10 px-2 text-left align-middle font-medium text-muted-foreground w-[180px]">
+                  Action
+                </th>
                 <th className="h-10 px-2 text-left align-middle font-medium text-muted-foreground">
                   Message
                 </th>
@@ -530,7 +552,7 @@ export function LogViewer({
               {filteredLogs.length === 0 ? (
                 <tr className="border-b">
                   <td
-                    colSpan={4}
+                    colSpan={6}
                     className="p-2 text-center text-muted-foreground py-8"
                   >
                     {logs.length === 0
@@ -539,40 +561,67 @@ export function LogViewer({
                   </td>
                 </tr>
               ) : (
-                filteredLogs.map((log, index) => (
-                  <tr
-                    key={index}
-                    className="border-b transition-colors hover:bg-muted/50 font-mono text-xs"
-                  >
-                    <td className="p-2 align-middle text-muted-foreground">
-                      {log.timestamp.toISOString().substring(11, 23)}
-                    </td>
-                    <td className="p-2 align-middle">
-                      <Badge variant={getLogLevelBadgeVariant(log.level)}>
-                        {LogLevel[log.level]}
-                      </Badge>
-                    </td>
-                    <td className="p-2 align-middle">
-                      <Badge
-                        variant="secondary"
-                        className={cn(
-                          "font-normal",
-                          getLogTypeBadgeColor(log.type),
+                filteredLogs.map(({ log, idx }) => {
+                  const ocppInfo = logOcppInfo[idx];
+                  return (
+                    <tr
+                      key={idx}
+                      className="border-b transition-colors hover:bg-muted/50 font-mono text-xs"
+                    >
+                      <td className="p-2 align-middle text-muted-foreground">
+                        {log.timestamp.toISOString().substring(11, 23)}
+                      </td>
+                      <td className="p-2 align-middle">
+                        <Badge variant={getLogLevelBadgeVariant(log.level)}>
+                          {LogLevel[log.level]}
+                        </Badge>
+                      </td>
+                      <td className="p-2 align-middle">
+                        <Badge
+                          variant="secondary"
+                          className={cn(
+                            "font-normal",
+                            getLogTypeBadgeColor(log.type),
+                          )}
+                        >
+                          {log.type}
+                        </Badge>
+                      </td>
+                      <td className="p-2 align-middle">
+                        {ocppInfo.direction ? (
+                          <Badge
+                            variant="outline"
+                            className={cn(
+                              "font-normal whitespace-nowrap",
+                              ocppInfo.direction === "sent"
+                                ? "border-sky-300 text-sky-700 dark:border-sky-700 dark:text-sky-300"
+                                : "border-amber-300 text-amber-700 dark:border-amber-700 dark:text-amber-300",
+                            )}
+                          >
+                            {ocppInfo.direction === "sent"
+                              ? "→ Sent"
+                              : "← Received"}
+                          </Badge>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
                         )}
-                      >
-                        {log.type}
-                      </Badge>
-                    </td>
-                    {/* whitespace-nowrap (was break-all): a long payload
-                     *  now stays on one line and scrolls horizontally in
-                     *  the container above instead of wrapping
-                     *  character-by-character into a mangled block
-                     *  (#178 2.1). */}
-                    <td className="p-2 align-middle whitespace-nowrap">
-                      {log.message}
-                    </td>
-                  </tr>
-                ))
+                      </td>
+                      <td className="p-2 align-middle whitespace-nowrap">
+                        {ocppInfo.action ?? (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                      {/* whitespace-nowrap (was break-all): a long payload
+                       *  now stays on one line and scrolls horizontally in
+                       *  the container above instead of wrapping
+                       *  character-by-character into a mangled block
+                       *  (#178 2.1). */}
+                      <td className="p-2 align-middle whitespace-nowrap">
+                        {log.message}
+                      </td>
+                    </tr>
+                  );
+                })
               )}
             </tbody>
           </table>

--- a/src/components/ui/log-viewer.tsx
+++ b/src/components/ui/log-viewer.tsx
@@ -435,7 +435,11 @@ export function LogViewer({
       </div>
 
       {/* Right Side - Logs */}
-      <div className="flex-1 flex flex-col">
+      {/* min-w-0 overrides the flex-item default `min-width: auto`, which
+       *  would otherwise let a wide log table force this column (and the
+       *  whole page) wider instead of scrolling inside its own container
+       *  (#178 2.1). */}
+      <div className="flex-1 flex flex-col min-w-0">
         {/* Top Bar */}
         <div className="flex justify-between items-center p-3 border-b bg-muted/50">
           <div className="flex items-center gap-3">
@@ -501,7 +505,7 @@ export function LogViewer({
 
         {/* Log Table */}
         <div
-          className="flex-1 overflow-auto relative"
+          className="flex-1 overflow-x-auto overflow-y-auto relative"
           ref={containerRef}
           style={{ maxHeight }}
         >
@@ -559,7 +563,12 @@ export function LogViewer({
                         {log.type}
                       </Badge>
                     </td>
-                    <td className="p-2 align-middle break-all">
+                    {/* whitespace-nowrap (was break-all): a long payload
+                     *  now stays on one line and scrolls horizontally in
+                     *  the container above instead of wrapping
+                     *  character-by-character into a mangled block
+                     *  (#178 2.1). */}
+                    <td className="p-2 align-middle whitespace-nowrap">
                       {log.message}
                     </td>
                   </tr>

--- a/src/components/ui/logEntryParsing.ts
+++ b/src/components/ui/logEntryParsing.ts
@@ -1,0 +1,132 @@
+import type { LogEntry } from "@/cp/shared/Logger";
+
+/**
+ * Best-effort extraction of the OCPP action name and wire direction from a
+ * {@link LogEntry} message string (#178 item E).
+ *
+ * `LogEntry` (`src/cp/shared/Logger.ts`) has no structured `action`/
+ * `direction` field — every OCPP action name and direction is baked into
+ * free-text log lines written by the transport layer. Two wire-level
+ * message shapes carry enough structure to parse reliably (confirmed
+ * against the actual emit sites, not guessed):
+ *
+ *  - WebSocket transport (`OCPPWebSocket.ts` `send()`/`handleMessage()`):
+ *    `"Sent: <json>"` / `"Received: <json>"`, where `<json>` is the raw
+ *    OCPP-J array: `[2, id, action, payload]` (CALL),
+ *    `[3, id, payload]` (CALLRESULT), `[4, id, code, desc, details]`
+ *    (CALLERROR).
+ *  - SOAP transport (`OCPPSoapHandler.ts` `postSoap()`):
+ *    `"SOAP POST <operation>: <xml>"` (request) /
+ *    `"SOAP response <operation>: <xml>"` (response).
+ *
+ * OCPP-J CALLRESULT/CALLERROR frames don't carry the action name inline by
+ * design (the spec correlates by message id, not by repeating the action).
+ * {@link annotateOcppLogs} resolves those by tracking `messageId -> action`
+ * across the *whole* chronological log list, so e.g. a
+ * `"Received: [3, \"42\", {...}]"` line correlates back to whichever CALL
+ * frame (sent or received) established id `"42"`.
+ *
+ * Log lines that aren't wire traffic (diagnostics like "Suppressing X",
+ * "Handling incoming message: ...", scenario/general logs, SOAP fault
+ * errors, etc.) simply produce `{}` — no action, no direction. This is an
+ * intentionally lossy, best-effort parse rather than a LogEntry data-model
+ * change; see the #178 item E scout note (docs/architecture or
+ * .superpowers/sdd/scout-178.md) for the enrich-vs-parse tradeoff.
+ */
+
+export type LogDirection = "sent" | "received";
+
+export interface OcppLogInfo {
+  action?: string;
+  direction?: LogDirection;
+}
+
+const WS_SENT_PREFIX = "Sent: ";
+const WS_RECEIVED_PREFIX = "Received: ";
+const SOAP_POST_RE = /^SOAP POST (\S+):/;
+const SOAP_RESPONSE_RE = /^SOAP response (\S+):/;
+
+const OCPPJ_CALL = 2;
+const OCPPJ_CALLRESULT = 3;
+const OCPPJ_CALLERROR = 4;
+
+interface WireFrame {
+  direction: LogDirection;
+  messageId?: string;
+  /** Present for CALL frames (and SOAP, which always names the operation).
+   *  Absent for CALLRESULT/CALLERROR frames — those get resolved via
+   *  {@link annotateOcppLogs}'s messageId correlation. */
+  action?: string;
+}
+
+function parseWireArrayMessage(
+  json: string,
+  direction: LogDirection,
+): WireFrame | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed) || parsed.length < 3) return null;
+  const [type, id] = parsed;
+  if (typeof id !== "string" && typeof id !== "number") return null;
+  const messageId = String(id);
+  if (type === OCPPJ_CALL && typeof parsed[2] === "string") {
+    return { direction, messageId, action: parsed[2] };
+  }
+  if (type === OCPPJ_CALLRESULT || type === OCPPJ_CALLERROR) {
+    return { direction, messageId };
+  }
+  return null;
+}
+
+function parseSingleMessage(message: string): WireFrame | null {
+  if (message.startsWith(WS_SENT_PREFIX)) {
+    return parseWireArrayMessage(message.slice(WS_SENT_PREFIX.length), "sent");
+  }
+  if (message.startsWith(WS_RECEIVED_PREFIX)) {
+    return parseWireArrayMessage(
+      message.slice(WS_RECEIVED_PREFIX.length),
+      "received",
+    );
+  }
+  const postMatch = SOAP_POST_RE.exec(message);
+  if (postMatch) return { direction: "sent", action: postMatch[1] };
+  const responseMatch = SOAP_RESPONSE_RE.exec(message);
+  if (responseMatch) {
+    return { direction: "received", action: responseMatch[1] };
+  }
+  return null;
+}
+
+/**
+ * Parse every entry's message for action/direction, resolving
+ * CALLRESULT/CALLERROR action names by message-id correlation against
+ * earlier CALL frames in the same list.
+ *
+ * `logs` should be the full, chronological log list (not a
+ * filtered/paginated subset) so correlation isn't broken by an active
+ * filter hiding the CALL frame that named the action. Returns one
+ * {@link OcppLogInfo} per input entry, same order/length as `logs`.
+ */
+export function annotateOcppLogs(
+  logs: Pick<LogEntry, "message">[],
+): OcppLogInfo[] {
+  const actionByMessageId = new Map<string, string>();
+  return logs.map((log) => {
+    const frame = parseSingleMessage(log.message);
+    if (!frame) return {};
+    if (frame.action) {
+      if (frame.messageId) {
+        actionByMessageId.set(frame.messageId, frame.action);
+      }
+      return { action: frame.action, direction: frame.direction };
+    }
+    const resolved = frame.messageId
+      ? actionByMessageId.get(frame.messageId)
+      : undefined;
+    return { action: resolved, direction: frame.direction };
+  });
+}

--- a/src/test/setup.dom.ts
+++ b/src/test/setup.dom.ts
@@ -75,4 +75,11 @@ export const mockReactFlow = () => {
 if (typeof window !== "undefined") {
   await import("@testing-library/jest-dom/vitest");
   mockReactFlow();
+
+  // jsdom doesn't implement Element.scrollTo (used by LogViewer's
+  // auto-scroll-to-bottom effect, #178). No-op is fine for tests — nothing
+  // asserts on actual scroll position.
+  if (typeof Element !== "undefined" && !Element.prototype.scrollTo) {
+    Element.prototype.scrollTo = function scrollTo() {};
+  }
 }


### PR DESCRIPTION
## Summary

Item E of @juherr's #178 v0.7.0 feedback (log viewer improvements, sections 2.1–2.4). Additive to the existing viewer — levels, timestamps, and current rendering are unchanged.

Refs #178

- **2.1 Horizontal scroll**: the log container now scrolls horizontally (`overflow-x: auto`) without forcing page-level horizontal scroll — fixes the unreadable-narrow-log problem when the Scenario panel is open.
- **2.2 + 2.3 Action & Direction columns**: OCPP entries now show the action name (BootNotification, StatusNotification, Authorize, StartTransaction, MeterValues, …) and direction (Sent/Received) as dedicated columns, so you don't have to read them out of the raw payload.
- **2.4 Column filters**: filter the log by direction, OCPP action, and free-text.

### Design: parse-in-viewer, not model-enrichment
`LogEntry` has no structured action/direction field, and the OCPP action is only inline at two emit sites (`OCPPWebSocket` raw JSON-RPC arrays, `OCPPSoapHandler` `SOAP <op>:` prefixes) — and CALLRESULT/CALLERROR replies carry no action at all (they'd need message-id correlation threaded through both message handlers' `sendResult`/`sendError`). So the action/direction are derived in the viewer via `annotateOcppLogs()` (`src/components/ui/logEntryParsing.ts`): `JSON.parse` + fixed-prefix matching (not prose regex) for the two well-defined wire formats, plus message-id correlation for CALLRESULT/CALLERROR. This keeps the whole change inside `src/components/ui/` with zero risk to the transport layer.

## Testing
- vitest 1104/1104 (+31 new, incl. a dom-test suite for the columns/filters and a thorough unit suite for the `annotateOcppLogs` parser), `bun test bun.test` 204/204 (transport untouched), eslint + prettier clean, `tsc -b --noEmit --force` = 478 (unchanged).
- Note: in-browser screenshot verification couldn't run (shared devtools profile locked by another session); verified via dom tests + code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Direction and Action columns to the log viewer.
  - Added sidebar filters for message direction and OCPP actions, including counts and “(none)” results.
  - Correlated response and error messages with their originating actions.
  - Added support for parsing WebSocket and SOAP log entries.

- **Bug Fixes**
  - Improved filtering consistency when messages are hidden by other filters.
  - Improved log table scrolling and prevented message text from wrapping unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->