### PR TITLE
refactor(verification): promote steve-verify frame model + assert DSL to src/ (#179 phase 2a)

### DIFF
--- a/src/cp/application/verification/assert.ts
+++ b/src/cp/application/verification/assert.ts
@@ -1,0 +1,354 @@
+/**
+ * assert.ts -- typed assertion DSL for scenario specs, mirroring lib.sh's
+ * check_* helpers but operating on parsed {@link Frame}s (see ocpp.ts)
+ * instead of grep windows, so response-status assertions correlate by
+ * OCPP-J uniqueId rather than log adjacency.
+ */
+
+import {
+  findCall,
+  findResponseFor,
+  type CallFrame,
+  type Direction,
+  type Frame,
+} from "./ocpp";
+
+export interface CheckResult {
+  description: string;
+  pass: boolean;
+  detail?: string;
+}
+
+/** Accumulates PASS/FAIL check results for one scenario run. */
+export class AssertRecorder {
+  private checks: CheckResult[] = [];
+
+  pass(description: string): void {
+    this.checks.push({ description, pass: true });
+  }
+
+  fail(description: string, detail?: string): void {
+    this.checks.push({ description, pass: false, detail });
+  }
+
+  get results(): readonly CheckResult[] {
+    return this.checks;
+  }
+
+  get total(): number {
+    return this.checks.length;
+  }
+
+  get failed(): number {
+    return this.checks.filter((c) => !c.pass).length;
+  }
+
+  get verdict(): "PASS" | "FAIL" {
+    return this.failed > 0 ? "FAIL" : "PASS";
+  }
+}
+
+/** check_log_contains equivalent: at least one CALL exists for direction+action. */
+export function assertSent(
+  rec: AssertRecorder,
+  frames: readonly Frame[],
+  action: string,
+  description = `${action}.req sent`,
+): CallFrame | undefined {
+  const call = findCall(frames, "sent", action);
+  if (call) {
+    rec.pass(description);
+  } else {
+    rec.fail(description, `no Sent CALL found for action=${action}`);
+  }
+  return call;
+}
+
+export function assertReceived(
+  rec: AssertRecorder,
+  frames: readonly Frame[],
+  action: string,
+  description = `${action}.req received`,
+): CallFrame | undefined {
+  const call = findCall(frames, "received", action);
+  if (call) {
+    rec.pass(description);
+  } else {
+    rec.fail(description, `no Received CALL found for action=${action}`);
+  }
+  return call;
+}
+
+/** check_log_not_contains equivalent, scoped to CALLs for one action/direction. */
+export function assertNotSent(
+  rec: AssertRecorder,
+  frames: readonly Frame[],
+  action: string,
+  direction: Direction = "sent",
+  description = `no ${action} ${direction}`,
+): void {
+  const call = findCall(frames, direction, action);
+  if (call) {
+    rec.fail(description, `unexpected ${direction} CALL found: ${call.raw}`);
+  } else {
+    rec.pass(description);
+  }
+}
+
+export interface ResponseStatusOptions {
+  /** Which side sent the CALL being answered (default "received": a
+   *  CSMS-initiated op like RemoteStartTransaction). Pass "sent" for a
+   *  CP-initiated op like BootNotification. */
+  direction?: Direction;
+  /** 0-indexed occurrence of `action`, for scenarios that repeat it
+   *  (e.g. a Full then a Differential SendLocalList). */
+  occurrence?: number;
+}
+
+/**
+ * check_response_status / check_sent_result equivalent, upgraded to
+ * uniqueId correlation: finds the `occurrence`-th CALL for `action` in
+ * `direction`, then its response PAIRED BY uniqueId (not the next
+ * CALLRESULT line in the log), and asserts payload.status === expected.
+ */
+export function assertResponseStatus(
+  rec: AssertRecorder,
+  frames: readonly Frame[],
+  action: string,
+  expectedStatus: string,
+  description = `${action} -> status ${expectedStatus}`,
+  options: ResponseStatusOptions = {},
+): void {
+  const direction = options.direction ?? "received";
+  const occurrence = options.occurrence ?? 0;
+
+  const call = findCall(frames, direction, action, occurrence);
+  if (!call) {
+    rec.fail(
+      description,
+      `no ${direction} CALL found for action=${action} (occurrence ${occurrence})`,
+    );
+    return;
+  }
+
+  const response = findResponseFor(frames, call);
+  if (!response) {
+    rec.fail(
+      description,
+      `no response frame found for uniqueId=${call.uniqueId} (${action})`,
+    );
+    return;
+  }
+  if (response.kind === "callerror") {
+    rec.fail(
+      description,
+      `expected CALLRESULT, got CALLERROR ${response.errorCode}: ${response.errorDescription}`,
+    );
+    return;
+  }
+
+  const status = (response.payload as { status?: unknown } | null)?.status;
+  if (status === expectedStatus) {
+    rec.pass(description);
+  } else {
+    rec.fail(
+      description,
+      `expected status=${expectedStatus}, got status=${String(status)} (uniqueId=${call.uniqueId})`,
+    );
+  }
+}
+
+/**
+ * Variant of {@link assertResponseStatus} for CALLRESULTs that nest their
+ * status under `idTagInfo.status` (StartTransaction.conf, Authorize.conf)
+ * rather than a top-level `status` field. Same uniqueId-paired correlation.
+ */
+export function assertIdTagInfoStatus(
+  rec: AssertRecorder,
+  frames: readonly Frame[],
+  action: string,
+  expectedStatus: string,
+  description: string,
+  options: ResponseStatusOptions = {},
+): void {
+  const direction = options.direction ?? "sent";
+  const occurrence = options.occurrence ?? 0;
+
+  const call = findCall(frames, direction, action, occurrence);
+  if (!call) {
+    rec.fail(
+      description,
+      `no ${direction} CALL found for action=${action} (occurrence ${occurrence})`,
+    );
+    return;
+  }
+
+  const response = findResponseFor(frames, call);
+  if (!response) {
+    rec.fail(
+      description,
+      `no response frame found for uniqueId=${call.uniqueId} (${action})`,
+    );
+    return;
+  }
+  if (response.kind === "callerror") {
+    rec.fail(
+      description,
+      `expected CALLRESULT, got CALLERROR ${response.errorCode}: ${response.errorDescription}`,
+    );
+    return;
+  }
+
+  const status = (
+    response.payload as { idTagInfo?: { status?: unknown } } | null
+  )?.idTagInfo?.status;
+  if (status === expectedStatus) {
+    rec.pass(description);
+  } else {
+    rec.fail(
+      description,
+      `expected idTagInfo.status=${expectedStatus}, got status=${String(status)} (uniqueId=${call.uniqueId})`,
+    );
+  }
+}
+
+export function assertEq(
+  rec: AssertRecorder,
+  actual: unknown,
+  expected: unknown,
+  description: string,
+): void {
+  if (actual === expected) {
+    rec.pass(description);
+  } else {
+    rec.fail(
+      description,
+      `expected '${String(expected)}', got '${String(actual)}'`,
+    );
+  }
+}
+
+export function assertTrue(
+  rec: AssertRecorder,
+  condition: boolean,
+  description: string,
+  detail?: string,
+): void {
+  if (condition) {
+    rec.pass(description);
+  } else {
+    rec.fail(description, detail);
+  }
+}
+
+/**
+ * check_log_contains equivalent for checks that aren't about a specific
+ * OCPP frame (scenario lifecycle structured events, free-text log
+ * messages) -- scans raw stdout lines rather than parsed frames.
+ */
+export function assertLineMatches(
+  rec: AssertRecorder,
+  lines: readonly string[],
+  pattern: RegExp,
+  description: string,
+): void {
+  if (lines.some((line) => pattern.test(line))) {
+    rec.pass(description);
+  } else {
+    rec.fail(description, `no line matched pattern: ${pattern}`);
+  }
+}
+
+/** check_log_not_contains equivalent over raw stdout lines. */
+export function assertNoLineMatches(
+  rec: AssertRecorder,
+  lines: readonly string[],
+  pattern: RegExp,
+  description: string,
+): void {
+  const hit = lines.find((line) => pattern.test(line));
+  if (hit) {
+    rec.fail(description, `unexpected line matched pattern ${pattern}: ${hit}`);
+  } else {
+    rec.pass(description);
+  }
+}
+
+/**
+ * check_log_order equivalent: passes if the FIRST line matching `patternA`
+ * appears before the FIRST line matching `patternB`.
+ */
+export function assertLineOrder(
+  rec: AssertRecorder,
+  lines: readonly string[],
+  patternA: RegExp,
+  patternB: RegExp,
+  description: string,
+): void {
+  const indexA = lines.findIndex((line) => patternA.test(line));
+  const indexB = lines.findIndex((line) => patternB.test(line));
+  if (indexA === -1 || indexB === -1) {
+    rec.fail(
+      description,
+      `one or both patterns not found (A=${patternA} found=${indexA !== -1}, B=${patternB} found=${indexB !== -1})`,
+    );
+  } else if (indexA < indexB) {
+    rec.pass(description);
+  } else {
+    rec.fail(
+      description,
+      `A (line ${indexA}) did not precede B (line ${indexB})`,
+    );
+  }
+}
+
+/**
+ * check_log_after equivalent: passes if `pattern` matches some line
+ * strictly after the LAST line matching `afterPattern`. Use this instead of
+ * {@link assertLineOrder} when `pattern` could also match an earlier,
+ * unrelated occurrence (e.g. a connector's automatic post-boot "Available"
+ * StatusNotification, which always precedes any scenario-driven state
+ * change and would make a first-match order check pass trivially).
+ */
+export function assertLineAfter(
+  rec: AssertRecorder,
+  lines: readonly string[],
+  afterPattern: RegExp,
+  pattern: RegExp,
+  description: string,
+): void {
+  let afterIndex = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (afterPattern.test(lines[i])) afterIndex = i;
+  }
+  if (afterIndex === -1) {
+    rec.fail(description, `reference pattern not found: ${afterPattern}`);
+    return;
+  }
+  const found = lines.slice(afterIndex + 1).some((line) => pattern.test(line));
+  if (found) {
+    rec.pass(description);
+  } else {
+    rec.fail(
+      description,
+      `pattern not found after line ${afterIndex} (${afterPattern}): ${pattern}`,
+    );
+  }
+}
+
+/**
+ * check_db_nonempty equivalent, generic over an already-fetched value
+ * (keeps assert.ts free of any SteveDb/SQL coupling -- callers fetch via
+ * `db.scalar(...)` and pass the result in).
+ */
+export function assertNonEmpty(
+  rec: AssertRecorder,
+  value: string,
+  description: string,
+): void {
+  if (value !== "") {
+    rec.pass(`${description} (got '${value}')`);
+  } else {
+    rec.fail(description, "value was empty");
+  }
+}

