### PR TITLE
feat(scenario): structured expectation on scenario_status + stable runId (#179 phase 1)

### DIFF
--- a/src/cli/__tests__/service.scenarioExpectation.bun.test.ts
+++ b/src/cli/__tests__/service.scenarioExpectation.bun.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "bun:test";
+import { Database as BunSqliteDatabase } from "bun:sqlite";
+import { CLIChargePointService } from "../service";
+import { BunSqliteDatabase as BunDb } from "../../cp/domain/persistence/BunSqliteDatabase";
+import { runMigrations } from "../../cp/domain/persistence/schema";
+import {
+  ScenarioDefinition,
+  ScenarioNodeType,
+} from "../../cp/application/scenario/ScenarioTypes";
+
+/**
+ * #179 Phase 1: a scenario parked on a CSMS-call trigger must report
+ * state:"waiting" with a normalized expectation, and every lifecycle event
+ * (plus the status) must carry a stable runId.
+ */
+function parkingScenario(connectorId: number): ScenarioDefinition {
+  return {
+    id: `expectation-${connectorId}-fixed`,
+    name: "Park on GetConfiguration",
+    targetType: "connector",
+    targetId: connectorId,
+    nodes: [
+      {
+        id: "start-1",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "S" },
+      },
+      {
+        id: "wait-cfg",
+        type: ScenarioNodeType.CSMS_CALL_TRIGGER,
+        position: { x: 0, y: 1 },
+        // timeout 0 = park forever; the CALL never arrives in this test.
+        data: {
+          label: "Wait GetConfiguration",
+          action: "GetConfiguration",
+          timeout: 0,
+        },
+      },
+      {
+        id: "end-1",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 2 },
+        data: { label: "E" },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "start-1", target: "wait-cfg" },
+      { id: "e2", source: "wait-cfg", target: "end-1" },
+    ],
+    createdAt: "2026-07-13T00:00:00Z",
+    updatedAt: "2026-07-13T00:00:00Z",
+  };
+}
+
+function newService(): CLIChargePointService {
+  const raw = new BunSqliteDatabase(":memory:");
+  const db = new BunDb(raw);
+  runMigrations(db);
+  return new CLIChargePointService(
+    {
+      cpId: "test-cp",
+      wsUrl: "ws://127.0.0.1:65534/never",
+      connectors: 1,
+      vendor: "v",
+      model: "m",
+    },
+    db,
+  );
+}
+
+describe("#179 Phase 1: scenario expectation + runId", () => {
+  it("reports waiting + expectation and threads a runId through status and events", async () => {
+    const svc = newService();
+    const id = svc.loadScenario(1, parkingScenario(1));
+
+    let startedRunId: string | undefined;
+    svc.onEvent((ev) => {
+      if (ev.event === "scenario_started") {
+        startedRunId = ev.data.runId;
+      }
+    });
+
+    svc.runScenario(1, id);
+    // Let the executor walk start → park on the csmsCallTrigger.
+    await new Promise((r) => setTimeout(r, 300));
+
+    const status = svc.getScenarioStatus(1, id);
+    expect(status).not.toBeNull();
+    expect(status!.state).toBe("waiting");
+    expect(status!.currentNodeId).toBe("wait-cfg");
+    expect(status!.expectation).toMatchObject({
+      type: "ocpp_call",
+      direction: "CSMS_TO_CP",
+      action: "GetConfiguration",
+      nodeId: "wait-cfg",
+    });
+
+    // runId is stable and shared between the started event and the status.
+    expect(typeof startedRunId).toBe("string");
+    expect(startedRunId).toContain(`${id}#`);
+    expect(status!.runId).toBe(startedRunId);
+
+    // Cleanup: stop the parked scenario.
+    svc.stopScenario(1, id);
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  it("clears the expectation and reports null status after the run is stopped", async () => {
+    const svc = newService();
+    const id = svc.loadScenario(1, parkingScenario(1));
+    svc.runScenario(1, id);
+    await new Promise((r) => setTimeout(r, 300));
+
+    expect(svc.getScenarioStatus(1, id)!.state).toBe("waiting");
+
+    svc.stopScenario(1, id);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Executor removed → status is null (no stale waiting/expectation).
+    expect(svc.getScenarioStatus(1, id)).toBeNull();
+  });
+});

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -104,6 +104,8 @@ export type CLIEvent =
       readonly data: {
         readonly connectorId: number;
         readonly scenarioId: string;
+        // #179: stable per-run identifier, correlates events/logs/reports.
+        readonly runId: string;
       };
     }
   | {
@@ -111,6 +113,7 @@ export type CLIEvent =
       readonly data: {
         readonly connectorId: number;
         readonly scenarioId: string;
+        readonly runId: string;
       };
     }
   | {
@@ -119,6 +122,7 @@ export type CLIEvent =
         readonly connectorId: number;
         readonly scenarioId: string;
         readonly error: string;
+        readonly runId: string;
       };
     }
   | {
@@ -127,6 +131,7 @@ export type CLIEvent =
         readonly connectorId: number;
         readonly scenarioId: string;
         readonly nodeId: string;
+        readonly runId: string;
       };
     }
   | {
@@ -200,6 +205,16 @@ export type CLIEvent =
 
 type EventHandler = (evt: CLIEvent) => void;
 
+/**
+ * #179: mint a stable, human-legible run id for one scenario execution.
+ * `scenarioId#<epochMs>-<rand>` — the scenarioId anchors it to the scenario,
+ * the epoch + short random suffix distinguish repeated runs of the same one.
+ */
+function makeScenarioRunId(scenarioId: string): string {
+  const rand = Math.random().toString(36).slice(2, 6);
+  return `${scenarioId}#${Date.now()}-${rand}`;
+}
+
 export class CLIChargePointService {
   private readonly _chargePoint: ChargePoint;
   private readonly _soapServer: OCPPSoapServer | null;
@@ -211,6 +226,10 @@ export class CLIChargePointService {
     { readonly definition: ScenarioDefinition; readonly connectorId: number }
   > = new Map();
   private readonly _executors: Map<string, ScenarioExecutor> = new Map();
+  // #179: stable per-run id for the currently-executing scenario, so status
+  // and lifecycle events can be correlated to a specific run. Keyed like
+  // _executors (by scenarioId) and cleared alongside it.
+  private readonly _runIdByScenario: Map<string, string> = new Map();
   private readonly _scenarioRepo: SqliteScenarioRepository;
   private readonly _runtimeRepo: ConnectorRuntimeRepository;
   /**
@@ -786,6 +805,7 @@ export class CLIChargePointService {
     if (executor) {
       executor.stop();
       this._executors.delete(scenarioId);
+      this._runIdByScenario.delete(scenarioId);
     }
     this._scenarios.delete(scenarioId);
     this._scenarioRepo.deleteOne(this._chargePoint.id, connectorId, scenarioId);
@@ -833,6 +853,12 @@ export class CLIChargePointService {
       throw new Error(`Connector ${connectorId} not found`);
     }
 
+    // #179: mint a stable run id for this invocation, threaded into every
+    // lifecycle event (and echoed on scenario_status) so a headless runner can
+    // correlate a specific run.
+    const runId = makeScenarioRunId(scenarioId);
+    this._runIdByScenario.set(scenarioId, runId);
+
     const callbacks = createScenarioExecutorCallbacks({
       chargePoint: this._chargePoint,
       connector,
@@ -841,20 +867,20 @@ export class CLIChargePointService {
           if (context.state === "completed") {
             this.emit({
               event: "scenario_completed",
-              data: { connectorId, scenarioId },
+              data: { connectorId, scenarioId, runId },
             });
           }
         },
         onNodeExecute: (nodeId) => {
           this.emit({
             event: "scenario_node_execute",
-            data: { connectorId, scenarioId, nodeId },
+            data: { connectorId, scenarioId, nodeId, runId },
           });
         },
         onError: (error) => {
           this.emit({
             event: "scenario_error",
-            data: { connectorId, scenarioId, error: error.message },
+            data: { connectorId, scenarioId, error: error.message, runId },
           });
         },
       },
@@ -929,11 +955,15 @@ export class CLIChargePointService {
     this._executors.set(scenarioId, executor);
     this._executorConnectorIds.set(scenarioId, connectorId);
 
-    this.emit({ event: "scenario_started", data: { connectorId, scenarioId } });
+    this.emit({
+      event: "scenario_started",
+      data: { connectorId, scenarioId, runId },
+    });
 
     executor.start(resumeOpts).finally(() => {
       this._executors.delete(scenarioId);
       this._executorConnectorIds.delete(scenarioId);
+      this._runIdByScenario.delete(scenarioId);
       // Scenario exited cleanly — clear the persisted position so a
       // subsequent restart treats the connector as idle (the
       // connector_runtime row's transaction_json itself is already
@@ -990,7 +1020,9 @@ export class CLIChargePointService {
     if (!executor) {
       return null;
     }
-    return executor.getContext();
+    // #179: echo the run id so a poller can tie this status to a specific run.
+    const runId = this._runIdByScenario.get(scenarioId);
+    return { ...executor.getContext(), runId };
   }
 
   stopScenario(connectorId: number, scenarioId: string): void {
@@ -998,8 +1030,12 @@ export class CLIChargePointService {
     if (!executor) {
       throw new Error(`Scenario ${scenarioId} is not running`);
     }
+    // #179: capture the run id before stop() — executor.stop() lets the
+    // start() promise settle, whose finally() clears _runIdByScenario.
+    const runId = this._runIdByScenario.get(scenarioId) ?? "";
     executor.stop();
     this._executors.delete(scenarioId);
+    this._runIdByScenario.delete(scenarioId);
     // Release the EV settings override (#105) — only when this scenario
     // declared evSettings and therefore owns it; see runScenario's
     // executor.start().finally() for the natural-completion counterpart.
@@ -1012,7 +1048,7 @@ export class CLIChargePointService {
     // this scenario is running.
     this.emit({
       event: "scenario_completed",
-      data: { connectorId, scenarioId },
+      data: { connectorId, scenarioId, runId },
     });
   }
 
@@ -1021,8 +1057,10 @@ export class CLIChargePointService {
       if (entry.connectorId === connectorId) {
         const executor = this._executors.get(scenarioId);
         if (executor) {
+          const runId = this._runIdByScenario.get(scenarioId) ?? "";
           executor.stop();
           this._executors.delete(scenarioId);
+          this._runIdByScenario.delete(scenarioId);
           // Release the EV settings override (#105) only for the owning
           // (evSettings-declaring) scenario, same as stopScenario.
           if (entry.definition.evSettings) {
@@ -1032,7 +1070,7 @@ export class CLIChargePointService {
           }
           this.emit({
             event: "scenario_completed",
-            data: { connectorId, scenarioId },
+            data: { connectorId, scenarioId, runId },
           });
         }
       }

--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -27,7 +27,9 @@ import {
   DataTransferNodeData,
   StartTransactionOptions,
   StopTransactionOptions,
+  ScenarioExpectation,
 } from "./ScenarioTypes";
+import { deriveExpectation } from "./ScenarioExpectations";
 import {
   createScenarioMachine,
   getScenarioStateName,
@@ -100,6 +102,11 @@ export class ScenarioExecutor {
   private remoteStopReason: string | null = null;
   private remoteStopOptions: StopTransactionOptions | null = null;
   private currentNodeId: string | null = null;
+  // #179: the normalized condition the currently-parked node is waiting on
+  // (null when no node is parked). The robot3 machine stays "running" while a
+  // node awaits an external event (the "waiting" state is never entered), so
+  // getContext() derives the reported "waiting" state from this field.
+  private currentExpectation: ScenarioExpectation | null = null;
   private executedNodes: string[] = [];
   // Issue #110: track which response overrides were armed during this run,
   // so they can be cleared when the run ends (both normal completion and stop()).
@@ -164,6 +171,7 @@ export class ScenarioExecutor {
     // Fresh abort gate for this run.
     this.aborted = false;
     this.currentNodeId = null;
+    this.currentExpectation = null;
     this.executedNodes = [];
     this.stepResolve = null;
     this.pendingSteps = 0;
@@ -354,6 +362,7 @@ export class ScenarioExecutor {
 
     // Clear current node
     this.currentNodeId = null;
+    this.currentExpectation = null;
   }
 
   /**
@@ -490,7 +499,22 @@ export class ScenarioExecutor {
       node.type !== ScenarioNodeType.START &&
       node.type !== ScenarioNodeType.END
     ) {
-      await this.executeNode(node);
+      // #179: while a node that parks on an external event is awaiting, expose
+      // its normalized expectation (and a reported "waiting" state) through
+      // getContext(). deriveExpectation returns null for non-waiting nodes, so
+      // this is a no-op for them. Cleared as soon as the node resolves.
+      this.currentExpectation = deriveExpectation(node, this.scenario.targetId);
+      if (this.currentExpectation) {
+        this.notifyStateChange();
+      }
+      try {
+        await this.executeNode(node);
+      } finally {
+        if (this.currentExpectation) {
+          this.currentExpectation = null;
+          this.notifyStateChange();
+        }
+      }
     }
 
     // Dispatch NODE_COMPLETE event
@@ -1371,6 +1395,7 @@ export class ScenarioExecutor {
     // walker bails before executing the next node.
     this.aborted = true;
     this.currentNodeId = null;
+    this.currentExpectation = null;
     this.abortResolve?.();
     // Stop the connector's auto-meter now; otherwise a pending maxTime/maxValue
     // could later resume the flow and fire a downstream Stop Transaction on a
@@ -1432,14 +1457,26 @@ export class ScenarioExecutor {
     const stateName = getScenarioStateName(this.service);
     const context = getScenarioContext(this.service);
 
+    // #179: the robot3 machine stays "running" while a node parks on an
+    // external event (the "waiting" state is never dispatched), so surface
+    // the already-valid "waiting" state — and the awaited condition — from
+    // currentExpectation. Only override an otherwise-"running" machine so a
+    // paused / stepping / stopped scenario keeps its real state.
+    const parked = this.currentExpectation;
+    const state: ScenarioExecutionState =
+      parked && stateName === "running"
+        ? "waiting"
+        : (stateName as ScenarioExecutionState);
+
     return {
       scenarioId: context.scenarioId,
-      state: stateName as ScenarioExecutionState,
+      state,
       mode: context.mode,
       currentNodeId: this.currentNodeId,
       executedNodes: [...this.executedNodes],
       loopCount: context.loopCount,
       error: context.error,
+      expectation: parked ?? null,
     };
   }
 

--- a/src/cp/application/scenario/ScenarioExpectations.ts
+++ b/src/cp/application/scenario/ScenarioExpectations.ts
@@ -1,0 +1,96 @@
+import {
+  ScenarioNodeType,
+  type CsmsCallTriggerNodeData,
+  type ScenarioExpectation,
+  type ScenarioNode,
+  type StatusTriggerNodeData,
+} from "./ScenarioTypes";
+
+/**
+ * #179 — derive the normalized {@link ScenarioExpectation} for a scenario node
+ * that *parks* the execution waiting on an external condition, or `null` for
+ * any node that does not wait.
+ *
+ * Pure function: it reads only the node and the target connector id, so it can
+ * be called from the executor without touching runtime state. The waiting
+ * nodes it covers are the five trigger types that block on a CSMS action, a
+ * connector status, or a ReserveNow (mirroring the `onWaitFor*` callbacks in
+ * ScenarioExecutor). The auto-increment MeterValue node also parks, but its
+ * target depends on runtime state (meter-start offset / EV settings) and is an
+ * active-work node rather than an external wait, so it is intentionally not
+ * surfaced as an expectation here.
+ *
+ * @param node the node about to execute
+ * @param connectorId the scenario's target connector (ScenarioDefinition.targetId)
+ */
+export function deriveExpectation(
+  node: ScenarioNode,
+  connectorId: number | undefined,
+): ScenarioExpectation | null {
+  const constraints = connectorId === undefined ? undefined : { connectorId };
+
+  const timeoutMs = (
+    nodeTimeoutSeconds: number | undefined,
+  ): number | undefined =>
+    nodeTimeoutSeconds && nodeTimeoutSeconds > 0
+      ? nodeTimeoutSeconds * 1000
+      : undefined;
+
+  switch (node.type) {
+    case ScenarioNodeType.REMOTE_START_TRIGGER:
+      return {
+        type: "ocpp_call",
+        direction: "CSMS_TO_CP",
+        action: "RemoteStartTransaction",
+        constraints,
+        timeoutMs: timeoutMs((node.data as { timeout?: number }).timeout),
+        nodeId: node.id,
+      };
+
+    case ScenarioNodeType.REMOTE_STOP_TRIGGER:
+      return {
+        type: "ocpp_call",
+        direction: "CSMS_TO_CP",
+        action: "RemoteStopTransaction",
+        constraints,
+        timeoutMs: timeoutMs((node.data as { timeout?: number }).timeout),
+        nodeId: node.id,
+      };
+
+    case ScenarioNodeType.CSMS_CALL_TRIGGER: {
+      const data = node.data as CsmsCallTriggerNodeData;
+      return {
+        type: "ocpp_call",
+        direction: "CSMS_TO_CP",
+        action: data.action,
+        constraints,
+        timeoutMs: timeoutMs(data.timeout),
+        nodeId: node.id,
+      };
+    }
+
+    case ScenarioNodeType.STATUS_TRIGGER: {
+      const data = node.data as StatusTriggerNodeData;
+      return {
+        type: "connector_status",
+        targetStatus: data.targetStatus,
+        constraints,
+        timeoutMs: timeoutMs(data.timeout),
+        nodeId: node.id,
+      };
+    }
+
+    case ScenarioNodeType.RESERVATION_TRIGGER:
+      return {
+        type: "reservation",
+        direction: "CSMS_TO_CP",
+        action: "ReserveNow",
+        constraints,
+        timeoutMs: timeoutMs((node.data as { timeout?: number }).timeout),
+        nodeId: node.id,
+      };
+
+    default:
+      return null;
+  }
+}

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -420,6 +420,32 @@ export function isScenarioDefinitionShape(
 }
 
 /**
+ * Normalized description of the external condition a parked scenario node is
+ * waiting for (#179). Surfaced on `ScenarioExecutionContext` while a waiting
+ * node (a CSMS-call / status / reservation trigger) is blocked, so a headless
+ * runner can see *what* the scenario expects next without parsing scenario
+ * JSON internals.
+ */
+export interface ScenarioExpectation {
+  /** What kind of condition the parked node awaits. */
+  type: "ocpp_call" | "connector_status" | "reservation";
+  /** For ocpp_call / reservation: who must send the awaited CALL. */
+  direction?: "CSMS_TO_CP" | "CP_TO_CSMS";
+  /** For ocpp_call / reservation: the OCPP action awaited. */
+  action?: string;
+  /** For connector_status: the status the connector must reach. */
+  targetStatus?: string;
+  /** Partial-match constraints on the awaited event (e.g. connectorId).
+   *  Superset-matched, never exhaustive. */
+  constraints?: Record<string, unknown>;
+  /** Node timeout in ms (node.data.timeout seconds × 1000). Absent / 0 =
+   *  wait forever. */
+  timeoutMs?: number;
+  /** The graph node currently parked. */
+  nodeId: string;
+}
+
+/**
  * Scenario execution context
  */
 export interface ScenarioExecutionContext {
@@ -430,6 +456,12 @@ export interface ScenarioExecutionContext {
   executedNodes: string[];
   loopCount: number;
   error?: string;
+  /** #179: while a waiting node is parked, the normalized condition it
+   *  awaits. Null / absent when no node is parked. */
+  expectation?: ScenarioExpectation | null;
+  /** #179: stable identifier for this execution, set by the service layer so
+   *  a poller can tie status to a specific run. */
+  runId?: string;
 }
 
 /**

--- a/src/cp/application/scenario/__tests__/ScenarioExecutor.control.test.ts
+++ b/src/cp/application/scenario/__tests__/ScenarioExecutor.control.test.ts
@@ -123,7 +123,7 @@ function statusTriggerScenario(id: string): ScenarioDefinition {
 }
 
 describe("ScenarioExecutor control flow", () => {
-  it("pause then resume completes with running-paused-running-completed states", async () => {
+  it("pause then resume completes; parked-on-status-trigger reports waiting (#179)", async () => {
     const waitStarted = deferred();
     const statusGate = deferred();
     const states: string[] = [];
@@ -143,17 +143,28 @@ describe("ScenarioExecutor control flow", () => {
     const execution = executor.start();
     await waitStarted.promise;
 
-    expect(executor.getContext().state).toBe("running");
+    // #179: parked on the status trigger, the machine stays "running" but the
+    // reported state is now "waiting" with the awaited condition surfaced.
+    const parked = executor.getContext();
+    expect(parked.state).toBe("waiting");
+    expect(parked.expectation).toMatchObject({
+      type: "connector_status",
+      targetStatus: "Charging",
+    });
+
     executor.pause();
     expect(executor.getContext().state).toBe("paused");
     executor.resume();
-    expect(executor.getContext().state).toBe("running");
+    // Still parked after resume → back to "waiting", not "running".
+    expect(executor.getContext().state).toBe("waiting");
 
     statusGate.resolve();
     await execution;
 
-    expect(executor.getContext().state).toBe("completed");
-    expect(states).toContain("running");
+    const done = executor.getContext();
+    expect(done.state).toBe("completed");
+    expect(done.expectation).toBeFalsy();
+    expect(states).toContain("waiting");
     expect(states).toContain("paused");
     expect(states.at(-1)).toBe("completed");
   });

--- a/src/cp/application/scenario/__tests__/ScenarioExpectations.test.ts
+++ b/src/cp/application/scenario/__tests__/ScenarioExpectations.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { deriveExpectation } from "../ScenarioExpectations";
+import {
+  ScenarioNodeType,
+  type ScenarioNode,
+  type ScenarioNodeData,
+} from "../ScenarioTypes";
+import { OCPPStatus } from "../../../domain/types/OcppTypes";
+
+function node(type: ScenarioNodeType, data: ScenarioNodeData): ScenarioNode {
+  return { id: `${type}-1`, type, position: { x: 0, y: 0 }, data };
+}
+
+describe("deriveExpectation (#179)", () => {
+  const connectorId = 1;
+
+  it("remoteStartTrigger → ocpp_call RemoteStartTransaction (CSMS→CP)", () => {
+    const exp = deriveExpectation(
+      node(ScenarioNodeType.REMOTE_START_TRIGGER, {
+        label: "Wait for RemoteStart",
+        timeout: 30,
+      } as ScenarioNodeData),
+      connectorId,
+    );
+    expect(exp).toEqual({
+      type: "ocpp_call",
+      direction: "CSMS_TO_CP",
+      action: "RemoteStartTransaction",
+      constraints: { connectorId: 1 },
+      timeoutMs: 30000,
+      nodeId: "remoteStartTrigger-1",
+    });
+  });
+
+  it("remoteStopTrigger → ocpp_call RemoteStopTransaction", () => {
+    const exp = deriveExpectation(
+      node(ScenarioNodeType.REMOTE_STOP_TRIGGER, {
+        label: "Wait for RemoteStop",
+      } as ScenarioNodeData),
+      connectorId,
+    );
+    expect(exp?.action).toBe("RemoteStopTransaction");
+    expect(exp?.type).toBe("ocpp_call");
+    // timeout absent/0 → no timeoutMs (wait forever)
+    expect(exp?.timeoutMs).toBeUndefined();
+  });
+
+  it("csmsCallTrigger → ocpp_call with the node's action", () => {
+    const exp = deriveExpectation(
+      node(ScenarioNodeType.CSMS_CALL_TRIGGER, {
+        label: "Wait for GetConfiguration",
+        action: "GetConfiguration",
+        timeout: 15,
+      } as ScenarioNodeData),
+      connectorId,
+    );
+    expect(exp).toMatchObject({
+      type: "ocpp_call",
+      direction: "CSMS_TO_CP",
+      action: "GetConfiguration",
+      timeoutMs: 15000,
+    });
+  });
+
+  it("statusTrigger → connector_status with targetStatus", () => {
+    const exp = deriveExpectation(
+      node(ScenarioNodeType.STATUS_TRIGGER, {
+        label: "Wait for Available",
+        targetStatus: OCPPStatus.Available,
+        timeout: 30,
+      } as ScenarioNodeData),
+      connectorId,
+    );
+    expect(exp).toMatchObject({
+      type: "connector_status",
+      targetStatus: "Available",
+      constraints: { connectorId: 1 },
+      timeoutMs: 30000,
+    });
+    expect(exp?.action).toBeUndefined();
+  });
+
+  it("reservationTrigger → reservation / ReserveNow", () => {
+    const exp = deriveExpectation(
+      node(ScenarioNodeType.RESERVATION_TRIGGER, {
+        label: "Wait for ReserveNow",
+      } as ScenarioNodeData),
+      connectorId,
+    );
+    expect(exp).toMatchObject({
+      type: "reservation",
+      direction: "CSMS_TO_CP",
+      action: "ReserveNow",
+    });
+  });
+
+  it("omits constraints when the connectorId is undefined", () => {
+    const exp = deriveExpectation(
+      node(ScenarioNodeType.REMOTE_START_TRIGGER, {
+        label: "Wait",
+      } as ScenarioNodeData),
+      undefined,
+    );
+    expect(exp?.constraints).toBeUndefined();
+  });
+
+  it.each([
+    ScenarioNodeType.STATUS_CHANGE,
+    ScenarioNodeType.TRANSACTION,
+    ScenarioNodeType.METER_VALUE,
+    ScenarioNodeType.DELAY,
+    ScenarioNodeType.START,
+    ScenarioNodeType.END,
+    ScenarioNodeType.RESPONSE_OVERRIDE,
+  ])("returns null for the non-waiting node type %s", (type) => {
+    expect(
+      deriveExpectation(node(type, { label: "x" } as ScenarioNodeData), 1),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Phase 1 of #179 (machine-readable expectations, verdicts, and reports for headless scenario runs). This phase is deliberately small and strictly additive: it surfaces **what a parked scenario is waiting for** and gives each run a **stable id**. Assertions/verdicts (Phase 2) and `scenario_report` (Phase 3) follow.

## What this adds

### Structured expectation on `scenario_status`
- New `ScenarioExpectation` type and a pure `deriveExpectation(node, connectorId)` that maps the five *waiting* trigger node types to a normalized shape:

  | Node | Expectation |
  |---|---|
  | `remoteStartTrigger` | `ocpp_call` · CSMS→CP · `RemoteStartTransaction` |
  | `remoteStopTrigger` | `ocpp_call` · CSMS→CP · `RemoteStopTransaction` |
  | `csmsCallTrigger` | `ocpp_call` · CSMS→CP · *node's action* |
  | `statusTrigger` | `connector_status` · *targetStatus* |
  | `reservationTrigger` | `reservation` · CSMS→CP · `ReserveNow` |

  Each carries `constraints:{connectorId}`, `timeoutMs` (node timeout × 1000), and `nodeId`. Non-waiting nodes → `null`.

- Matches the issue's example:
  ```json
  {"scenarioId":"…","state":"waiting","currentNodeId":"wait-for-remote-start",
   "expectation":{"type":"ocpp_call","direction":"CSMS_TO_CP","action":"RemoteStartTransaction","constraints":{"connectorId":1},"timeoutMs":30000}}
  ```

### Making `waiting` reachable
The robot3 machine's `waiting` state was effectively dead — `WAIT_START` is never dispatched, so `scenario_status.state` reported `"running"` even while a node was parked on a CSMS/connector wait. The executor now tracks `currentExpectation` around each parked node and `getContext()` reports the already-valid `state:"waiting"` (only overriding an otherwise-`"running"` machine, so `paused` / `stepping` / stopped keep their real state). No production code keys "is running" off `getContext().state` — both the CLI service and the manager use `executors.has()` — so this is additive; the only `context.state` branch is `=== "completed"`, which is never spuriously triggered.

### Stable `runId`
`CLIChargePointService` mints `scenarioId#<epochMs>-<rand>` per run, threads it through `scenario_started` / `scenario_completed` / `scenario_error` / `scenario_node_execute`, echoes it on `getScenarioStatus`, and clears it with the executor. Lifecycle event `data` is `z.unknown()` on the wire, so no schema change and old clients ignore the extra key.

## Scope note

The auto-increment MeterValue node also parks, but its target depends on runtime state (meter-start offset / EV settings) and it is *active work* rather than an external wait, so it is intentionally not surfaced as an expectation here. The local (web-console) path receives the `expectation` for free via `getContext()`; a local-path `runId` is deferred to when a consumer needs it (Phase 2/3).

## Tests
- `deriveExpectation` unit matrix (every waiting type + non-waiting → null + no-connector case).
- Executor reports `waiting` + expectation while parked and clears it on completion (updated the pause/resume control test to the new semantics).
- Service-level bun test: `scenario_status` returns `waiting` + expectation, and the `runId` is shared between the `scenario_started` event and the status; null status after stop (no stale waiting).

## Gates
- `tsc -b --noEmit --force`: 478 (baseline)
- vitest: 1149/1149
- `test:bun`: 209/209
- prettier / eslint: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clear waiting-state details for scenarios paused on triggers, including the expected action, connector status, reservation, or OCPP call.
  - Added stable run identifiers to scenario status and lifecycle events for easier execution tracking.
  - Waiting expectations now include relevant node, connector, and timeout information.

- **Bug Fixes**
  - Stopping a scenario now clears its status and any stale waiting expectation.
  - Paused and resumed scenarios now consistently report their waiting state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->