### PR TITLE
fix(security): adapt WebSocket URL scheme to the selected security profile (#178 item G)

### DIFF
--- a/src/components/ChargePointConfigModal.dom.test.tsx
+++ b/src/components/ChargePointConfigModal.dom.test.tsx
@@ -353,6 +353,39 @@ describe("ChargePointConfigModal — OCPP-1.5 + Security Profile UI", () => {
     expect(document.getElementById("authorizationKey")).toBeNull();
   });
 
+  // #178 item G: security profiles force the transport security on the wire
+  // (profile 1 → ws, 2/3 → wss), so changing the profile keeps the displayed
+  // WebSocket URL scheme honest instead of silently diverging.
+  it("adapts the WebSocket URL scheme when the security profile changes", async () => {
+    const rendered = await renderModal({
+      mode: "remote",
+      initialConfig: baseConfig({
+        ocppVersion: "OCPP-1.6J",
+        securityProfile: 0,
+        wsURL: "ws://localhost:8080/steve/websocket/CentralSystemService/",
+      }),
+    });
+    roots.push(rendered.root);
+
+    // Profile 2 (TLS) upgrades ws → wss.
+    await selectOption("securityProfile", "2 — Basic Auth + TLS (server cert)");
+    expect(inputById("wsURL").value).toBe(
+      "wss://localhost:8080/steve/websocket/CentralSystemService/",
+    );
+
+    // Profile 1 (unsecured) downgrades wss → ws.
+    await selectOption("securityProfile", "1 — Basic Auth");
+    expect(inputById("wsURL").value).toBe(
+      "ws://localhost:8080/steve/websocket/CentralSystemService/",
+    );
+
+    // Profile 0 enforces nothing — the operator's scheme is left as-is.
+    await selectOption("securityProfile", "0 — No auth, no TLS");
+    expect(inputById("wsURL").value).toBe(
+      "ws://localhost:8080/steve/websocket/CentralSystemService/",
+    );
+  });
+
   it("blocks save when OCPP-1.5 is selected without a SOAP callback URL", async () => {
     const onSave = vi.fn();
     const rendered = await renderModal({

--- a/src/components/ChargePointConfigModal.tsx
+++ b/src/components/ChargePointConfigModal.tsx
@@ -3,7 +3,10 @@ import { Save, X } from "lucide-react";
 import { buildFullOcppUrl, parseFullOcppUrl } from "../utils/ocppUrl";
 import { BROWSER_TLS_UNSUPPORTED_MESSAGE } from "../data/interfaces/UnsupportedFeatureError";
 import { isSoapVersion } from "../cp/domain/types/OcppVersion";
-import { adaptCentralSystemUrlScheme } from "../utils/ocppUrlScheme";
+import {
+  adaptCentralSystemUrlScheme,
+  adaptOcppUrlSecurity,
+} from "../utils/ocppUrlScheme";
 import {
   classifyBasicAuthSource,
   type OcppSecurityProfile,
@@ -204,6 +207,24 @@ const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
       ocppVersion: value,
       wsURL: adaptCentralSystemUrlScheme(prev.wsURL, isSoapVersion(value)),
     }));
+  };
+
+  // #178 item G: OCPP 1.6 security profiles force the transport security at
+  // connect time (profile 1 → ws, profiles 2/3 → wss), so mirror that into the
+  // displayed URL scheme when the profile changes rather than letting the form
+  // silently diverge from the wire. Profile 0 enforces nothing, so the
+  // operator's typed scheme is left untouched.
+  const changeSecurityProfile = (value: string) => {
+    const profile = Number(value) as OcppSecurityProfile;
+    setConfig((prev) =>
+      profile === 0
+        ? { ...prev, securityProfile: profile }
+        : {
+            ...prev,
+            securityProfile: profile,
+            wsURL: adaptOcppUrlSecurity(prev.wsURL, profile >= 2),
+          },
+    );
   };
 
   const updateTls = (patch: Partial<OcppTlsOptions>) => {
@@ -542,12 +563,7 @@ const ChargePointConfigModal: React.FC<ChargePointConfigModalProps> = ({
                   </Label>
                   <Select
                     value={String(securityProfile)}
-                    onValueChange={(value) =>
-                      updateConfig(
-                        "securityProfile",
-                        Number(value) as OcppSecurityProfile,
-                      )
-                    }
+                    onValueChange={changeSecurityProfile}
                   >
                     <SelectTrigger id="securityProfile">
                       <SelectValue />

--- a/src/utils/__tests__/ocppUrlScheme.test.ts
+++ b/src/utils/__tests__/ocppUrlScheme.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { adaptCentralSystemUrlScheme } from "../ocppUrlScheme";
+import {
+  adaptCentralSystemUrlScheme,
+  adaptOcppUrlSecurity,
+} from "../ocppUrlScheme";
 
 describe("adaptCentralSystemUrlScheme (#164)", () => {
   // A generic, non-SteVe-boilerplate host/path, used to verify the plain
@@ -118,5 +121,63 @@ describe("adaptCentralSystemUrlScheme (#164)", () => {
         adaptCentralSystemUrlScheme("ws://otherhost/some/custom/path", true),
       ).toBe("http://otherhost/some/custom/path");
     });
+  });
+});
+
+describe("adaptOcppUrlSecurity (#178 item G)", () => {
+  const HOST = "example.com:8080/ocpp/CentralSystemService/CP001";
+
+  describe("requiring a secure transport (profiles 2/3)", () => {
+    it("upgrades ws:// -> wss:// and keeps host/port/path", () => {
+      expect(adaptOcppUrlSecurity(`ws://${HOST}`, true)).toBe(`wss://${HOST}`);
+    });
+
+    it("upgrades http:// -> https://", () => {
+      expect(adaptOcppUrlSecurity(`http://${HOST}`, true)).toBe(
+        `https://${HOST}`,
+      );
+    });
+
+    it("leaves an already-secure URL unchanged", () => {
+      expect(adaptOcppUrlSecurity(`wss://${HOST}`, true)).toBe(`wss://${HOST}`);
+      expect(adaptOcppUrlSecurity(`https://${HOST}`, true)).toBe(
+        `https://${HOST}`,
+      );
+    });
+  });
+
+  describe("requiring an unsecured transport (profile 1)", () => {
+    it("downgrades wss:// -> ws:// and keeps host/port/path", () => {
+      expect(adaptOcppUrlSecurity(`wss://${HOST}`, false)).toBe(`ws://${HOST}`);
+    });
+
+    it("downgrades https:// -> http://", () => {
+      expect(adaptOcppUrlSecurity(`https://${HOST}`, false)).toBe(
+        `http://${HOST}`,
+      );
+    });
+
+    it("leaves an already-unsecured URL unchanged", () => {
+      expect(adaptOcppUrlSecurity(`ws://${HOST}`, false)).toBe(`ws://${HOST}`);
+      expect(adaptOcppUrlSecurity(`http://${HOST}`, false)).toBe(
+        `http://${HOST}`,
+      );
+    });
+  });
+
+  it("preserves the transport — never swaps ws<->http, only the secure half", () => {
+    // ws stays ws-family (→ wss), never becomes https; http stays http-family.
+    expect(adaptOcppUrlSecurity(`ws://${HOST}`, true)).toBe(`wss://${HOST}`);
+    expect(adaptOcppUrlSecurity(`http://${HOST}`, true)).toBe(
+      `https://${HOST}`,
+    );
+  });
+
+  it("matches schemes case-insensitively", () => {
+    expect(adaptOcppUrlSecurity(`WS://${HOST}`, true)).toBe(`wss://${HOST}`);
+  });
+
+  it("returns an unrecognized scheme unchanged", () => {
+    expect(adaptOcppUrlSecurity(`soap://${HOST}`, true)).toBe(`soap://${HOST}`);
   });
 });

--- a/src/utils/ocppUrlScheme.ts
+++ b/src/utils/ocppUrlScheme.ts
@@ -51,3 +51,31 @@ export function adaptCentralSystemUrlScheme(
     return swapStevePath(`wss://${url.slice(8)}`, false);
   return url;
 }
+
+/**
+ * Adapt a Central System URL's scheme to match a WebSocket security profile
+ * (#178 item G), preserving the transport.
+ *
+ * OCPP 1.6 security profiles fix the transport security at connect time —
+ * profile 1 uses an unsecured socket (`ws`), profiles 2 and 3 require TLS
+ * (`wss`) — and `buildOcppWebSocketUrl` overwrites `url.protocol` accordingly.
+ * Without this, the scheme the operator typed in the form silently diverges
+ * from what actually goes on the wire once a profile is chosen. Flip only the
+ * secure/insecure half of the scheme (`ws` <-> `wss`, `http` <-> `https`) so
+ * the displayed URL stays honest; host, port and path are untouched, and a URL
+ * whose scheme already matches (or is unrecognized) is returned unchanged.
+ *
+ * `secure` should be true for profiles 2/3 and false for profile 1; profile 0
+ * enforces nothing, so callers should leave the URL alone rather than calling
+ * this.
+ */
+export function adaptOcppUrlSecurity(url: string, secure: boolean): string {
+  if (secure) {
+    if (/^ws:\/\//i.test(url)) return `wss://${url.slice(5)}`;
+    if (/^http:\/\//i.test(url)) return `https://${url.slice(7)}`;
+    return url;
+  }
+  if (/^wss:\/\//i.test(url)) return `ws://${url.slice(6)}`;
+  if (/^https:\/\//i.test(url)) return `http://${url.slice(8)}`;
+  return url;
+}


### PR DESCRIPTION
Addresses item G of #178 (URL scheme should follow the selected security profile).

## Problem

The Security Profile select and the WebSocket URL field were fully decoupled. At connect time, `buildOcppWebSocketUrl` overwrites the URL scheme based on the security profile (profile 1 → `ws:`, profiles 2/3 → `wss:`), but the form never reflected that — so an operator who typed `ws://` and picked profile 2, or typed `wss://` and picked profile 1, saw one scheme in the UI while a different one went on the wire. The mismatch was silently resolved at connect time, which is arguably more confusing than a plain error.

## Fix

Mirror the connect-time forcing into the form. Changing the security profile now adapts the WebSocket URL scheme so the displayed URL stays honest about the wire:

- profile 1 → `ws` (unsecured)
- profiles 2/3 → `wss` (TLS)
- profile 0 enforces nothing, so the operator's scheme is left untouched

A new `adaptOcppUrlSecurity(url, secure)` util does the flip, sitting alongside the existing `adaptCentralSystemUrlScheme` (which handles the *transport* scheme on OCPP-version change). Only the secure half of the scheme flips (`ws` ↔ `wss`, `http` ↔ `https`); host, port and path are preserved, and an already-matching or unrecognized scheme is returned unchanged.

## Tests

- `adaptOcppUrlSecurity` unit tests: upgrade/downgrade both directions, no-op when already matching, transport never swapped (ws never becomes https), case-insensitive, unknown scheme untouched.
- Dom test: selecting profile 2 upgrades the shown URL to `wss://`, profile 1 downgrades to `ws://`, profile 0 leaves it as-is.

## Gates
- `tsc -b --noEmit --force`: 478 (baseline)
- vitest (components + utils): 398/398
- `test:bun`: 207/207
- prettier / eslint: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selecting a secure OCPP security profile now automatically updates the connection URL to use a secure scheme.
  * Selecting an unsecured profile switches supported URLs back to an unsecured scheme while preserving the host, port, and path.

* **Bug Fixes**
  * Existing URL schemes remain unchanged when no security adjustment is required.

* **Tests**
  * Added coverage for secure, unsecured, case-insensitive, and unsupported URL schemes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->