--- a/src/cp/application/verification/ocpp.ts
+++ b/src/cp/application/verification/ocpp.ts
@@ -1,0 +1,219 @@
+/**
+ * ocpp.ts -- OCPP-J wire-frame parser + uniqueId correlation.
+ *
+ * The simulator CLI (src/cli/main.ts --json) does not emit a structured
+ * event carrying raw OCPP frames: ChargePointEvents declares `messageSent`
+ * / `messageReceived` payloads shaped exactly for this, but nothing in the
+ * codebase ever emits them (see the Task 1 investigation notes in
+ * .superpowers/sdd/tsr-task-1-report.md). What IS always present, JSON
+ * mode or not, is the plain-text line the shared Logger writes straight to
+ * console for every WebSocket frame:
+ *
+ *   [<iso-timestamp>] [<LEVEL>] [WebSocket] Sent: [2,"<uniqueId>","<Action>",{...}]
+ *   [<iso-timestamp>] [<LEVEL>] [WebSocket] Received: [3,"<uniqueId>",{...}]
+ *
+ * This module parses that line format into typed frames and correlates a
+ * request to its response by OCPP-J `uniqueId` -- not by "next matching
+ * line within N lines of the request" (the bash predecessor's
+ * check_response_status / check_sent_result window-scan), which can pick
+ * up the wrong CALLRESULT when other traffic (StatusNotification, a second
+ * concurrent op, ...) is interleaved on the wire between a request and its
+ * own response.
+ */
+
+export type Direction = "sent" | "received";
+
+export interface CallFrame {
+  kind: "call";
+  direction: Direction;
+  uniqueId: string;
+  action: string;
+  payload: unknown;
+  timestamp: string;
+  raw: string;
+}
+
+export interface CallResultFrame {
+  kind: "callresult";
+  direction: Direction;
+  uniqueId: string;
+  payload: unknown;
+  timestamp: string;
+  raw: string;
+}
+
+export interface CallErrorFrame {
+  kind: "callerror";
+  direction: Direction;
+  uniqueId: string;
+  errorCode: string;
+  errorDescription: string;
+  errorDetails: unknown;
+  timestamp: string;
+  raw: string;
+}
+
+export type ResponseFrame = CallResultFrame | CallErrorFrame;
+export type Frame = CallFrame | CallResultFrame | CallErrorFrame;
+
+// `[<timestamp>] [<LEVEL>] [<Type>] <rest>` -- the Logger's plain-format
+// line (src/cp/shared/Logger.ts formatLogEntry). Only WebSocket-typed lines
+// ever carry "Sent:"/"Received:", but matching on the prefix generally
+// keeps this parser agnostic to which LogType wrote it.
+const LOG_LINE_RE = /^\[([^\]]+)\]\s+\[[^\]]+\]\s+\[[^\]]+\]\s+(.*)$/;
+const FRAME_MESSAGE_RE = /^(Sent|Received):\s+(\[.*\])\s*$/;
+
+/**
+ * Parses a single stdout line from the simulator CLI into a {@link Frame},
+ * or returns null for anything that isn't an OCPP-J Sent/Received line
+ * (structured JSON events, JSON command responses, other log lines, blank
+ * lines).
+ */
+export function parseLogLine(line: string): Frame | null {
+  const lineMatch = LOG_LINE_RE.exec(line);
+  if (!lineMatch) return null;
+  const [, timestamp, rest] = lineMatch;
+
+  const frameMatch = FRAME_MESSAGE_RE.exec(rest);
+  if (!frameMatch) return null;
+  const direction: Direction = frameMatch[1] === "Sent" ? "sent" : "received";
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(frameMatch[2]);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed) || typeof parsed[0] !== "number") return null;
+
+  const messageTypeId = parsed[0];
+  const uniqueId = String(parsed[1] ?? "");
+  if (!uniqueId) return null;
+
+  switch (messageTypeId) {
+    case 2: {
+      if (parsed.length < 4 || typeof parsed[2] !== "string") return null;
+      return {
+        kind: "call",
+        direction,
+        uniqueId,
+        action: parsed[2],
+        payload: parsed[3],
+        timestamp,
+        raw: line,
+      };
+    }
+    case 3: {
+      if (parsed.length < 3) return null;
+      return {
+        kind: "callresult",
+        direction,
+        uniqueId,
+        payload: parsed[2],
+        timestamp,
+        raw: line,
+      };
+    }
+    case 4: {
+      if (parsed.length < 5 || typeof parsed[2] !== "string") return null;
+      return {
+        kind: "callerror",
+        direction,
+        uniqueId,
+        errorCode: parsed[2],
+        errorDescription: String(parsed[3] ?? ""),
+        errorDetails: parsed[4],
+        timestamp,
+        raw: line,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+/** Parses a whole multi-line log (or stdout capture), preserving order. */
+export function parseLog(text: string): Frame[] {
+  const frames: Frame[] = [];
+  for (const line of text.split("\n")) {
+    const frame = parseLogLine(line);
+    if (frame) frames.push(frame);
+  }
+  return frames;
+}
+
+/**
+ * Finds the `occurrence`-th (0-indexed, default 0) CALL frame matching
+ * `direction` + `action`, in log order.
+ */
+export function findCall(
+  frames: readonly Frame[],
+  direction: Direction,
+  action: string,
+  occurrence = 0,
+): CallFrame | undefined {
+  let seen = 0;
+  for (const frame of frames) {
+    if (
+      frame.kind === "call" &&
+      frame.direction === direction &&
+      frame.action === action
+    ) {
+      if (seen === occurrence) return frame;
+      seen++;
+    }
+  }
+  return undefined;
+}
+
+/** Returns every CALL frame matching `direction` + `action`, in log order. */
+export function findAllCalls(
+  frames: readonly Frame[],
+  direction: Direction,
+  action: string,
+): CallFrame[] {
+  return frames.filter(
+    (f): f is CallFrame =>
+      f.kind === "call" && f.direction === direction && f.action === action,
+  );
+}
+
+/**
+ * Finds the CALLRESULT/CALLERROR that answers `call`, correlated strictly
+ * by OCPP-J `uniqueId` and reply direction (a response to a sent CALL must
+ * be received, and vice versa) -- never by adjacency in the log. Returns
+ * the FIRST such response in log order (an OCPP peer should never send two
+ * responses to the same uniqueId, but this is deterministic either way).
+ *
+ * uniqueId-uniqueness assumption: this correlation is only sound if
+ * `uniqueId`s are effectively unique for the span of the log being
+ * searched. In practice they are -- both the CP (OCPPWebSocket) and SteVe
+ * generate UUIDs per outstanding request -- but a long-running or reused
+ * log CAN contain the same uniqueId string twice by coincidence (or, in a
+ * test fixture, deliberately). Guard against that: a response can only
+ * ever be for the CALL that precedes it on the wire, so this only searches
+ * frames STRICTLY AFTER `call`'s own position in `frames` -- an earlier
+ * frame sharing the same uniqueId (e.g. a stale response left over from a
+ * prior exchange that happened to reuse the id) is never matched, even
+ * though it satisfies direction+uniqueId.
+ */
+export function findResponseFor(
+  frames: readonly Frame[],
+  call: CallFrame,
+): ResponseFrame | undefined {
+  const responseDirection: Direction =
+    call.direction === "sent" ? "received" : "sent";
+  const callIndex = frames.indexOf(call);
+  const start = callIndex === -1 ? 0 : callIndex + 1;
+  for (let i = start; i < frames.length; i++) {
+    const frame = frames[i];
+    if (
+      (frame.kind === "callresult" || frame.kind === "callerror") &&
+      frame.direction === responseDirection &&
+      frame.uniqueId === call.uniqueId
+    ) {
+      return frame;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
Phase 2a of #179 — a pure refactor that sets up phase 2. No behavior change.

## What

Move the OCPP-J wire-frame parser (`ocpp.ts`) and the typed assertion DSL (`assert.ts`) from `scripts/steve-verify/runner/` into a shared `src/cp/application/verification/` module.

## Why

Phase 2 adds an **in-simulator** assertion engine (`scenario_report` verdicts). Rather than reimplement the frame model + assert primitives — and risk the in-sim engine drifting from the CI harness that already validates the cert16 suite — both consumers should share **one** semantics. This promotes that shared code into `src/`; phase 2 builds its engine on top of it.

## How (pure move)

- `src/cp/application/verification/ocpp.ts` and `assert.ts` are the moved files (verbatim).
- `scripts/steve-verify/runner/{ocpp,assert}.ts` become **thin re-export shims** (`export * from "../../../src/cp/application/verification/…"`), so every existing runner import (`./ocpp`, `./assert` across `main.ts`, `spec-types.ts`, `specs/*`, `__tests__/*`) resolves unchanged — no importer churn.
- Both files are self-contained (`ocpp.ts` has no imports; `assert.ts` imports only `ocpp.ts`) with no env-specific globals, so they compile cleanly under the app tsconfig and the bun runner alike.

## Gates
- `tsc -b --noEmit --force`: 482 (baseline, zero new errors)
- `test:bun`: 209/209 (incl. the steve-verify `ocpp`/`assert` suites, exercised through the re-export)
- vitest: 1149/1149
- prettier / eslint: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OCPP-J log parsing with support for calls, responses, errors, directions, timestamps, and request correlation.
  * Added verification tools for checking sent and received actions, response statuses, message ordering, text patterns, and expected values.
  * Added aggregated pass/fail reporting for verification results, including failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->