### PR TITLE
fix(scenarios): remove leading Available nodes duplicating the boot StatusNotification (#185)

### DIFF
--- a/scripts/steve-verify/runner/specs/core.ts
+++ b/scripts/steve-verify/runner/specs/core.ts
@@ -31,7 +31,7 @@ import { sleep } from "../util";
 export const tc001ColdBootSpec: ScenarioSpec<void> = {
   templateId: "cert16-tc001-cold-boot",
   description:
-    "TC_001 Cold Boot: CP re-affirms StatusNotification(Available) after boot, then idles.",
+    "TC_001 Cold Boot: CP core drives StatusNotification(Available) on boot (no scripted node), then idles.",
   connector: 1,
   bootWaitSecs: 4,
   holdSecs: 20,

--- a/src/utils/scenarios/cert16-tc001-cold-boot.json
+++ b/src/utils/scenarios/cert16-tc001-cold-boot.json
@@ -1,7 +1,7 @@
 {
   "id": "cert16-tc001-cold-boot",
   "name": "Cert 1.6 Core: TC_001 Cold Boot",
-  "description": "BootNotification.req/.conf runs automatically on connect; scenario re-affirms StatusNotification(Available) for the target connector, then idles while the CP's own Heartbeat timer keeps running.",
+  "description": "BootNotification.req/.conf runs automatically on connect; the CP core drives every idle connector to Available and sends StatusNotification(Available) on boot, so this scenario just observes that boot behavior and idles while the CP's own Heartbeat timer keeps running.",
   "targetType": "connector",
   "targetId": 1,
   "trigger": { "type": "manual" },
@@ -13,15 +13,6 @@
       "type": "start",
       "position": { "x": 400, "y": 50 },
       "data": { "label": "Start", "triggerOn": "connect" }
-    },
-    {
-      "id": "status-notify-available",
-      "type": "statusNotification",
-      "position": { "x": 400, "y": 150 },
-      "data": {
-        "label": "StatusNotification: Available",
-        "status": "Available"
-      }
     },
     {
       "id": "delay-idle",
@@ -40,8 +31,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-notify-available" },
-    { "id": "e2", "source": "status-notify-available", "target": "delay-idle" },
+    { "id": "e1", "source": "start-1", "target": "delay-idle" },
     { "id": "e3", "source": "delay-idle", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc019-get-configuration-all.json
+++ b/src/utils/scenarios/cert16-tc019-get-configuration-all.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "trigger-get-config",
       "type": "csmsCallTrigger",
       "position": { "x": 400, "y": 250 },
@@ -38,12 +32,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    {
-      "id": "e2",
-      "source": "status-available",
-      "target": "trigger-get-config"
-    },
+    { "id": "e1", "source": "start-1", "target": "trigger-get-config" },
     { "id": "e3", "source": "trigger-get-config", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc019-get-configuration-key.json
+++ b/src/utils/scenarios/cert16-tc019-get-configuration-key.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "trigger-get-config",
       "type": "csmsCallTrigger",
       "position": { "x": 400, "y": 250 },
@@ -38,12 +32,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    {
-      "id": "e2",
-      "source": "status-available",
-      "target": "trigger-get-config"
-    },
+    { "id": "e1", "source": "start-1", "target": "trigger-get-config" },
     { "id": "e3", "source": "trigger-get-config", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc021-change-configuration.json
+++ b/src/utils/scenarios/cert16-tc021-change-configuration.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "trigger-change-config",
       "type": "csmsCallTrigger",
       "position": { "x": 400, "y": 250 },
@@ -38,12 +32,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    {
-      "id": "e2",
-      "source": "status-available",
-      "target": "trigger-change-config"
-    },
+    { "id": "e1", "source": "start-1", "target": "trigger-change-config" },
     { "id": "e3", "source": "trigger-change-config", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc026-remote-start-rejected.json
+++ b/src/utils/scenarios/cert16-tc026-remote-start-rejected.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "arm-override",
       "type": "responseOverride",
       "position": { "x": 400, "y": 250 },
@@ -57,8 +51,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    { "id": "e2", "source": "status-available", "target": "arm-override" },
+    { "id": "e1", "source": "start-1", "target": "arm-override" },
     { "id": "e3", "source": "arm-override", "target": "trigger-remote-start" },
     { "id": "e4", "source": "trigger-remote-start", "target": "delay-verify" },
     { "id": "e5", "source": "delay-verify", "target": "end-1" }

--- a/src/utils/scenarios/cert16-tc031-unlock-unknown-connector.json
+++ b/src/utils/scenarios/cert16-tc031-unlock-unknown-connector.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "trigger-unlock",
       "type": "csmsCallTrigger",
       "position": { "x": 400, "y": 250 },
@@ -38,8 +32,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    { "id": "e2", "source": "status-available", "target": "trigger-unlock" },
+    { "id": "e1", "source": "start-1", "target": "trigger-unlock" },
     { "id": "e3", "source": "trigger-unlock", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc044-1-firmware-update.json
+++ b/src/utils/scenarios/cert16-tc044-1-firmware-update.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "trigger-firmware-update",
       "type": "csmsCallTrigger",
       "position": { "x": 400, "y": 250 },
@@ -47,12 +41,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    {
-      "id": "e2",
-      "source": "status-available",
-      "target": "trigger-firmware-update"
-    },
+    { "id": "e1", "source": "start-1", "target": "trigger-firmware-update" },
     {
       "id": "e3",
       "source": "trigger-firmware-update",

--- a/src/utils/scenarios/cert16-tc045-1-get-diagnostics.json
+++ b/src/utils/scenarios/cert16-tc045-1-get-diagnostics.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "trigger-get-diagnostics",
       "type": "csmsCallTrigger",
       "position": { "x": 400, "y": 250 },
@@ -47,12 +41,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    {
-      "id": "e2",
-      "source": "status-available",
-      "target": "trigger-get-diagnostics"
-    },
+    { "id": "e1", "source": "start-1", "target": "trigger-get-diagnostics" },
     {
       "id": "e3",
       "source": "trigger-get-diagnostics",

--- a/src/utils/scenarios/cert16-tc048-4-reserve-now-rejected.json
+++ b/src/utils/scenarios/cert16-tc048-4-reserve-now-rejected.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "arm-rejected-response",
       "type": "responseOverride",
       "position": { "x": 400, "y": 250 },
@@ -48,12 +42,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    {
-      "id": "e2",
-      "source": "status-available",
-      "target": "arm-rejected-response"
-    },
+    { "id": "e1", "source": "start-1", "target": "arm-rejected-response" },
     {
       "id": "e3",
       "source": "arm-rejected-response",

--- a/src/utils/scenarios/cert16-tc052-cancel-reservation-rejected.json
+++ b/src/utils/scenarios/cert16-tc052-cancel-reservation-rejected.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "trigger-cancel-reservation",
       "type": "csmsCallTrigger",
       "position": { "x": 400, "y": 250 },
@@ -38,12 +32,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    {
-      "id": "e2",
-      "source": "status-available",
-      "target": "trigger-cancel-reservation"
-    },
+    { "id": "e1", "source": "start-1", "target": "trigger-cancel-reservation" },
     { "id": "e3", "source": "trigger-cancel-reservation", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc054-trigger-message.json
+++ b/src/utils/scenarios/cert16-tc054-trigger-message.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "trigger-message",
       "type": "csmsCallTrigger",
       "position": { "x": 400, "y": 250 },
@@ -44,8 +38,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    { "id": "e2", "source": "status-available", "target": "trigger-message" },
+    { "id": "e1", "source": "start-1", "target": "trigger-message" },
     { "id": "e3", "source": "trigger-message", "target": "delay-cp-sends" },
     { "id": "e4", "source": "delay-cp-sends", "target": "end-1" }
   ]

--- a/src/utils/scenarios/cert16-tc055-trigger-message-rejected.json
+++ b/src/utils/scenarios/cert16-tc055-trigger-message-rejected.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "arm-rejected-response",
       "type": "responseOverride",
       "position": { "x": 400, "y": 250 },
@@ -48,12 +42,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    {
-      "id": "e2",
-      "source": "status-available",
-      "target": "arm-rejected-response"
-    },
+    { "id": "e1", "source": "start-1", "target": "arm-rejected-response" },
     {
       "id": "e3",
       "source": "arm-rejected-response",

--- a/src/utils/scenarios/cert16-tc061-clear-cache.json
+++ b/src/utils/scenarios/cert16-tc061-clear-cache.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "trigger-clear-cache",
       "type": "csmsCallTrigger",
       "position": { "x": 400, "y": 250 },
@@ -38,12 +32,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    {
-      "id": "e2",
-      "source": "status-available",
-      "target": "trigger-clear-cache"
-    },
+    { "id": "e1", "source": "start-1", "target": "trigger-clear-cache" },
     { "id": "e3", "source": "trigger-clear-cache", "target": "end-1" }
   ]
 }

--- a/src/utils/scenarios/cert16-tc064-data-transfer.json
+++ b/src/utils/scenarios/cert16-tc064-data-transfer.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "send-data-transfer",
       "type": "dataTransfer",
       "position": { "x": 400, "y": 250 },
@@ -45,12 +39,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    {
-      "id": "e2",
-      "source": "status-available",
-      "target": "send-data-transfer"
-    },
+    { "id": "e1", "source": "start-1", "target": "send-data-transfer" },
     { "id": "e3", "source": "send-data-transfer", "target": "delay-1" },
     { "id": "e4", "source": "delay-1", "target": "end-1" }
   ]

--- a/src/utils/scenarios/cert16-tc066-get-composite-schedule.json
+++ b/src/utils/scenarios/cert16-tc066-get-composite-schedule.json
@@ -14,12 +14,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "csms-set-charging-profile",
       "type": "csmsCallTrigger",
       "position": { "x": 400, "y": 250 },
@@ -47,12 +41,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    {
-      "id": "e2",
-      "source": "status-available",
-      "target": "csms-set-charging-profile"
-    },
+    { "id": "e1", "source": "start-1", "target": "csms-set-charging-profile" },
     {
       "id": "e3",
       "source": "csms-set-charging-profile",

--- a/src/utils/scenarios/cert16-tc067-clear-charging-profile.json
+++ b/src/utils/scenarios/cert16-tc067-clear-charging-profile.json
@@ -14,12 +14,6 @@
       "data": { "label": "Start", "triggerOn": "connect" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "csms-set-charging-profile",
       "type": "csmsCallTrigger",
       "position": { "x": 400, "y": 250 },
@@ -53,12 +47,7 @@
     }
   ],
   "edges": [
-    { "id": "e1", "source": "start-1", "target": "status-available" },
-    {
-      "id": "e2",
-      "source": "status-available",
-      "target": "csms-set-charging-profile"
-    },
+    { "id": "e1", "source": "start-1", "target": "csms-set-charging-profile" },
     {
       "id": "e3",
       "source": "csms-set-charging-profile",

--- a/src/utils/scenarios/full-charging-cycle.json
+++ b/src/utils/scenarios/full-charging-cycle.json
@@ -15,12 +15,6 @@
       "data": { "label": "Start" }
     },
     {
-      "id": "status-available",
-      "type": "statusChange",
-      "position": { "x": 400, "y": 150 },
-      "data": { "label": "Set Available", "status": "Available" }
-    },
-    {
       "id": "transaction-start",
       "type": "transaction",
       "position": { "x": 400, "y": 350 },
@@ -70,11 +64,6 @@
     {
       "id": "e-start-available",
       "source": "start-1",
-      "target": "status-available"
-    },
-    {
-      "id": "e-available-txstart",
-      "source": "status-available",
       "target": "transaction-start"
     },
     {


### PR DESCRIPTION
Closes #185.

## Problem

`onBootNotificationAccepted()` already drives every idle connector to `Available` and sends `StatusNotification(Available)` at boot, **before** any scenario node runs (a `triggerOn: "connect"` start node only fires once boot is Accepted). Yet 17 built-in scenarios carried a leading `statusChange`/`statusNotification(Available)` node right after `start`, so `Available` went on the wire **twice** at boot — the same duplicate class as #176, via a different mechanism.

## Fix

Splice out the redundant leading node in all 17 scenarios. Surgical, format-preserving edit: only the node and its two edges change; the `start` edge is rewired straight to the next node (verified with a brace-matched transform + connectivity check, not a full reparse, so the diff is minimal — 16 insertions / 190 deletions).

## Verification safety

- No spec asserts order/count on the leading `Available`. The only spec referencing it, `tc001ColdBootSpec`'s `sentAvailableOnConnector1` check, now verifies the **domain's** boot-driven `StatusNotification(Available)` directly instead of a scripted re-send — and stays green (boot still emits it).
- The three "final Available" spec assertions (tc003 / tc004 / tc024) target the post-transaction `Available`, none of which is among these 17.
- `tc001-cold-boot` becomes a pure connect-and-observe-boot scenario; its description and the `core.ts` spec description are updated to match.

## Affected scenarios (17)

tc001-cold-boot, tc019-get-configuration-all/key, tc021-change-configuration, tc026-remote-start-rejected, tc031-unlock-unknown-connector, tc044-1-firmware-update, tc045-1-get-diagnostics, tc048-4-reserve-now-rejected, tc052-cancel-reservation-rejected, tc054-trigger-message, tc055-trigger-message-rejected, tc061-clear-cache, tc064-data-transfer, tc066-get-composite-schedule, tc067-clear-charging-profile, full-charging-cycle.

## Gates

- `tsc -b --noEmit --force`: 478 (baseline)
- vitest: 1105/1105 (2 unrelated data-hook timeout flakes pass in isolation)
- `test:bun`: 207/207
- prettier / eslint: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated certification and charging scenarios to begin directly with the intended action instead of an unnecessary “Available” status step.
  * Corrected cold-boot scenario descriptions to reflect the device’s actual boot behavior.
  * Simplified workflow paths across configuration, remote commands, firmware, diagnostics, reservations, messaging, charging, and data-transfer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->