### PR TITLE
fix(reservation): emit StatusNotification.req for ReserveNow/CancelReservation (#186)

### DIFF
--- a/scripts/steve-verify/runner/specs/authlist-reservation.ts
+++ b/scripts/steve-verify/runner/specs/authlist-reservation.ts
@@ -343,6 +343,19 @@ export const reservationBasicSpec: ScenarioSpec<void> = {
       "Accepted",
       "ReserveNow accepted",
     );
+    // #186: the CP core now drives the connector Reserved through
+    // updateConnectorStatus, so a StatusNotification(Reserved) reaches the
+    // wire on Accepted (previously a bare `connector.status =` write left the
+    // CSMS blind to the transition). assertLineAfter (not assertLineOrder):
+    // the connector's post-boot Available always precedes ReserveNow, so anchor
+    // on the ReserveNow exchange to confirm Reserved is the response to it.
+    assertLineAfter(
+      rec,
+      lines,
+      /Received: \[2,.*"ReserveNow"/,
+      /Sent: \[2,.*"StatusNotification".*"status":"Reserved"/,
+      "StatusNotification(Reserved) sent after ReserveNow accepted (#186)",
+    );
     assertLineMatches(
       rec,
       lines,
@@ -619,7 +632,7 @@ export const tc051CancelReservationSpec: ScenarioSpec<CancelReservationDriveStat
 
       return { reservationPk };
     },
-    async assert({ frames, rec, db, driveState }) {
+    async assert({ frames, lines, rec, db, driveState }) {
       assertResponseStatus(
         rec,
         frames,
@@ -633,6 +646,24 @@ export const tc051CancelReservationSpec: ScenarioSpec<CancelReservationDriveStat
         "CancelReservation",
         "Accepted",
         "CancelReservation accepted",
+      );
+      // #186: both reservation transitions are now OCPP-visible. ReserveNow
+      // drives Reserved; CancelReservation flips it back to Available -- both
+      // through updateConnectorStatus, so each emits a StatusNotification.req
+      // the CSMS can see (this scenario previously sent nothing for either).
+      assertLineAfter(
+        rec,
+        lines,
+        /Received: \[2,.*"ReserveNow"/,
+        /Sent: \[2,.*"StatusNotification".*"status":"Reserved"/,
+        "StatusNotification(Reserved) sent after ReserveNow (#186)",
+      );
+      assertLineAfter(
+        rec,
+        lines,
+        /Received: \[2,.*"CancelReservation"/,
+        /Sent: \[2,.*"StatusNotification".*"status":"Available"/,
+        "StatusNotification(Available) sent after CancelReservation (#186)",
       );
 
       if (!driveState.reservationPk) {

--- a/src/cp/infrastructure/transport/handlers/call/ReservationHandlers.ts
+++ b/src/cp/infrastructure/transport/handlers/call/ReservationHandlers.ts
@@ -57,9 +57,15 @@ export class ReserveNowHandler implements CallHandler<
       reservationId,
     );
 
-    // If reservation was accepted, update connector status to Reserved
+    // If reservation was accepted, drive the connector to Reserved through
+    // updateConnectorStatus so an OCPP StatusNotification(Reserved) is emitted
+    // on the wire (a bare `connector.status = …` fires only the connector-local
+    // statusChange event and the CSMS never sees the transition).
     if (status === ReservationStatus.Accepted) {
-      connector.status = OCPPStatus.Reserved;
+      context.chargePoint.updateConnectorStatus(
+        connectorId,
+        OCPPStatus.Reserved,
+      );
     }
 
     return { status };
@@ -94,7 +100,12 @@ export class CancelReservationHandler implements CallHandler<
         reservation.connectorId,
       );
       if (connector && connector.status === OCPPStatus.Reserved) {
-        connector.status = OCPPStatus.Available;
+        // Route through updateConnectorStatus so StatusNotification(Available)
+        // is sent for the post-cancel transition (mirrors ReserveNow above).
+        context.chargePoint.updateConnectorStatus(
+          reservation.connectorId,
+          OCPPStatus.Available,
+        );
       }
 
       return { status: CancelReservationStatus.Accepted };

--- a/src/cp/infrastructure/transport/handlers/call/__tests__/ReservationHandlers.test.ts
+++ b/src/cp/infrastructure/transport/handlers/call/__tests__/ReservationHandlers.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  ReserveNowHandler,
+  CancelReservationHandler,
+} from "../ReservationHandlers";
+import type { HandlerContext } from "../../MessageHandlerRegistry";
+import type { ChargePoint } from "../../../../../domain/charge-point/ChargePoint";
+import {
+  ReservationStatus,
+  CancelReservationStatus,
+  OCPPStatus,
+} from "../../../../../domain/types/OcppTypes";
+
+/**
+ * Issue #186: ReserveNow/CancelReservation must drive the connector through
+ * `updateConnectorStatus` so an OCPP StatusNotification.req actually goes on
+ * the wire for the Reserved / post-cancel Available transitions. The previous
+ * `connector.status = …` assignment fired only the connector-local statusChange
+ * event (enough for scenario statusTriggers) but the CSMS never saw the change.
+ *
+ * These tests pin that routing: a bare property write would leave the
+ * `updateConnectorStatus` spy uncalled and fail the assertions below.
+ */
+
+interface ConnectorShape {
+  status: OCPPStatus;
+  availability: "Operative" | "Inoperative";
+  transaction: unknown | null;
+}
+
+interface ReservationManagerShape {
+  createReservation: ReturnType<typeof vi.fn>;
+  getReservation: ReturnType<typeof vi.fn>;
+  cancelReservation: ReturnType<typeof vi.fn>;
+}
+
+function buildContext(opts: {
+  connector: ConnectorShape | null;
+  reservationManager: Partial<ReservationManagerShape>;
+}) {
+  const updateConnectorStatus = vi.fn();
+  const reservationManager: ReservationManagerShape = {
+    createReservation: vi.fn(),
+    getReservation: vi.fn(),
+    cancelReservation: vi.fn(),
+    ...opts.reservationManager,
+  };
+  const chargePoint = {
+    getConnector: vi.fn(() => opts.connector),
+    reservationManager,
+    updateConnectorStatus,
+  };
+  const ctx = {
+    chargePoint: chargePoint as unknown as ChargePoint,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as HandlerContext;
+  return { ctx, updateConnectorStatus, reservationManager };
+}
+
+const reserveNowPayload = {
+  connectorId: 1,
+  expiryDate: new Date(Date.now() + 60_000).toISOString(),
+  idTag: "CERT-TAG-1",
+  parentIdTag: undefined,
+  reservationId: 42,
+};
+
+describe("ReserveNowHandler (#186 StatusNotification wiring)", () => {
+  it("drives the connector to Reserved via updateConnectorStatus on Accepted", () => {
+    const { ctx, updateConnectorStatus } = buildContext({
+      connector: {
+        status: OCPPStatus.Available,
+        availability: "Operative",
+        transaction: null,
+      },
+      reservationManager: {
+        createReservation: vi.fn(() => ReservationStatus.Accepted),
+      },
+    });
+
+    const res = new ReserveNowHandler().handle(reserveNowPayload, ctx);
+
+    expect(res).toEqual({ status: ReservationStatus.Accepted });
+    // The whole point of #186: routed through updateConnectorStatus (which
+    // emits StatusNotification), not a bare `connector.status =` assignment.
+    expect(updateConnectorStatus).toHaveBeenCalledWith(1, OCPPStatus.Reserved);
+  });
+
+  it("does NOT touch connector status when the reservation is rejected", () => {
+    const { ctx, updateConnectorStatus } = buildContext({
+      connector: {
+        status: OCPPStatus.Available,
+        availability: "Operative",
+        transaction: null,
+      },
+      reservationManager: {
+        createReservation: vi.fn(() => ReservationStatus.Rejected),
+      },
+    });
+
+    const res = new ReserveNowHandler().handle(reserveNowPayload, ctx);
+
+    expect(res).toEqual({ status: ReservationStatus.Rejected });
+    expect(updateConnectorStatus).not.toHaveBeenCalled();
+  });
+
+  it("rejects a Faulted connector as Faulted without a status update", () => {
+    const { ctx, updateConnectorStatus } = buildContext({
+      connector: {
+        status: OCPPStatus.Faulted,
+        availability: "Operative",
+        transaction: null,
+      },
+      reservationManager: {},
+    });
+
+    const res = new ReserveNowHandler().handle(reserveNowPayload, ctx);
+
+    expect(res).toEqual({ status: ReservationStatus.Faulted });
+    expect(updateConnectorStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe("CancelReservationHandler (#186 StatusNotification wiring)", () => {
+  it("restores the connector to Available via updateConnectorStatus", () => {
+    const { ctx, updateConnectorStatus } = buildContext({
+      connector: {
+        status: OCPPStatus.Reserved,
+        availability: "Operative",
+        transaction: null,
+      },
+      reservationManager: {
+        getReservation: vi.fn(() => ({ connectorId: 1, reservationId: 42 })),
+        cancelReservation: vi.fn(() => true),
+      },
+    });
+
+    const res = new CancelReservationHandler().handle(
+      { reservationId: 42 },
+      ctx,
+    );
+
+    expect(res).toEqual({ status: CancelReservationStatus.Accepted });
+    expect(updateConnectorStatus).toHaveBeenCalledWith(1, OCPPStatus.Available);
+  });
+
+  it("does NOT emit an Available transition when the connector is not Reserved", () => {
+    const { ctx, updateConnectorStatus } = buildContext({
+      connector: {
+        status: OCPPStatus.Charging,
+        availability: "Operative",
+        transaction: {},
+      },
+      reservationManager: {
+        getReservation: vi.fn(() => ({ connectorId: 1, reservationId: 42 })),
+        cancelReservation: vi.fn(() => true),
+      },
+    });
+
+    const res = new CancelReservationHandler().handle(
+      { reservationId: 42 },
+      ctx,
+    );
+
+    // Still Accepted (the reservation was cancelled) but no wire transition —
+    // an in-progress transaction must not be clobbered back to Available.
+    expect(res).toEqual({ status: CancelReservationStatus.Accepted });
+    expect(updateConnectorStatus).not.toHaveBeenCalled();
+  });
+
+  it("returns Rejected and emits nothing when the reservation does not exist", () => {
+    const { ctx, updateConnectorStatus } = buildContext({
+      connector: {
+        status: OCPPStatus.Reserved,
+        availability: "Operative",
+        transaction: null,
+      },
+      reservationManager: {
+        getReservation: vi.fn(() => undefined),
+        cancelReservation: vi.fn(() => false),
+      },
+    });
+
+    const res = new CancelReservationHandler().handle(
+      { reservationId: 99999 },
+      ctx,
+    );
+
+    expect(res).toEqual({ status: CancelReservationStatus.Rejected });
+    expect(updateConnectorStatus).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/scenarios/cert16-reservation-basic.json
+++ b/src/utils/scenarios/cert16-reservation-basic.json
@@ -1,7 +1,7 @@
 {
   "id": "cert16-reservation-basic",
   "name": "Cert 1.6 Core: Reservation (Basic)",
-  "description": "Parks waiting for ReserveNow.req (connector goes Reserved internally on Accepted); once the reserved idTag is presented, StatusNotification(Preparing) → StartTransaction.req (carries the reservationId) → StatusNotification(Charging) with bounded MeterValue.req → StopTransaction.req → StatusNotification(Finishing) → StatusNotification(Available).",
+  "description": "Parks waiting for ReserveNow.req (the CP core emits StatusNotification(Reserved) on Accepted); once the reserved idTag is presented, StatusNotification(Preparing) → StartTransaction.req (carries the reservationId) → StatusNotification(Charging) with bounded MeterValue.req → StopTransaction.req → StatusNotification(Finishing) → StatusNotification(Available).",
   "targetType": "connector",
   "targetId": 1,
   "trigger": { "type": "manual" },
@@ -19,12 +19,6 @@
       "type": "reservationTrigger",
       "position": { "x": 400, "y": 150 },
       "data": { "label": "Wait for ReserveNow", "timeout": 0 }
-    },
-    {
-      "id": "status-reserved",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 250 },
-      "data": { "label": "Set Reserved", "status": "Reserved" }
     },
     {
       "id": "delay-arrival",
@@ -75,9 +69,8 @@
     {
       "id": "e2",
       "source": "trigger-reservation",
-      "target": "status-reserved"
+      "target": "delay-arrival"
     },
-    { "id": "e3", "source": "status-reserved", "target": "delay-arrival" },
     { "id": "e4", "source": "delay-arrival", "target": "tx-start" },
     { "id": "e5", "source": "tx-start", "target": "meter-auto" },
     { "id": "e6", "source": "meter-auto", "target": "tx-stop" },


### PR DESCRIPTION
Closes #186.

## Problem

`ReserveNowHandler.handle` (on acceptance) and `CancelReservationHandler.handle` assigned `connector.status = Reserved` / `= Available` **directly**, bypassing `updateConnectorStatus`. That fired only the connector-local `statusChange` event (which scenario `statusTrigger` nodes listen to) but never called `_outbox.sendStatusNotification` — so a real CSMS **never saw** the connector report `Reserved`, nor the post-cancel `Available`, over the wire.

## Fix

Route both handlers through `updateConnectorStatus`, like every other handler. This is a strict superset of the old behavior: `updateConnectorStatus` still writes `connector.status` (firing the same connector event scenarios depend on) **and** additionally emits the `StatusNotification.req`.

The existing guards are preserved:
- ReserveNow only transitions on `ReservationStatus.Accepted` (rejected/faulted/occupied/unavailable leave status untouched).
- CancelReservation only restores `Available` when the connector is actually `Reserved` (never clobbers an in-progress transaction).

## Scenario / verification reconciliation

- `cert16-reservation-basic`: dropped the now-redundant `Set Reserved` node — the core drives `Reserved` on `ReserveNow.Accepted`, so the explicit node would double-send (same duplicate class as #176/#185).
- `steve-verify`: `tc046` (reservation-basic) and `tc051` (cancel) now assert `StatusNotification(Reserved)` after ReserveNow and `StatusNotification(Available)` after CancelReservation.
- Added `ReservationHandlers` unit tests pinning the `updateConnectorStatus` routing (a bare property write regresses them).

## Gates
- `tsc -b --noEmit --force`: 478 (baseline, no new errors)
- vitest: 1113/1113 (2 unrelated data-hook timeout flakes pass in isolation)
- `test:bun`: 207/207
- eslint / prettier: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reservation acceptance now reports the connector as **Reserved** through an OCPP status notification.
  - Canceling an active reservation now reports the connector as **Available** when appropriate.
  - Reservation status transitions are now reflected consistently in protocol messages and certification scenarios.

- **Tests**
  - Added coverage for accepted, rejected, faulted, and invalid reservation flows, including connector status notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->