### PR TITLE
fix(security): consolidate duplicate Basic Auth settings into the Security section (#178 item F)

### DIFF
--- a/src/components/ChargePointConfigModal.dom.test.tsx
+++ b/src/components/ChargePointConfigModal.dom.test.tsx
@@ -271,6 +271,43 @@ describe("ChargePointConfigModal — OCPP-1.5 + Security Profile UI", () => {
     expect(saved.basicAuthUsername).toBe("legacy-user");
   });
 
+  // #178 item F regression guard: with the legacy toggle hidden in the
+  // Security section, a remote + non-SOAP CP that already had legacy Basic
+  // Auth on must still have SOME way to turn it off — the informational block
+  // exposes a "Disable" button that clears basicAuthEnabled.
+  it("lets a persisted legacy Basic Auth value be disabled from the Security section", async () => {
+    const onSave = vi.fn();
+    const rendered = await renderModal({
+      mode: "remote",
+      isNewChargePoint: false,
+      onSave,
+      initialConfig: baseConfig({
+        ocppVersion: "OCPP-1.6J",
+        securityProfile: 0,
+        basicAuthEnabled: true,
+        basicAuthUsername: "legacy-user",
+        basicAuthPassword: "",
+      }),
+    });
+    roots.push(rendered.root);
+
+    const disableButton = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent?.includes("Disable legacy Basic Authentication"),
+    ) as HTMLButtonElement | undefined;
+    expect(disableButton).toBeDefined();
+
+    await act(async () => {
+      disableButton!.click();
+    });
+    await act(async () => {
+      saveButton().click();
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const saved = onSave.mock.calls[0][0] as ChargePointConfig;
+    expect(saved.basicAuthEnabled).toBe(false);
+  });
+
   it("keeps the generic Basic Auth toggle for SOAP versions in remote mode (no Security Profile model)", async () => {
     const rendered = await renderModal({
       mode: "remote",

--- a/src/components/ChargePointConfigModal.dom.test.tsx
+++ b/src/components/ChargePointConfigModal.dom.test.tsx
@@ -202,15 +202,95 @@ describe("ChargePointConfigModal — OCPP-1.5 + Security Profile UI", () => {
     expect(document.getElementById("securityProfile")).toBeNull();
   });
 
-  it("hides the legacy Basic Auth toggle once a security profile is selected", async () => {
+  // #178 item F: the Security section is the single source of truth for
+  // Basic Auth in remote + non-SOAP mode, at every security profile
+  // (including the default profile 0) — the legacy Optional Settings
+  // toggle must never render alongside it.
+  it("never shows the legacy Basic Auth toggle in remote + non-SOAP mode, at any security profile", async () => {
     const rendered = await renderModal({ mode: "remote" });
     roots.push(rendered.root);
 
-    expect(document.getElementById("basicAuthEnabled")).not.toBeNull();
+    // Default profile (0): no toggle, informational pointer text instead.
+    expect(document.getElementById("basicAuthEnabled")).toBeNull();
+    expect(document.body.textContent).toContain("No authentication configured");
 
     await selectOption("securityProfile", "1 — Basic Auth");
+    expect(document.getElementById("basicAuthEnabled")).toBeNull();
+
+    await selectOption("securityProfile", "2 — Basic Auth + TLS (server cert)");
+    expect(document.getElementById("basicAuthEnabled")).toBeNull();
+
+    await selectOption("securityProfile", "3 — Mutual TLS (client cert)");
+    expect(document.getElementById("basicAuthEnabled")).toBeNull();
+  });
+
+  it("surfaces a persisted legacy Basic Auth value instead of dropping it, when Security Profile is 0", async () => {
+    const rendered = await renderModal({
+      mode: "remote",
+      isNewChargePoint: false,
+      initialConfig: baseConfig({
+        ocppVersion: "OCPP-1.6J",
+        securityProfile: 0,
+        basicAuthEnabled: true,
+        basicAuthUsername: "legacy-user",
+        basicAuthPassword: "",
+      }),
+    });
+    roots.push(rendered.root);
 
     expect(document.getElementById("basicAuthEnabled")).toBeNull();
+    expect(document.body.textContent).toContain(
+      "currently active via the legacy Optional Settings toggle",
+    );
+    expect(document.body.textContent).toContain("legacy-user");
+  });
+
+  it("round-trips a persisted legacy Basic Auth value on save without a visible edit control (no silent credential drop)", async () => {
+    const onSave = vi.fn();
+    const rendered = await renderModal({
+      mode: "remote",
+      isNewChargePoint: false,
+      onSave,
+      initialConfig: baseConfig({
+        ocppVersion: "OCPP-1.6J",
+        securityProfile: 0,
+        basicAuthEnabled: true,
+        basicAuthUsername: "legacy-user",
+        basicAuthPassword: "",
+      }),
+    });
+    roots.push(rendered.root);
+
+    await act(async () => {
+      saveButton().click();
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const saved = onSave.mock.calls[0][0] as ChargePointConfig;
+    expect(saved.basicAuthEnabled).toBe(true);
+    expect(saved.basicAuthUsername).toBe("legacy-user");
+  });
+
+  it("keeps the generic Basic Auth toggle for SOAP versions in remote mode (no Security Profile model)", async () => {
+    const rendered = await renderModal({
+      mode: "remote",
+      initialConfig: baseConfig({ ocppVersion: "OCPP-1.5" }),
+    });
+    roots.push(rendered.root);
+
+    expect(document.getElementById("securityProfile")).toBeNull();
+    expect(document.getElementById("basicAuthEnabled")).not.toBeNull();
+  });
+
+  it("keeps the generic Basic Auth toggle for local mode regardless of OCPP version", async () => {
+    const rendered = await renderModal({
+      mode: "local",
+      initialConfig: baseConfig({ ocppVersion: "OCPP-1.6J" }),
+    });
+    roots.push(rendered.root);
+
+    expect(document.getElementById("securityProfile")).toBeNull();
+    expect(document.getElementById("basicAuthEnabled")).not.toBeNull();
   });
 
   it("shows AuthorizationKey + CA field for profile 2 (not cert/key)", async () => {

--- a/src/components/ChargePointConfigModal.tsx
+++ b/src/components/ChargePointConfigModal.tsx
@@ -752,16 +752,31 @@ const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
               </p>
             ) : securityProfile === 0 ? (
               basicAuthSource === "legacy" ? (
-                <p className="text-xs text-muted mb-4">
-                  Basic Authentication is currently active via the legacy
-                  Optional Settings toggle (username:{" "}
-                  <code>{config.basicAuthUsername || "(none)"}</code>). It will
-                  keep working unchanged. To manage authentication from the
-                  Security section instead, set Security Profile to 1 (Basic
-                  Auth) above and provide an Authorization Key — note the wire
-                  username becomes the Charge Point ID once you do, which may
-                  differ from the legacy username above.
-                </p>
+                <div className="mb-4">
+                  <p className="text-xs text-muted mb-2">
+                    Basic Authentication is currently active via the legacy
+                    Optional Settings toggle (username:{" "}
+                    <code>{config.basicAuthUsername || "(none)"}</code>). It
+                    will keep working unchanged. To manage authentication from
+                    the Security section instead, set Security Profile to 1
+                    (Basic Auth) above and provide an Authorization Key — note
+                    the wire username becomes the Charge Point ID once you do,
+                    which may differ from the legacy username above.
+                  </p>
+                  {/* #178 item F: legacy Basic Auth has no editable control in
+                      the Security section, so without this a remote+non-SOAP CP
+                      that already had it enabled could never turn it off from
+                      the UI. Mirrors the Optional Settings checkbox's off path
+                      (basicAuthEnabled → false). */}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => updateConfig("basicAuthEnabled", false)}
+                  >
+                    Disable legacy Basic Authentication
+                  </Button>
+                </div>
               ) : (
                 <p className="text-xs text-muted mb-4">
                   No authentication configured. Set Security Profile to 1 above

--- a/src/components/ChargePointConfigModal.tsx
+++ b/src/components/ChargePointConfigModal.tsx
@@ -4,9 +4,10 @@ import { buildFullOcppUrl, parseFullOcppUrl } from "../utils/ocppUrl";
 import { BROWSER_TLS_UNSUPPORTED_MESSAGE } from "../data/interfaces/UnsupportedFeatureError";
 import { isSoapVersion } from "../cp/domain/types/OcppVersion";
 import { adaptCentralSystemUrlScheme } from "../utils/ocppUrlScheme";
-import type {
-  OcppSecurityProfile,
-  OcppTlsOptions,
+import {
+  classifyBasicAuthSource,
+  type OcppSecurityProfile,
+  type OcppTlsOptions,
 } from "../cp/infrastructure/transport/wsUrlWithBasic";
 import {
   Dialog,
@@ -231,6 +232,13 @@ const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
   const [saveError, setSaveError] = useState<string | null>(null);
   const displayFullUrl = fullUrlDraft ?? composedFullUrl;
   const securityProfile = config.securityProfile ?? 0;
+  // #178 item F: what actually governs Basic Auth right now, per the same
+  // classifier the connection layer uses (wsUrlWithBasic.ts). Drives the
+  // Optional Settings pointer text below the Security section.
+  const basicAuthSource = classifyBasicAuthSource({
+    securityProfile: config.securityProfile,
+    legacyBasicAuthEnabled: config.basicAuthEnabled,
+  });
 
   // The SOAP callback / TLS material save-blocking errors above are only
   // valid for the config that was on screen when Save was clicked. Once the
@@ -674,8 +682,17 @@ const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
           <div className="card p-4">
             <h3 className="card-header mb-4">Optional Settings</h3>
 
-            {/* Basic Auth */}
-            {mode === "local" || securityProfile === 0 ? (
+            {/* Basic Auth — #178 item F: the Security section above (1.6+,
+                remote mode) is the single source of truth for Basic Auth.
+                This generic toggle is the fallback path retained for
+                configurations that have no Security Profile concept: local
+                mode (no per-CP TLS/profile plumbing) and SOAP versions
+                (OCPP 1.2 / 1.5 / 1.6S — the WS-based security-profile model
+                doesn't apply to the SOAP transport). See
+                classifyBasicAuthSource in wsUrlWithBasic.ts for the
+                single-resolver precedence both this UI and the connection
+                layer share. */}
+            {mode === "local" || isSoapVersion(config.ocppVersion) ? (
               <div className="mb-4">
                 <div className="flex items-center gap-2 mb-3">
                   <Checkbox
@@ -733,6 +750,24 @@ const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
                 Authentication is governed by the mutual TLS client certificate
                 and key in the Security section above (security profile 3).
               </p>
+            ) : securityProfile === 0 ? (
+              basicAuthSource === "legacy" ? (
+                <p className="text-xs text-muted mb-4">
+                  Basic Authentication is currently active via the legacy
+                  Optional Settings toggle (username:{" "}
+                  <code>{config.basicAuthUsername || "(none)"}</code>). It will
+                  keep working unchanged. To manage authentication from the
+                  Security section instead, set Security Profile to 1 (Basic
+                  Auth) above and provide an Authorization Key — note the wire
+                  username becomes the Charge Point ID once you do, which may
+                  differ from the legacy username above.
+                </p>
+              ) : (
+                <p className="text-xs text-muted mb-4">
+                  No authentication configured. Set Security Profile to 1 above
+                  to enable Basic Authentication.
+                </p>
+              )
             ) : (
               <p className="text-xs text-muted mb-4">
                 Authentication is governed by the Authorization Key in the

--- a/src/cp/infrastructure/transport/wsUrlWithBasic.test.ts
+++ b/src/cp/infrastructure/transport/wsUrlWithBasic.test.ts
@@ -4,6 +4,7 @@ import {
   buildOcppBasicAuthorization,
   buildOcppWebSocketConnectOptions,
   buildOcppWebSocketUrl,
+  classifyBasicAuthSource,
   OcppSecurityProfileConfigError,
 } from "./wsUrlWithBasic";
 
@@ -151,5 +152,123 @@ describe("OCPP WebSocket Basic auth", () => {
         runtime.document = previousDocument;
       }
     }
+  });
+});
+
+// #178 item F: consolidating the duplicate Basic Auth settings (legacy
+// Optional-Settings toggle vs. 1.6+ Security Profile) into a single
+// resolver. classifyBasicAuthSource is the shape-only classification the
+// UI uses to decide what to tell the operator; resolveBasicAuth (exercised
+// indirectly via buildOcppWebSocketConnectOptions below) is the same
+// precedence applied to actually build connection credentials.
+describe("classifyBasicAuthSource (#178 item F)", () => {
+  it("prefers the Security Profile once explicitly configured (1 or 2)", () => {
+    expect(
+      classifyBasicAuthSource({
+        securityProfile: 1,
+        legacyBasicAuthEnabled: true,
+      }),
+    ).toBe("security-profile");
+    expect(
+      classifyBasicAuthSource({
+        securityProfile: 2,
+        legacyBasicAuthEnabled: true,
+      }),
+    ).toBe("security-profile");
+  });
+
+  it("reports no Basic Auth under mutual TLS (profile 3), even if the legacy toggle is still set", () => {
+    expect(
+      classifyBasicAuthSource({
+        securityProfile: 3,
+        legacyBasicAuthEnabled: true,
+      }),
+    ).toBe("none");
+  });
+
+  it("falls back to the legacy toggle when no Security Profile has ever been set (backward compat)", () => {
+    expect(
+      classifyBasicAuthSource({
+        securityProfile: undefined,
+        legacyBasicAuthEnabled: true,
+      }),
+    ).toBe("legacy");
+  });
+
+  it("falls back to the legacy toggle at the explicit default profile 0", () => {
+    expect(
+      classifyBasicAuthSource({
+        securityProfile: 0,
+        legacyBasicAuthEnabled: true,
+      }),
+    ).toBe("legacy");
+  });
+
+  it("reports none when neither mechanism is configured", () => {
+    expect(
+      classifyBasicAuthSource({
+        securityProfile: undefined,
+        legacyBasicAuthEnabled: false,
+      }),
+    ).toBe("none");
+    expect(
+      classifyBasicAuthSource({
+        securityProfile: 0,
+        legacyBasicAuthEnabled: false,
+      }),
+    ).toBe("none");
+  });
+});
+
+describe("#178 item F — backward-compat migration at connect time", () => {
+  it("a charge point saved before Security Profiles existed (securityProfile undefined) still authenticates with its legacy credentials", () => {
+    const opts = buildOcppWebSocketConnectOptions({
+      baseUrl: "wss://csms.example.com/ocpp/",
+      chargePointId: "CP001",
+      basicAuth: { username: "legacy-user", password: "legacy-pass" },
+      securityProfile: undefined,
+      authorizationKey: undefined,
+    });
+
+    expect(opts.headers.Authorization).toBe(
+      buildOcppBasicAuthorization({
+        username: "legacy-user",
+        password: "legacy-pass",
+      }),
+    );
+  });
+
+  it("a charge point explicitly saved at the default profile 0 with legacy Basic Auth still authenticates unchanged", () => {
+    const opts = buildOcppWebSocketConnectOptions({
+      baseUrl: "wss://csms.example.com/ocpp/",
+      chargePointId: "CP001",
+      basicAuth: { username: "legacy-user", password: "legacy-pass" },
+      securityProfile: 0,
+    });
+
+    expect(opts.headers.Authorization).toBe(
+      buildOcppBasicAuthorization({
+        username: "legacy-user",
+        password: "legacy-pass",
+      }),
+    );
+  });
+
+  it("does NOT silently drop legacy credentials by auto-promoting to profile 1 (would force username to the CP id)", () => {
+    const opts = buildOcppWebSocketConnectOptions({
+      baseUrl: "wss://csms.example.com/ocpp/",
+      chargePointId: "CP001",
+      basicAuth: { username: "legacy-user", password: "legacy-pass" },
+      securityProfile: 0,
+    });
+
+    // The legacy username is preserved verbatim — a security-profile-1
+    // resolution would have forced it to "CP001" instead.
+    expect(opts.headers.Authorization).not.toBe(
+      buildOcppBasicAuthorization({
+        username: "CP001",
+        password: "legacy-pass",
+      }),
+    );
   });
 });

--- a/src/cp/infrastructure/transport/wsUrlWithBasic.ts
+++ b/src/cp/infrastructure/transport/wsUrlWithBasic.ts
@@ -149,14 +149,59 @@ function isNodeRuntime(): boolean {
   );
 }
 
+/** Which mechanism currently governs Basic Auth for a charge point. */
+export type BasicAuthSource = "security-profile" | "legacy" | "none";
+
+/**
+ * #178 item F — single source of truth for Basic Auth.
+ *
+ * Before this change, a charge point could carry Basic Auth credentials in
+ * two independent places: the legacy Optional-Settings toggle
+ * (`basicAuthEnabled`/`Username`/`Password`) and the 1.6+ Security Profile
+ * (`securityProfile` + `authorizationKey`). Both were read here, with
+ * Security Profile 1/2 always winning and profile 0/undefined falling back
+ * to the legacy fields.
+ *
+ * This classifier makes that precedence explicit and reusable outside the
+ * connect path (the ChargePointConfigModal UI uses it to decide what to
+ * tell the operator), without ever needing the plaintext password — it's a
+ * shape classification, not a value transformation.
+ *
+ * `securityProfile` 0/undefined intentionally still defers to the legacy
+ * flag rather than being auto-promoted to profile 1: OCPP's security-profile
+ * model forces the wire username to the charge point id, which a legacy
+ * config's custom username may not match, so an automatic promotion would
+ * silently change on-wire identity (and could brick a saved config whose
+ * daemon-side `authorizationKey` was never set). This fallback is what
+ * keeps a config saved before #178 authenticating unchanged — it is the
+ * "migration": legacy configs keep working via the same single resolver
+ * every other config goes through, forever, without needing their stored
+ * shape rewritten. Operators can opt into an explicit profile-1 conversion
+ * themselves via the Security Profile selector.
+ */
+export function classifyBasicAuthSource(params: {
+  readonly securityProfile?: OcppSecurityProfile;
+  readonly legacyBasicAuthEnabled: boolean;
+}): BasicAuthSource {
+  if (params.securityProfile === 1 || params.securityProfile === 2) {
+    return "security-profile";
+  }
+  if (params.securityProfile === 3) return "none";
+  return params.legacyBasicAuthEnabled ? "legacy" : "none";
+}
+
 function resolveBasicAuth(params: {
   chargePointId: string;
   basicAuth: BasicAuthSettings | null;
   securityProfile?: OcppSecurityProfile;
   authorizationKey?: string;
 }): BasicAuthSettings | null {
-  if (params.securityProfile === 3) return null;
-  if (params.securityProfile === 1 || params.securityProfile === 2) {
+  const source = classifyBasicAuthSource({
+    securityProfile: params.securityProfile,
+    legacyBasicAuthEnabled: params.basicAuth !== null,
+  });
+  if (source === "none") return null;
+  if (source === "security-profile") {
     if (!params.authorizationKey) {
       throw new OcppSecurityProfileConfigError(
         `OCPP security profile ${params.securityProfile} requires ` +
@@ -168,7 +213,7 @@ function resolveBasicAuth(params: {
       password: params.authorizationKey,
     };
   }
-  return params.basicAuth;
+  return params.basicAuth; // "legacy"
 }
 
 function stripAuthorizationHeader(


### PR DESCRIPTION
Addresses item F of #178 (duplicate Basic Auth settings).

## Problem

Basic Auth could be configured in **two** places for a remote + non-SOAP charge point at the default security profile (0): the legacy Optional Settings "Enable Basic Authentication" toggle **and** the Security Profile's Basic Auth (profile 1/2). Both could render at once, leaving it ambiguous which one was authoritative.

## Approach

Make the two controls **mutually exclusive** by transport, and name the resolver both the UI and the connection layer share:

- **Security section** is the single source of truth for Basic Auth in **remote + non-SOAP** (OCPP 1.6J / 2.0.1 / 2.1). The legacy toggle never renders there.
- **Legacy Optional Settings toggle** is retained only where the Security Profile model doesn't apply: **local mode** (no per-CP TLS/profile plumbing) and **SOAP versions** (1.2 / 1.5 / 1.6S — the WS security-profile model is not defined for SOAP transport).
- `classifyBasicAuthSource` (in `wsUrlWithBasic.ts`) is the one precedence resolver both the UI ("which control to show") and the connection layer ("which credential to use") call, so they can't diverge.

## Why legacy Basic Auth is *classified*, not auto-migrated

A persisted CP that already had the legacy toggle enabled keeps authenticating **exactly as before** — the connection layer's existing profile-0/undefined fallback to the legacy credentials is now named and tested explicitly, and the UI surfaces that state instead of silently dropping it.

Auto-promoting legacy Basic Auth to security profile 1 is **not** safe: OCPP 1.6 security profile 1 fixes the wire username to the Charge Point ID, whereas legacy Basic Auth carries an arbitrary username. Promoting would change the credential on the wire and can break saves for CPs that never had an `authorizationKey`. So the two remain distinct auth semantics — legacy (arbitrary username) and profile 1 (username = CP id) — and the profile-0 informational block explains the difference and how to move to profile 1 deliberately.

## Regression fix included

Hiding the legacy toggle initially left a remote + non-SOAP CP that already had legacy Basic Auth enabled with **no** way to turn it off from the UI. The profile-0 informational block now includes a **"Disable legacy Basic Authentication"** button that clears `basicAuthEnabled` (mirroring the old toggle's off path), guarded by a dom test.

## Tests

- `classifyBasicAuthSource` unit tests: legacy config still authenticates; the wire username is **not** swapped to the CP id.
- Dom tests: legacy toggle never renders in remote + non-SOAP at any profile; persisted legacy value is surfaced (not dropped); round-trips on save; **can be disabled** via the new button; generic toggle retained for SOAP + local.

## Gates
- `tsc -b --noEmit --force`: 478 (baseline)
- vitest (components + transport scope): 108/108
- prettier / eslint: clean

## Note for review

This is a deliberately conservative reading of "consolidate into one UI": it removes the ambiguity (never two controls at once) and keeps legacy configs working, but it does **not** merge legacy and profile-1 Basic Auth into a single control, because they are different auth semantics (arbitrary username vs CP-id username). Happy to expand toward a full unify + explicit "convert legacy → profile 1" migration action if that's preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer Basic Authentication guidance when legacy settings are detected.
  * Added an option to disable legacy Basic Authentication from the Security section.
  * Improved Basic Authentication handling across security profiles, SOAP connections, and local connections.

* **Bug Fixes**
  * Preserved existing legacy Basic Authentication settings when no security profile is configured.
  * Prevented unintended credential changes during connection setup.
  * Ensured security profiles correctly take precedence over legacy authentication settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->