### PR TITLE
feat(verification): declarative assertions + verdict + per-run transcript (#179 phase 2b)

### DIFF
--- a/src/cli/__tests__/service.scenarioVerdict.bun.test.ts
+++ b/src/cli/__tests__/service.scenarioVerdict.bun.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "bun:test";
+import { Database as BunSqliteDatabase } from "bun:sqlite";
+import { CLIChargePointService } from "../service";
+import { BunSqliteDatabase as BunDb } from "../../cp/domain/persistence/BunSqliteDatabase";
+import { runMigrations } from "../../cp/domain/persistence/schema";
+import {
+  AssertionSpec,
+  ScenarioDefinition,
+  ScenarioNodeType,
+} from "../../cp/application/scenario/ScenarioTypes";
+
+/**
+ * #179 Phase 2b: a scenario with no external waits, completing on its own
+ * (start -> meterValue -> end) so it finishes without a live CSMS
+ * connection. `sendMessage: false` mirrors ScenarioExecutor.context.test.ts's
+ * completing-scenario fixture, keeping the run instant.
+ */
+function completingScenario(
+  id: string,
+  assertions?: AssertionSpec[],
+): ScenarioDefinition {
+  return {
+    id,
+    name: "Completing scenario",
+    targetType: "connector",
+    targetId: 1,
+    nodes: [
+      {
+        id: "start-1",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "S" },
+      },
+      {
+        id: "mv-1",
+        type: ScenarioNodeType.METER_VALUE,
+        position: { x: 0, y: 1 },
+        data: { label: "MV", value: 100, sendMessage: false },
+      },
+      {
+        id: "end-1",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 2 },
+        data: { label: "E" },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "start-1", target: "mv-1" },
+      { id: "e2", source: "mv-1", target: "end-1" },
+    ],
+    createdAt: "2026-07-13T00:00:00Z",
+    updatedAt: "2026-07-13T00:00:00Z",
+    ...(assertions ? { assertions } : {}),
+  };
+}
+
+function newService(): CLIChargePointService {
+  const raw = new BunSqliteDatabase(":memory:");
+  const db = new BunDb(raw);
+  runMigrations(db);
+  return new CLIChargePointService(
+    {
+      cpId: "test-cp",
+      wsUrl: "ws://127.0.0.1:65534/never",
+      connectors: 1,
+      vendor: "v",
+      model: "m",
+    },
+    db,
+  );
+}
+
+describe("#179 Phase 2b: declarative assertions + verdict + per-run transcript", () => {
+  it("getScenarioRunResult is null before any run has finished", () => {
+    const svc = newService();
+    const id = svc.loadScenario(1, completingScenario("not-run-yet"));
+    expect(svc.getScenarioRunResult(id)).toBeNull();
+  });
+
+  it("a scenario with no declared assertions produces a SKIPPED verdict (unchanged behavior)", async () => {
+    const svc = newService();
+    const id = svc.loadScenario(1, completingScenario("no-assertions"));
+    svc.runScenario(1, id);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const result = svc.getScenarioRunResult(id);
+    expect(result).not.toBeNull();
+    expect(result!.scenarioId).toBe(id);
+    expect(result!.connectorId).toBe(1);
+    expect(result!.verdict).toBe("SKIPPED");
+    expect(result!.assertions).toEqual([]);
+    expect(typeof result!.frameCount).toBe("number");
+    expect(new Date(result!.startedAt).getTime()).toBeLessThanOrEqual(
+      new Date(result!.endedAt).getTime(),
+    );
+  });
+
+  it("an assertion deterministically satisfiable without a live CSMS produces PASS", async () => {
+    const svc = newService();
+    // This test never calls connect() -- the WebSocket never opens, so the
+    // boot gate suppresses every outbound OCPP call and nothing hits the
+    // wire. An ocpp_absent assertion for any action is therefore
+    // deterministically satisfiable, giving a real end-to-end PASS through
+    // the actual service (not a synthetic frame fixture).
+    const id = svc.loadScenario(
+      1,
+      completingScenario("pass-assertion", [
+        { id: "no-reset", type: "ocpp_absent", action: "Reset" },
+      ]),
+    );
+    svc.runScenario(1, id);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const result = svc.getScenarioRunResult(id);
+    expect(result).not.toBeNull();
+    expect(result!.verdict).toBe("PASS");
+    expect(result!.assertions).toHaveLength(1);
+    expect(result!.assertions[0]).toMatchObject({
+      id: "no-reset",
+      type: "ocpp_absent",
+      status: "passed",
+    });
+  });
+
+  it("an assertion requiring wire traffic that never happens (no live CSMS) produces FAIL", async () => {
+    const svc = newService();
+    const id = svc.loadScenario(
+      1,
+      completingScenario("fail-assertion", [
+        { id: "boot-sent", type: "ocpp_sent", action: "BootNotification" },
+      ]),
+    );
+    svc.runScenario(1, id);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const result = svc.getScenarioRunResult(id);
+    expect(result).not.toBeNull();
+    expect(result!.verdict).toBe("FAIL");
+    expect(result!.assertions).toHaveLength(1);
+    expect(result!.assertions[0].status).toBe("failed");
+  });
+
+  it("resolves a specific runId, and returns null for a mismatched one", async () => {
+    const svc = newService();
+    const id = svc.loadScenario(1, completingScenario("runid-lookup"));
+
+    let startedRunId: string | undefined;
+    svc.onEvent((ev) => {
+      if (ev.event === "scenario_started") startedRunId = ev.data.runId;
+    });
+    svc.runScenario(1, id);
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(typeof startedRunId).toBe("string");
+    // Narrow startedRunId to `string` (a `typeof` check inside `expect()`
+    // doesn't narrow for TS control-flow analysis) so it type-checks
+    // against ScenarioRunResult['runId'] below.
+    if (!startedRunId) throw new Error("scenario_started never fired");
+    const byRunId = svc.getScenarioRunResult(id, startedRunId);
+    expect(byRunId).not.toBeNull();
+    expect(byRunId!.runId).toBe(startedRunId);
+    // Omitting runId resolves the same (latest) result.
+    expect(svc.getScenarioRunResult(id)!.runId).toBe(startedRunId);
+    // A runId that doesn't belong to this scenario resolves to null, not a
+    // stale/foreign result.
+    expect(svc.getScenarioRunResult(id, "not-a-real-run-id")).toBeNull();
+  });
+});

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -49,6 +49,12 @@ import type {
   HistoryOptions,
 } from "../cp/application/services/types/StateSnapshot";
 import { scenarioTemplates, getTemplateById } from "../utils/scenarioTemplates";
+import { TranscriptBuffer } from "../cp/application/verification/TranscriptBuffer";
+import {
+  evaluateAssertions,
+  computeVerdict,
+  type ScenarioRunResult,
+} from "../cp/application/verification/ScenarioAssertions";
 
 export type CLIEvent =
   | { readonly event: "connected"; readonly data: Record<string, never> }
@@ -230,6 +236,24 @@ export class CLIChargePointService {
   // and lifecycle events can be correlated to a specific run. Keyed like
   // _executors (by scenarioId) and cleared alongside it.
   private readonly _runIdByScenario: Map<string, string> = new Map();
+  // #179 Phase 2b: OCPP wire transcript capture for the currently-executing
+  // scenario, keyed like _executors/_runIdByScenario by scenarioId. Started
+  // alongside the run id in runScenario and stopped (then dropped) once the
+  // run ends, in finalizeScenarioRun.
+  private readonly _transcriptByScenario: Map<string, TranscriptBuffer> =
+    new Map();
+  // #179 Phase 2b: wall-clock start time (ISO) for the currently-executing
+  // scenario's run, read back by finalizeScenarioRun to build the
+  // ScenarioRunResult.
+  private readonly _runStartedAtByScenario: Map<string, string> = new Map();
+  // #179 Phase 2b: bounded history of per-run verdicts + assertion results,
+  // keyed by runId. Capped so a long-lived daemon doesn't accumulate
+  // results forever; recordRunResult evicts the oldest entry past the cap.
+  private readonly _runResults: Map<string, ScenarioRunResult> = new Map();
+  private static readonly MAX_RUN_RESULTS = 20;
+  // Latest runId recorded per scenarioId, so getScenarioRunResult can
+  // resolve "the latest run" without scanning _runResults.
+  private readonly _latestRunIdByScenario: Map<string, string> = new Map();
   private readonly _scenarioRepo: SqliteScenarioRepository;
   private readonly _runtimeRepo: ConnectorRuntimeRepository;
   /**
@@ -806,6 +830,16 @@ export class CLIChargePointService {
       executor.stop();
       this._executors.delete(scenarioId);
       this._runIdByScenario.delete(scenarioId);
+      // #179 Phase 2b: drop the transcript subscription for the run being
+      // torn down along with it -- otherwise it would keep capturing every
+      // future WebSocket frame on this CP with nothing left to stop it.
+      // No verdict is computed here (the scenario itself is being deleted).
+      const transcript = this._transcriptByScenario.get(scenarioId);
+      if (transcript) {
+        transcript.stop();
+        this._transcriptByScenario.delete(scenarioId);
+      }
+      this._runStartedAtByScenario.delete(scenarioId);
     }
     this._scenarios.delete(scenarioId);
     this._scenarioRepo.deleteOne(this._chargePoint.id, connectorId, scenarioId);
@@ -859,6 +893,17 @@ export class CLIChargePointService {
     const runId = makeScenarioRunId(scenarioId);
     this._runIdByScenario.set(scenarioId, runId);
 
+    // #179 Phase 2b: capture the OCPP wire transcript for this run so its
+    // declared assertions (if any) can be evaluated once it ends.
+    const transcript = new TranscriptBuffer(this._chargePoint.logger);
+    transcript.start();
+    this._transcriptByScenario.set(scenarioId, transcript);
+    this._runStartedAtByScenario.set(scenarioId, new Date().toISOString());
+
+    // Set by the onError hook below; read in executor.start().finally() to
+    // decide this run's verdict executionState ("error" vs "completed").
+    let hadError = false;
+
     const callbacks = createScenarioExecutorCallbacks({
       chargePoint: this._chargePoint,
       connector,
@@ -878,6 +923,7 @@ export class CLIChargePointService {
           });
         },
         onError: (error) => {
+          hadError = true;
           this.emit({
             event: "scenario_error",
             data: { connectorId, scenarioId, error: error.message, runId },
@@ -978,6 +1024,18 @@ export class CLIChargePointService {
         connector.clearEvSettingsOverride();
       }
       this.persistConnectorRuntime(connector, connectorId);
+      // #179 Phase 2b: the run has settled (naturally or via error) --
+      // stop capturing the transcript and compute this run's verdict. The
+      // stop-path methods (stopScenario/stopAllScenarios) finalize
+      // synchronously before this callback can fire (see their comments),
+      // so finalizeScenarioRun's transcript guard makes this a no-op then.
+      this.finalizeScenarioRun(
+        scenarioId,
+        connectorId,
+        runId,
+        hadError ? "error" : "completed",
+        false,
+      );
     });
   }
 
@@ -1025,6 +1083,87 @@ export class CLIChargePointService {
     return { ...executor.getContext(), runId };
   }
 
+  /**
+   * #179 Phase 2b: the verdict + assertion results for a scenario run, or
+   * null if no run has finished yet (or the given runId doesn't match a
+   * stored result for this scenario). Omitting runId returns the latest
+   * recorded run for the scenario. Only the last {@link MAX_RUN_RESULTS}
+   * runs across the whole service are retained. Phase 3 surfaces this over
+   * RPC as `scenario_report`; this accessor is the only new public surface
+   * added here.
+   */
+  getScenarioRunResult(
+    scenarioId: string,
+    runId?: string,
+  ): ScenarioRunResult | null {
+    const targetRunId = runId ?? this._latestRunIdByScenario.get(scenarioId);
+    if (!targetRunId) return null;
+    const result = this._runResults.get(targetRunId);
+    if (!result || result.scenarioId !== scenarioId) return null;
+    return result;
+  }
+
+  /**
+   * #179 Phase 2b: stop capturing this run's transcript, evaluate the
+   * scenario's declared assertions (if any) against it, and store the
+   * resulting {@link ScenarioRunResult}. A scenario with no `assertions`
+   * evaluates to zero results, which computeVerdict resolves to SKIPPED --
+   * unchanged behavior for every scenario written before this feature.
+   *
+   * Idempotent: the run's transcript is removed from
+   * `_transcriptByScenario` the first time this runs for a given
+   * scenarioId, so a second call for the same run (the stop-path methods
+   * finalize synchronously, ahead of the microtask-deferred
+   * executor.start().finally() callback racing them for the same run — see
+   * their comments) is a no-op.
+   */
+  private finalizeScenarioRun(
+    scenarioId: string,
+    connectorId: number,
+    runId: string,
+    executionState: "completed" | "error",
+    blocked: boolean,
+  ): void {
+    const transcript = this._transcriptByScenario.get(scenarioId);
+    if (!transcript) return;
+    transcript.stop();
+    this._transcriptByScenario.delete(scenarioId);
+
+    const startedAt =
+      this._runStartedAtByScenario.get(scenarioId) ?? new Date().toISOString();
+    this._runStartedAtByScenario.delete(scenarioId);
+
+    const assertionSpecs =
+      this._scenarios.get(scenarioId)?.definition.assertions ?? [];
+    const assertions = evaluateAssertions(assertionSpecs, transcript.frames);
+    const verdict = computeVerdict(assertions, { executionState, blocked });
+
+    this.recordRunResult({
+      runId,
+      scenarioId,
+      connectorId,
+      verdict,
+      assertions,
+      startedAt,
+      endedAt: new Date().toISOString(),
+      frameCount: transcript.frames.length,
+    });
+  }
+
+  /** Stores a run result, evicting the oldest entry once
+   *  {@link MAX_RUN_RESULTS} is exceeded (Map iteration order is insertion
+   *  order, so the first key is the oldest). */
+  private recordRunResult(result: ScenarioRunResult): void {
+    this._runResults.set(result.runId, result);
+    this._latestRunIdByScenario.set(result.scenarioId, result.runId);
+    if (this._runResults.size > CLIChargePointService.MAX_RUN_RESULTS) {
+      const oldestKey = this._runResults.keys().next().value;
+      if (oldestKey !== undefined) {
+        this._runResults.delete(oldestKey);
+      }
+    }
+  }
+
   stopScenario(connectorId: number, scenarioId: string): void {
     const executor = this._executors.get(scenarioId);
     if (!executor) {
@@ -1033,6 +1172,12 @@ export class CLIChargePointService {
     // #179: capture the run id before stop() — executor.stop() lets the
     // start() promise settle, whose finally() clears _runIdByScenario.
     const runId = this._runIdByScenario.get(scenarioId) ?? "";
+    // #179 Phase 2b: capture whether the run was parked on a waiting node
+    // BEFORE stop() clears currentExpectation — a scenario stopped mid-wait
+    // couldn't reach a verifiable state, so its verdict should be BLOCKED
+    // rather than a possibly-misleading FAIL/PASS off a truncated
+    // transcript.
+    const wasWaiting = executor.getContext().state === "waiting";
     executor.stop();
     this._executors.delete(scenarioId);
     this._runIdByScenario.delete(scenarioId);
@@ -1050,6 +1195,17 @@ export class CLIChargePointService {
       event: "scenario_completed",
       data: { connectorId, scenarioId, runId },
     });
+    // #179 Phase 2b: finalize now, synchronously, before executor.start()'s
+    // own .finally() (deferred to a microtask by the abort machinery) can
+    // race it — finalizeScenarioRun's transcript guard makes that later
+    // call a no-op.
+    this.finalizeScenarioRun(
+      scenarioId,
+      connectorId,
+      runId,
+      "completed",
+      wasWaiting,
+    );
   }
 
   stopAllScenarios(connectorId: number): void {
@@ -1058,6 +1214,8 @@ export class CLIChargePointService {
         const executor = this._executors.get(scenarioId);
         if (executor) {
           const runId = this._runIdByScenario.get(scenarioId) ?? "";
+          // #179 Phase 2b: see stopScenario's comment.
+          const wasWaiting = executor.getContext().state === "waiting";
           executor.stop();
           this._executors.delete(scenarioId);
           this._runIdByScenario.delete(scenarioId);
@@ -1072,6 +1230,13 @@ export class CLIChargePointService {
             event: "scenario_completed",
             data: { connectorId, scenarioId, runId },
           });
+          this.finalizeScenarioRun(
+            scenarioId,
+            connectorId,
+            runId,
+            "completed",
+            wasWaiting,
+          );
         }
       }
     }
@@ -1097,6 +1262,14 @@ export class CLIChargePointService {
     }
     this._executors.clear();
     this._scenarios.clear();
+    // #179 Phase 2b: drop any in-flight transcript subscriptions so a
+    // torn-down service doesn't leave stale Logger listeners behind. No
+    // verdicts are computed here (the whole service is going away).
+    for (const transcript of this._transcriptByScenario.values()) {
+      transcript.stop();
+    }
+    this._transcriptByScenario.clear();
+    this._runStartedAtByScenario.clear();
     this._chargePoint.disconnect();
     this.detachConnectorEventForwarders();
     for (const unsub of this._unsubscribes) {

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -393,7 +393,77 @@ export interface ScenarioDefinition {
    * still be made via the `EV_SETTINGS_CHANGE` node.
    */
   evSettings?: Partial<EVSettings>;
+
+  /**
+   * #179 Phase 2b: declarative pass/fail assertions checked against the
+   * captured OCPP wire transcript once the run ends. Optional — a scenario
+   * with no assertions produces a SKIPPED verdict and runs exactly as
+   * before (no behavior change).
+   */
+  assertions?: AssertionSpec[];
 }
+
+/**
+ * #179 Phase 2b: the kind of check an {@link AssertionSpec} performs against
+ * the captured OCPP wire transcript of one scenario run.
+ */
+export type AssertionType =
+  | "ocpp_sent"
+  | "ocpp_received"
+  | "ocpp_absent"
+  | "response_status"
+  | "idtag_info_status"
+  | "payload_match"
+  | "message_order"
+  | "message_after"
+  | "state_transition"
+  | "no_unexpected";
+
+/**
+ * Declarative assertion attached to a {@link ScenarioDefinition}. Evaluated
+ * against the run's captured {@link Frame} transcript by
+ * `evaluateAssertions` (src/cp/application/verification/ScenarioAssertions.ts)
+ * once the run ends. Field usage varies by `type` — see that module's
+ * mapping doc.
+ */
+export interface AssertionSpec {
+  /** Stable identifier; echoed on the corresponding {@link AssertionResult}. */
+  id: string;
+  description?: string;
+  type: AssertionType;
+  /** OCPP action for frame-based assertion types. */
+  action?: string;
+  direction?: "sent" | "received";
+  /** Expected status for response_status / idtag_info_status. */
+  status?: string;
+  /** Nth (0-indexed) occurrence of `action`. Default 0. */
+  occurrence?: number;
+  /** Partial subset match against the matched CALL's payload (payload_match). */
+  payload?: Record<string, unknown>;
+  /** Expected connector status for state_transition. */
+  targetStatus?: string;
+  /** Set of actions that must not appear as a sent CALL (no_unexpected). */
+  actions?: string[];
+  /** Reference frame matcher for message_order / message_after. */
+  before?: { action: string; direction?: "sent" | "received" };
+  after?: { action: string; direction?: "sent" | "received" };
+}
+
+/** Outcome of evaluating one {@link AssertionSpec} against a run's transcript. */
+export type AssertionStatus = "passed" | "failed" | "skipped" | "blocked";
+
+export interface AssertionResult {
+  id: string;
+  type: AssertionType;
+  status: AssertionStatus;
+  description: string;
+  /** Explanation of what was/wasn't found; set on failure. */
+  detail?: string;
+}
+
+/** Overall pass/fail verdict for one scenario run, rolled up from its
+ *  {@link AssertionResult}s (see `computeVerdict`). */
+export type ScenarioVerdict = "PASS" | "FAIL" | "BLOCKED" | "SKIPPED";
 
 /**
  * Minimal runtime shape check for a value read from an operator-supplied

--- a/src/cp/application/verification/ScenarioAssertions.ts
+++ b/src/cp/application/verification/ScenarioAssertions.ts
@@ -1,0 +1,483 @@
+/**
+ * ScenarioAssertions.ts -- declarative assertion engine for scenario runs
+ * (#179 Phase 2b). Evaluates a scenario's `AssertionSpec[]`
+ * (src/cp/application/scenario/ScenarioTypes.ts) against the OCPP wire
+ * `Frame[]` captured for one run (see TranscriptBuffer) and rolls the
+ * per-assertion results up into an overall {@link ScenarioVerdict}.
+ *
+ * Mirrors assert.ts's check semantics (uniqueId-correlated response
+ * matching via findResponseFor, occurrence-indexed findCall, ...) but
+ * returns a result per spec instead of pushing into an AssertRecorder --
+ * a scenario run has no interactive test-runner context to record into,
+ * and Phase 3 wants a serializable per-run report.
+ */
+
+import {
+  findAllCalls,
+  findCall,
+  findResponseFor,
+  type Direction,
+  type Frame,
+} from "./ocpp";
+import type {
+  AssertionResult,
+  AssertionSpec,
+  AssertionStatus,
+  ScenarioVerdict,
+} from "../scenario/ScenarioTypes";
+
+/**
+ * Deep partial match used by `payload_match`: every key in `subset` must be
+ * present in `actual` with a deep-equal value. Objects are matched as a
+ * subset (extra keys in `actual` are ignored); arrays are compared
+ * element-by-element and must be the same length -- an assertion author
+ * pinning an array generally means the whole array, not just a prefix.
+ */
+function deepPartialMatch(subset: unknown, actual: unknown): boolean {
+  if (subset === actual) return true;
+  if (
+    typeof subset !== "object" ||
+    subset === null ||
+    typeof actual !== "object" ||
+    actual === null
+  ) {
+    return false;
+  }
+  if (Array.isArray(subset)) {
+    if (!Array.isArray(actual) || subset.length !== actual.length) {
+      return false;
+    }
+    return subset.every((item, i) => deepPartialMatch(item, actual[i]));
+  }
+  if (Array.isArray(actual)) return false;
+  const subsetObj = subset as Record<string, unknown>;
+  const actualObj = actual as Record<string, unknown>;
+  return Object.keys(subsetObj).every((key) =>
+    deepPartialMatch(subsetObj[key], actualObj[key]),
+  );
+}
+
+/** A frame "matches" a message_order/message_after reference when it's a
+ *  CALL for the given action in the given direction (default "sent"). */
+function matchesFrameRef(
+  frame: Frame,
+  ref: { action: string; direction?: Direction },
+): boolean {
+  return (
+    frame.kind === "call" &&
+    frame.action === ref.action &&
+    frame.direction === (ref.direction ?? "sent")
+  );
+}
+
+function makeResult(
+  spec: AssertionSpec,
+  status: AssertionStatus,
+  defaultDescription: string,
+  detail?: string,
+): AssertionResult {
+  return {
+    id: spec.id,
+    type: spec.type,
+    status,
+    description: spec.description ?? defaultDescription,
+    detail,
+  };
+}
+
+/** Shared implementation for `response_status` / `idtag_info_status`:
+ *  find the `occurrence`-th CALL for `action` in `direction`, its response
+ *  paired by OCPP-J uniqueId, and check the status at `statusPath`. */
+function evaluateResponseStatus(
+  spec: AssertionSpec,
+  frames: readonly Frame[],
+  action: string,
+  expectedStatus: string,
+  direction: Direction,
+  occurrence: number,
+  statusPath: "status" | "idTagInfo.status",
+): AssertionResult {
+  const description =
+    statusPath === "status"
+      ? `${action} -> status ${expectedStatus}`
+      : `${action} -> idTagInfo.status ${expectedStatus}`;
+
+  const call = findCall(frames, direction, action, occurrence);
+  if (!call) {
+    return makeResult(
+      spec,
+      "failed",
+      description,
+      `no ${direction} CALL found for action=${action} (occurrence ${occurrence})`,
+    );
+  }
+  const response = findResponseFor(frames, call);
+  if (!response) {
+    return makeResult(
+      spec,
+      "failed",
+      description,
+      `no response frame found for uniqueId=${call.uniqueId} (${action})`,
+    );
+  }
+  if (response.kind === "callerror") {
+    return makeResult(
+      spec,
+      "failed",
+      description,
+      `expected CALLRESULT, got CALLERROR ${response.errorCode}: ${response.errorDescription}`,
+    );
+  }
+
+  const actualStatus =
+    statusPath === "status"
+      ? (response.payload as { status?: unknown } | null)?.status
+      : (response.payload as { idTagInfo?: { status?: unknown } } | null)
+          ?.idTagInfo?.status;
+  if (actualStatus === expectedStatus) {
+    return makeResult(spec, "passed", description);
+  }
+  return makeResult(
+    spec,
+    "failed",
+    description,
+    `expected ${statusPath}=${expectedStatus}, got ${statusPath}=${String(actualStatus)} (uniqueId=${call.uniqueId})`,
+  );
+}
+
+/** Evaluates a single {@link AssertionSpec}. A malformed spec (missing a
+ *  field its `type` requires) never throws -- it resolves to a "failed"
+ *  result with an explanatory detail, since a scenario JSON hand-edited by
+ *  an operator is untrusted input. */
+function evaluateOne(
+  spec: AssertionSpec,
+  frames: readonly Frame[],
+): AssertionResult {
+  const fallbackDescription = spec.description ?? `assertion ${spec.id}`;
+
+  switch (spec.type) {
+    case "ocpp_sent": {
+      if (!spec.action) {
+        return makeResult(
+          spec,
+          "failed",
+          fallbackDescription,
+          "ocpp_sent requires 'action'",
+        );
+      }
+      const description = `${spec.action}.req sent`;
+      const call = findCall(frames, "sent", spec.action);
+      return call
+        ? makeResult(spec, "passed", description)
+        : makeResult(
+            spec,
+            "failed",
+            description,
+            `no Sent CALL found for action=${spec.action}`,
+          );
+    }
+
+    case "ocpp_received": {
+      if (!spec.action) {
+        return makeResult(
+          spec,
+          "failed",
+          fallbackDescription,
+          "ocpp_received requires 'action'",
+        );
+      }
+      const description = `${spec.action}.req received`;
+      const call = findCall(frames, "received", spec.action);
+      return call
+        ? makeResult(spec, "passed", description)
+        : makeResult(
+            spec,
+            "failed",
+            description,
+            `no Received CALL found for action=${spec.action}`,
+          );
+    }
+
+    case "ocpp_absent": {
+      if (!spec.action) {
+        return makeResult(
+          spec,
+          "failed",
+          fallbackDescription,
+          "ocpp_absent requires 'action'",
+        );
+      }
+      const direction = spec.direction ?? "sent";
+      const description = `no ${spec.action} ${direction}`;
+      const call = findCall(frames, direction, spec.action);
+      return call
+        ? makeResult(
+            spec,
+            "failed",
+            description,
+            `unexpected ${direction} CALL found: ${call.raw}`,
+          )
+        : makeResult(spec, "passed", description);
+    }
+
+    case "response_status": {
+      if (!spec.action || !spec.status) {
+        return makeResult(
+          spec,
+          "failed",
+          fallbackDescription,
+          "response_status requires 'action' and 'status'",
+        );
+      }
+      return evaluateResponseStatus(
+        spec,
+        frames,
+        spec.action,
+        spec.status,
+        spec.direction ?? "received",
+        spec.occurrence ?? 0,
+        "status",
+      );
+    }
+
+    case "idtag_info_status": {
+      if (!spec.action || !spec.status) {
+        return makeResult(
+          spec,
+          "failed",
+          fallbackDescription,
+          "idtag_info_status requires 'action' and 'status'",
+        );
+      }
+      return evaluateResponseStatus(
+        spec,
+        frames,
+        spec.action,
+        spec.status,
+        spec.direction ?? "sent",
+        spec.occurrence ?? 0,
+        "idTagInfo.status",
+      );
+    }
+
+    case "payload_match": {
+      if (!spec.action || !spec.payload) {
+        return makeResult(
+          spec,
+          "failed",
+          fallbackDescription,
+          "payload_match requires 'action' and 'payload'",
+        );
+      }
+      const direction = spec.direction ?? "sent";
+      const occurrence = spec.occurrence ?? 0;
+      const description = `${spec.action} payload matches`;
+      const call = findCall(frames, direction, spec.action, occurrence);
+      if (!call) {
+        return makeResult(
+          spec,
+          "failed",
+          description,
+          `no ${direction} CALL found for action=${spec.action} (occurrence ${occurrence})`,
+        );
+      }
+      return deepPartialMatch(spec.payload, call.payload)
+        ? makeResult(spec, "passed", description)
+        : makeResult(
+            spec,
+            "failed",
+            description,
+            `payload for ${spec.action} (uniqueId=${call.uniqueId}) did not match expected subset`,
+          );
+    }
+
+    case "message_order": {
+      if (!spec.before || !spec.after) {
+        return makeResult(
+          spec,
+          "failed",
+          fallbackDescription,
+          "message_order requires 'before' and 'after'",
+        );
+      }
+      const { before, after } = spec;
+      const description = `${before.action} before ${after.action}`;
+      const beforeIndex = frames.findIndex((f) => matchesFrameRef(f, before));
+      const afterIndex = frames.findIndex((f) => matchesFrameRef(f, after));
+      if (beforeIndex === -1 || afterIndex === -1) {
+        return makeResult(
+          spec,
+          "failed",
+          description,
+          `one or both frames not found (before=${before.action} found=${beforeIndex !== -1}, after=${after.action} found=${afterIndex !== -1})`,
+        );
+      }
+      return beforeIndex < afterIndex
+        ? makeResult(spec, "passed", description)
+        : makeResult(
+            spec,
+            "failed",
+            description,
+            `before (frame ${beforeIndex}) did not precede after (frame ${afterIndex})`,
+          );
+    }
+
+    case "message_after": {
+      if (!spec.before || !spec.after) {
+        return makeResult(
+          spec,
+          "failed",
+          fallbackDescription,
+          "message_after requires 'before' and 'after'",
+        );
+      }
+      const { before, after } = spec;
+      const description = `${after.action} after ${before.action}`;
+      let lastBeforeIndex = -1;
+      frames.forEach((f, i) => {
+        if (matchesFrameRef(f, before)) lastBeforeIndex = i;
+      });
+      if (lastBeforeIndex === -1) {
+        return makeResult(
+          spec,
+          "failed",
+          description,
+          `reference frame not found: ${before.action}`,
+        );
+      }
+      const found = frames
+        .slice(lastBeforeIndex + 1)
+        .some((f) => matchesFrameRef(f, after));
+      return found
+        ? makeResult(spec, "passed", description)
+        : makeResult(
+            spec,
+            "failed",
+            description,
+            `${after.action} not found after frame ${lastBeforeIndex} (${before.action})`,
+          );
+    }
+
+    case "state_transition": {
+      if (!spec.targetStatus) {
+        return makeResult(
+          spec,
+          "failed",
+          fallbackDescription,
+          "state_transition requires 'targetStatus'",
+        );
+      }
+      const description = `StatusNotification -> ${spec.targetStatus}`;
+      const matched = findAllCalls(frames, "sent", "StatusNotification").some(
+        (f) =>
+          (f.payload as { status?: unknown } | null)?.status ===
+          spec.targetStatus,
+      );
+      return matched
+        ? makeResult(spec, "passed", description)
+        : makeResult(
+            spec,
+            "failed",
+            description,
+            `no sent StatusNotification found with status=${spec.targetStatus}`,
+          );
+    }
+
+    case "no_unexpected": {
+      if (!spec.actions || spec.actions.length === 0) {
+        return makeResult(
+          spec,
+          "failed",
+          fallbackDescription,
+          "no_unexpected requires a non-empty 'actions' list",
+        );
+      }
+      const description = `no unexpected: ${spec.actions.join(", ")}`;
+      const found = spec.actions.filter((action) =>
+        findCall(frames, "sent", action),
+      );
+      return found.length === 0
+        ? makeResult(spec, "passed", description)
+        : makeResult(
+            spec,
+            "failed",
+            description,
+            `unexpected sent CALL(s) found: ${found.join(", ")}`,
+          );
+    }
+
+    default:
+      // Unknown `type` string (e.g. hand-edited scenario JSON from a newer
+      // build) -- fail loudly instead of silently skipping.
+      return makeResult(
+        spec,
+        "failed",
+        fallbackDescription,
+        `unknown assertion type: ${String(spec.type)}`,
+      );
+  }
+}
+
+/** Evaluates every {@link AssertionSpec} against the run's captured
+ *  transcript, one result per spec, in declaration order. */
+export function evaluateAssertions(
+  specs: AssertionSpec[],
+  frames: readonly Frame[],
+): AssertionResult[] {
+  return specs.map((spec) => evaluateOne(spec, frames));
+}
+
+/**
+ * Minimal per-run report (#179 Phase 2b), stored by CLIChargePointService
+ * once a scenario run ends. Phase 3 expands this into the full
+ * `scenario_report` RPC surface; kept intentionally small here -- just
+ * enough for `getScenarioRunResult` to answer "did this run pass".
+ */
+export interface ScenarioRunResult {
+  runId: string;
+  scenarioId: string;
+  connectorId: number;
+  verdict: ScenarioVerdict;
+  assertions: AssertionResult[];
+  startedAt: string;
+  endedAt: string;
+  frameCount: number;
+}
+
+export interface ComputeVerdictOptions {
+  /** Whether the scenario run ended normally or via the executor's error
+   *  path. "error" forces a BLOCKED verdict -- an errored run can't be
+   *  trusted to have reached a verifiable state. */
+  executionState: "completed" | "error";
+  /** True when the run was stopped while parked on a waiting node (a
+   *  timeout or a manual stop mid-wait) rather than reaching `end`
+   *  naturally. Also forces BLOCKED. */
+  blocked?: boolean;
+}
+
+/**
+ * Rolls a run's per-assertion results up into one {@link ScenarioVerdict}:
+ *
+ * 1. SKIPPED -- no assertions were declared, or every declared assertion
+ *    resolved to "skipped".
+ * 2. BLOCKED -- the run errored or was blocked (outranks FAIL: a run that
+ *    never reached a verifiable state shouldn't be reported as a clean
+ *    failure).
+ * 3. FAIL -- at least one assertion failed.
+ * 4. PASS -- every assertion passed.
+ */
+export function computeVerdict(
+  results: AssertionResult[],
+  opts: ComputeVerdictOptions,
+): ScenarioVerdict {
+  if (results.length === 0 || results.every((r) => r.status === "skipped")) {
+    return "SKIPPED";
+  }
+  if (opts.executionState === "error" || opts.blocked === true) {
+    return "BLOCKED";
+  }
+  if (results.some((r) => r.status === "failed")) {
+    return "FAIL";
+  }
+  return "PASS";
+}

--- a/src/cp/application/verification/TranscriptBuffer.ts
+++ b/src/cp/application/verification/TranscriptBuffer.ts
@@ -1,0 +1,77 @@
+/**
+ * TranscriptBuffer.ts -- captures the OCPP wire transcript of one scenario
+ * run (#179 Phase 2b) by subscribing to a ChargePoint's Logger for its
+ * WebSocket-typed log entries and parsing each into a {@link Frame} (see
+ * ocpp.ts). ScenarioAssertions.evaluateAssertions evaluates a scenario's
+ * declared assertions against `frames` once the run ends.
+ */
+
+import { LogType } from "../../shared/Logger";
+import type { Logger, LogEntry } from "../../shared/Logger";
+import { parseFrameMessage, type Frame } from "./ocpp";
+
+/**
+ * A captured {@link Frame} plus its position in this buffer's capture
+ * order. `Frame` is a discriminated union (CallFrame | CallResultFrame |
+ * CallErrorFrame), so this is a type intersection rather than an
+ * `interface extends` -- TypeScript interfaces cannot extend a union type.
+ */
+export type TranscriptFrame = Frame & { seq: number };
+
+/**
+ * Subscribes to a Logger's WebSocket log entries for the lifetime of one
+ * scenario run and accumulates every Sent:/Received: frame it can parse,
+ * in capture order. Non-frame WebSocket log entries (connection status,
+ * parse-error warnings, ...) are silently skipped -- parseFrameMessage
+ * returns null for them.
+ */
+export class TranscriptBuffer {
+  private readonly _logger: Logger;
+  private readonly _frames: TranscriptFrame[] = [];
+  private _seq = 0;
+  private _unsubscribe: (() => void) | null = null;
+
+  constructor(logger: Logger) {
+    this._logger = logger;
+  }
+
+  /**
+   * Subscribes to the logger's WebSocket-typed log stream. Idempotent --
+   * calling start() while already started is a no-op (won't double
+   * subscribe and double-count frames).
+   */
+  start(): void {
+    if (this._unsubscribe) return;
+    // Logger.on returns its own unsubscribe closure (wraps
+    // emitter.off(event, listener) internally), so capturing that is the
+    // cleanest way to unsubscribe cleanly in stop() without holding a
+    // separate reference to the listener function ourselves.
+    this._unsubscribe = this._logger.on(
+      `log.${LogType.WEBSOCKET}`,
+      (entry: LogEntry) => {
+        const frame = parseFrameMessage(
+          entry.message,
+          entry.timestamp.toISOString(),
+        );
+        if (frame) {
+          this._frames.push({ ...frame, seq: this._seq });
+          this._seq += 1;
+        }
+      },
+    );
+  }
+
+  /** Unsubscribes from the logger. Safe to call multiple times, or before
+   *  start() has ever been called. */
+  stop(): void {
+    if (this._unsubscribe) {
+      this._unsubscribe();
+      this._unsubscribe = null;
+    }
+  }
+
+  /** Captured frames, in capture order. */
+  get frames(): readonly Frame[] {
+    return this._frames;
+  }
+}

--- a/src/cp/application/verification/__tests__/ScenarioAssertions.test.ts
+++ b/src/cp/application/verification/__tests__/ScenarioAssertions.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect } from "vitest";
+import { evaluateAssertions, computeVerdict } from "../ScenarioAssertions";
+import type { CallFrame, CallResultFrame, Frame } from "../ocpp";
+import type {
+  AssertionResult,
+  AssertionSpec,
+} from "../../scenario/ScenarioTypes";
+
+/** Builds a synthetic wire transcript covering every assertion type this
+ *  module supports, in a plausible OCPP wire order:
+ *
+ *   0. sent    CALL       BootNotification
+ *   1. received CALLRESULT (Accepted)                       -- answers 0
+ *   2. sent    CALL       StatusNotification (Preparing)
+ *   3. received CALL      RemoteStartTransaction
+ *   4. sent    CALLRESULT (Accepted)                        -- answers 3
+ *   5. sent    CALL       StatusNotification (Charging)
+ *   6. sent    CALL       StartTransaction
+ *   7. received CALLRESULT (idTagInfo.status Accepted)      -- answers 6
+ *   8. sent    CALL       MeterValues
+ */
+function call(
+  direction: "sent" | "received",
+  uniqueId: string,
+  action: string,
+  payload: unknown,
+): CallFrame {
+  return {
+    kind: "call",
+    direction,
+    uniqueId,
+    action,
+    payload,
+    timestamp: "2026-07-13T00:00:00.000Z",
+    raw: `${direction === "sent" ? "Sent" : "Received"}: [2,"${uniqueId}","${action}",...]`,
+  };
+}
+
+function result(
+  direction: "sent" | "received",
+  uniqueId: string,
+  payload: unknown,
+): CallResultFrame {
+  return {
+    kind: "callresult",
+    direction,
+    uniqueId,
+    payload,
+    timestamp: "2026-07-13T00:00:01.000Z",
+    raw: `${direction === "sent" ? "Sent" : "Received"}: [3,"${uniqueId}",...]`,
+  };
+}
+
+function buildTranscript(): Frame[] {
+  return [
+    call("sent", "b1", "BootNotification", { chargePointVendor: "V" }), // 0
+    result("received", "b1", { status: "Accepted" }), // 1
+    call("sent", "s1", "StatusNotification", {
+      connectorId: 1,
+      status: "Preparing",
+    }), // 2
+    call("received", "r1", "RemoteStartTransaction", {
+      connectorId: 1,
+      idTag: "TAG1",
+    }), // 3
+    result("sent", "r1", { status: "Accepted" }), // 4
+    call("sent", "s2", "StatusNotification", {
+      connectorId: 1,
+      status: "Charging",
+    }), // 5
+    call("sent", "st1", "StartTransaction", {
+      connectorId: 1,
+      idTag: "TAG1",
+      meterStart: 0,
+    }), // 6
+    result("received", "st1", {
+      idTagInfo: { status: "Accepted" },
+      transactionId: 1,
+    }), // 7
+    call("sent", "mv1", "MeterValues", { connectorId: 1, transactionId: 1 }), // 8
+  ];
+}
+
+function evalOne(
+  spec: AssertionSpec,
+  frames: Frame[] = buildTranscript(),
+): AssertionResult {
+  const [r] = evaluateAssertions([spec], frames);
+  return r;
+}
+
+describe("evaluateAssertions", () => {
+  it("ocpp_sent: passes when the action was sent, fails otherwise", () => {
+    expect(
+      evalOne({ id: "a1", type: "ocpp_sent", action: "BootNotification" })
+        .status,
+    ).toBe("passed");
+    expect(
+      evalOne({ id: "a2", type: "ocpp_sent", action: "Reset" }).status,
+    ).toBe("failed");
+  });
+
+  it("ocpp_sent: malformed (missing action) fails with a detail, not a throw", () => {
+    const r = evalOne({ id: "a3", type: "ocpp_sent" });
+    expect(r.status).toBe("failed");
+    expect(r.detail).toMatch(/requires 'action'/);
+  });
+
+  it("ocpp_received: passes when the action was received, fails otherwise", () => {
+    expect(
+      evalOne({
+        id: "b1",
+        type: "ocpp_received",
+        action: "RemoteStartTransaction",
+      }).status,
+    ).toBe("passed");
+    expect(
+      evalOne({ id: "b2", type: "ocpp_received", action: "ReserveNow" }).status,
+    ).toBe("failed");
+  });
+
+  it("ocpp_absent: passes when the action was never sent (default direction), fails when it was", () => {
+    expect(
+      evalOne({ id: "c1", type: "ocpp_absent", action: "Reset" }).status,
+    ).toBe("passed");
+    expect(
+      evalOne({ id: "c2", type: "ocpp_absent", action: "StatusNotification" })
+        .status,
+    ).toBe("failed");
+  });
+
+  it("ocpp_absent: respects an explicit direction", () => {
+    // RemoteStartTransaction was received, not sent -- absent on "sent" passes.
+    expect(
+      evalOne({
+        id: "c3",
+        type: "ocpp_absent",
+        action: "RemoteStartTransaction",
+        direction: "sent",
+      }).status,
+    ).toBe("passed");
+  });
+
+  it("response_status: default direction 'received', pairs the CALLRESULT by uniqueId", () => {
+    expect(
+      evalOne({
+        id: "d1",
+        type: "response_status",
+        action: "RemoteStartTransaction",
+        status: "Accepted",
+      }).status,
+    ).toBe("passed");
+    const failing = evalOne({
+      id: "d2",
+      type: "response_status",
+      action: "RemoteStartTransaction",
+      status: "Rejected",
+    });
+    expect(failing.status).toBe("failed");
+    expect(failing.detail).toMatch(/expected status=Rejected/);
+  });
+
+  it("response_status: malformed (missing status) fails with a detail", () => {
+    const r = evalOne({
+      id: "d3",
+      type: "response_status",
+      action: "RemoteStartTransaction",
+    });
+    expect(r.status).toBe("failed");
+    expect(r.detail).toMatch(/requires 'action' and 'status'/);
+  });
+
+  it("idtag_info_status: default direction 'sent', checks payload.idTagInfo.status", () => {
+    expect(
+      evalOne({
+        id: "e1",
+        type: "idtag_info_status",
+        action: "StartTransaction",
+        status: "Accepted",
+      }).status,
+    ).toBe("passed");
+    expect(
+      evalOne({
+        id: "e2",
+        type: "idtag_info_status",
+        action: "StartTransaction",
+        status: "Invalid",
+      }).status,
+    ).toBe("failed");
+  });
+
+  it("payload_match: passes on a deep-partial subset match, fails on mismatch", () => {
+    expect(
+      evalOne({
+        id: "f1",
+        type: "payload_match",
+        action: "RemoteStartTransaction",
+        direction: "received",
+        payload: { idTag: "TAG1" },
+      }).status,
+    ).toBe("passed");
+    expect(
+      evalOne({
+        id: "f2",
+        type: "payload_match",
+        action: "RemoteStartTransaction",
+        direction: "received",
+        payload: { idTag: "WRONG" },
+      }).status,
+    ).toBe("failed");
+  });
+
+  it("payload_match: malformed (missing payload) fails with a detail", () => {
+    const r = evalOne({
+      id: "f3",
+      type: "payload_match",
+      action: "RemoteStartTransaction",
+      direction: "received",
+    });
+    expect(r.status).toBe("failed");
+    expect(r.detail).toMatch(/requires 'action' and 'payload'/);
+  });
+
+  it("message_order: passes iff the first 'before' match precedes the first 'after' match", () => {
+    expect(
+      evalOne({
+        id: "g1",
+        type: "message_order",
+        before: { action: "StatusNotification" },
+        after: { action: "StartTransaction" },
+      }).status,
+    ).toBe("passed");
+    expect(
+      evalOne({
+        id: "g2",
+        type: "message_order",
+        before: { action: "StartTransaction" },
+        after: { action: "BootNotification" },
+      }).status,
+    ).toBe("failed");
+  });
+
+  it("message_order: malformed (missing before/after) fails with a detail", () => {
+    const r = evalOne({ id: "g3", type: "message_order" });
+    expect(r.status).toBe("failed");
+    expect(r.detail).toMatch(/requires 'before' and 'after'/);
+  });
+
+  it("message_after: passes iff an 'after' match occurs strictly after the LAST 'before' match", () => {
+    expect(
+      evalOne({
+        id: "h1",
+        type: "message_after",
+        before: { action: "RemoteStartTransaction", direction: "received" },
+        after: { action: "StartTransaction" },
+      }).status,
+    ).toBe("passed");
+    // BootNotification (index 0) is before RemoteStartTransaction (index 3),
+    // so it can never satisfy "after".
+    expect(
+      evalOne({
+        id: "h2",
+        type: "message_after",
+        before: { action: "RemoteStartTransaction", direction: "received" },
+        after: { action: "BootNotification" },
+      }).status,
+    ).toBe("failed");
+  });
+
+  it("state_transition: passes iff a sent StatusNotification with the target status exists", () => {
+    expect(
+      evalOne({ id: "i1", type: "state_transition", targetStatus: "Charging" })
+        .status,
+    ).toBe("passed");
+    expect(
+      evalOne({ id: "i2", type: "state_transition", targetStatus: "Faulted" })
+        .status,
+    ).toBe("failed");
+  });
+
+  it("no_unexpected: passes iff none of the listed actions were sent", () => {
+    expect(
+      evalOne({
+        id: "j1",
+        type: "no_unexpected",
+        actions: ["Reset", "UpdateFirmware"],
+      }).status,
+    ).toBe("passed");
+    const failing = evalOne({
+      id: "j2",
+      type: "no_unexpected",
+      actions: ["StatusNotification", "Reset"],
+    });
+    expect(failing.status).toBe("failed");
+    expect(failing.detail).toMatch(/StatusNotification/);
+  });
+
+  it("no_unexpected: malformed (empty actions) fails with a detail", () => {
+    const r = evalOne({ id: "j3", type: "no_unexpected", actions: [] });
+    expect(r.status).toBe("failed");
+    expect(r.detail).toMatch(/non-empty 'actions'/);
+  });
+
+  it("evaluates every spec, one result per spec, in declaration order", () => {
+    const specs: AssertionSpec[] = [
+      { id: "k1", type: "ocpp_sent", action: "BootNotification" },
+      { id: "k2", type: "state_transition", targetStatus: "Charging" },
+      { id: "k3", type: "ocpp_sent", action: "NeverSent" },
+    ];
+    const results = evaluateAssertions(specs, buildTranscript());
+    expect(results.map((r) => r.id)).toEqual(["k1", "k2", "k3"]);
+    expect(results.map((r) => r.status)).toEqual([
+      "passed",
+      "passed",
+      "failed",
+    ]);
+  });
+
+  it("uses spec.description when provided instead of the default", () => {
+    const r = evalOne({
+      id: "l1",
+      type: "ocpp_sent",
+      action: "BootNotification",
+      description: "boot happened",
+    });
+    expect(r.description).toBe("boot happened");
+  });
+});
+
+describe("computeVerdict", () => {
+  const passed: AssertionResult = {
+    id: "p",
+    type: "ocpp_sent",
+    status: "passed",
+    description: "p",
+  };
+  const failed: AssertionResult = {
+    id: "f",
+    type: "ocpp_sent",
+    status: "failed",
+    description: "f",
+  };
+  const skipped: AssertionResult = {
+    id: "s",
+    type: "ocpp_sent",
+    status: "skipped",
+    description: "s",
+  };
+
+  it("SKIPPED when there are no results", () => {
+    expect(computeVerdict([], { executionState: "completed" })).toBe("SKIPPED");
+  });
+
+  it("SKIPPED when every result is skipped", () => {
+    expect(
+      computeVerdict([skipped, skipped], { executionState: "completed" }),
+    ).toBe("SKIPPED");
+  });
+
+  it("PASS when every result passed", () => {
+    expect(
+      computeVerdict([passed, passed], { executionState: "completed" }),
+    ).toBe("PASS");
+  });
+
+  it("FAIL when at least one result failed", () => {
+    expect(
+      computeVerdict([passed, failed], { executionState: "completed" }),
+    ).toBe("FAIL");
+  });
+
+  it("BLOCKED on an errored execution, outranking a failure", () => {
+    expect(computeVerdict([passed, failed], { executionState: "error" })).toBe(
+      "BLOCKED",
+    );
+  });
+
+  it("BLOCKED when opts.blocked is true, even with otherwise-passing results", () => {
+    expect(
+      computeVerdict([passed, passed], {
+        executionState: "completed",
+        blocked: true,
+      }),
+    ).toBe("BLOCKED");
+  });
+});

--- a/src/cp/application/verification/__tests__/ocpp.test.ts
+++ b/src/cp/application/verification/__tests__/ocpp.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { parseFrameMessage, parseLogLine } from "../ocpp";
+
+describe("parseFrameMessage", () => {
+  it("parses a Sent CALL message, raw defaulting to the message itself", () => {
+    const frame = parseFrameMessage(
+      'Sent: [2,"uid-1","BootNotification",{"chargePointVendor":"V"}]',
+      "2026-07-13T00:00:00.000Z",
+    );
+    expect(frame).toEqual({
+      kind: "call",
+      direction: "sent",
+      uniqueId: "uid-1",
+      action: "BootNotification",
+      payload: { chargePointVendor: "V" },
+      timestamp: "2026-07-13T00:00:00.000Z",
+      raw: 'Sent: [2,"uid-1","BootNotification",{"chargePointVendor":"V"}]',
+    });
+  });
+
+  it("parses a Received CALLRESULT message", () => {
+    const frame = parseFrameMessage(
+      'Received: [3,"uid-1",{"status":"Accepted"}]',
+      "2026-07-13T00:00:01.000Z",
+    );
+    expect(frame).toEqual({
+      kind: "callresult",
+      direction: "received",
+      uniqueId: "uid-1",
+      payload: { status: "Accepted" },
+      timestamp: "2026-07-13T00:00:01.000Z",
+      raw: 'Received: [3,"uid-1",{"status":"Accepted"}]',
+    });
+  });
+
+  it("returns null for a non-frame message", () => {
+    expect(
+      parseFrameMessage("WebSocket connected successfully", "ts"),
+    ).toBeNull();
+  });
+
+  it("accepts an explicit `raw` distinct from the parsed message", () => {
+    // TranscriptBuffer's use case: it only has entry.message (the bare
+    // "Sent:/Received: [...]" text, no log-line prefix), so `raw` there
+    // equals `message`. But callers with the full formatted line (like
+    // parseLogLine below) can pass a different `raw`.
+    const frame = parseFrameMessage(
+      'Sent: [2,"uid-2","Heartbeat",{}]',
+      "ts",
+      '[ts] [INFO] [WebSocket] Sent: [2,"uid-2","Heartbeat",{}]',
+    );
+    expect(frame?.raw).toBe(
+      '[ts] [INFO] [WebSocket] Sent: [2,"uid-2","Heartbeat",{}]',
+    );
+  });
+
+  it("parseLogLine delegates to parseFrameMessage with raw = the full line", () => {
+    const line =
+      '[2026-07-13T00:00:00.000Z] [INFO] [WebSocket] Sent: [2,"uid-3","Heartbeat",{}]';
+    const viaLogLine = parseLogLine(line);
+    const viaFrameMessage = parseFrameMessage(
+      'Sent: [2,"uid-3","Heartbeat",{}]',
+      "2026-07-13T00:00:00.000Z",
+      line,
+    );
+    expect(viaLogLine).toEqual(viaFrameMessage);
+    expect(viaLogLine?.raw).toBe(line);
+  });
+});

--- a/src/cp/application/verification/ocpp.ts
+++ b/src/cp/application/verification/ocpp.ts
@@ -64,17 +64,20 @@ const LOG_LINE_RE = /^\[([^\]]+)\]\s+\[[^\]]+\]\s+\[[^\]]+\]\s+(.*)$/;
 const FRAME_MESSAGE_RE = /^(Sent|Received):\s+(\[.*\])\s*$/;
 
 /**
- * Parses a single stdout line from the simulator CLI into a {@link Frame},
- * or returns null for anything that isn't an OCPP-J Sent/Received line
- * (structured JSON events, JSON command responses, other log lines, blank
- * lines).
+ * Parses just the `Sent:/Received: [...]` frame message half (no log-line
+ * prefix) into a {@link Frame}. `raw` is what ends up in the returned
+ * frame's `raw` field -- callers that only have the bare message (e.g.
+ * {@link TranscriptBuffer}, which subscribes to structured {@link LogEntry}s
+ * rather than formatted lines) can pass it explicitly; it defaults to
+ * `message` itself. {@link parseLogLine} passes the full formatted line so
+ * its frames' `raw` stays the whole line, matching prior behavior.
  */
-export function parseLogLine(line: string): Frame | null {
-  const lineMatch = LOG_LINE_RE.exec(line);
-  if (!lineMatch) return null;
-  const [, timestamp, rest] = lineMatch;
-
-  const frameMatch = FRAME_MESSAGE_RE.exec(rest);
+export function parseFrameMessage(
+  message: string,
+  timestamp: string,
+  raw: string = message,
+): Frame | null {
+  const frameMatch = FRAME_MESSAGE_RE.exec(message);
   if (!frameMatch) return null;
   const direction: Direction = frameMatch[1] === "Sent" ? "sent" : "received";
 
@@ -100,7 +103,7 @@ export function parseLogLine(line: string): Frame | null {
         action: parsed[2],
         payload: parsed[3],
         timestamp,
-        raw: line,
+        raw,
       };
     }
     case 3: {
@@ -111,7 +114,7 @@ export function parseLogLine(line: string): Frame | null {
         uniqueId,
         payload: parsed[2],
         timestamp,
-        raw: line,
+        raw,
       };
     }
     case 4: {
@@ -124,12 +127,25 @@ export function parseLogLine(line: string): Frame | null {
         errorDescription: String(parsed[3] ?? ""),
         errorDetails: parsed[4],
         timestamp,
-        raw: line,
+        raw,
       };
     }
     default:
       return null;
   }
+}
+
+/**
+ * Parses a single stdout line from the simulator CLI into a {@link Frame},
+ * or returns null for anything that isn't an OCPP-J Sent/Received line
+ * (structured JSON events, JSON command responses, other log lines, blank
+ * lines).
+ */
+export function parseLogLine(line: string): Frame | null {
+  const lineMatch = LOG_LINE_RE.exec(line);
+  if (!lineMatch) return null;
+  const [, timestamp, rest] = lineMatch;
+  return parseFrameMessage(rest, timestamp, line);
 }
 
 /** Parses a whole multi-line log (or stdout capture), preserving order. */


### PR DESCRIPTION
Phase 2b of #179. Builds on Phase 1 (expectation + runId) and Phase 2a (shared `verification/` module). A scenario can now declare **machine-readable assertions**, and each run gets a **PASS / FAIL / BLOCKED / SKIPPED verdict** computed from the OCPP wire transcript it produced. Still additive — no RPC surface yet (Phase 3 exposes it as `scenario_report`).

## What this adds

### Declarative assertions
`ScenarioDefinition.assertions?: AssertionSpec[]` (optional). Ten assertion types:

| Type | Meaning |
|---|---|
| `ocpp_sent` / `ocpp_received` | a CALL for `action` was sent / received |
| `ocpp_absent` | no CALL for `action` in `direction` |
| `response_status` | the (uniqueId-paired) response to `action` has `status` |
| `idtag_info_status` | the response's `idTagInfo.status` equals `status` |
| `payload_match` | a CALL's payload is a superset of `payload` (deep partial) |
| `message_order` | first `before` frame precedes first `after` frame |
| `message_after` | an `after` frame occurs strictly after the last `before` frame |
| `state_transition` | a sent `StatusNotification(targetStatus)` exists |
| `no_unexpected` | none of `actions` were sent |

The engine (`ScenarioAssertions.evaluateAssertions`) reuses the shared `ocpp.ts` frame helpers (`findCall`, `findResponseFor`, `findAllCalls`) promoted in Phase 2a, so it mirrors `assert.ts` semantics exactly (uniqueId-correlated response matching, occurrence indexing, CALLERROR = failure) — one semantics for both the in-sim engine and the CI harness. Malformed/unknown specs resolve to a `failed` result with an explanatory detail rather than throwing (scenario JSON is untrusted input).

### Verdict
`computeVerdict` rolls the per-assertion results up: **SKIPPED** (no assertions declared / all skipped) → **BLOCKED** (run errored, or was stopped while parked on a waiting node — couldn't reach a verifiable state; outranks FAIL) → **FAIL** (any assertion failed) → **PASS**.

### Per-run transcript
`TranscriptBuffer` captures a run's frames by subscribing to the CP Logger's WebSocket entries and parsing each via the new `ocpp.parseFrameMessage` (extracted from `parseLogLine` — `parseLogLine`'s behavior is unchanged, verified by the steve-verify bun suite). Clean unsubscribe via the closure `Logger.on` returns.

### Wiring
`CLIChargePointService` starts a transcript per run, finalizes it on the natural end **and** the stop paths (`finalizeScenarioRun` is idempotent; the stop paths run synchronously ahead of the microtask-deferred `.finally()`), evaluates the verdict, and stores a bounded (20) `ScenarioRunResult` keyed by `runId`. New public accessor `getScenarioRunResult(scenarioId, runId?)` — the only new surface; **no RPC method** (Phase 3). Transcripts are also stopped in `removeScenario`/`cleanup` so a torn-down run never leaks a Logger subscription.

## Tests
- 24 engine cases (one+ per assertion type against synthetic frames, malformed-spec handling, verdict roll-up incl. BLOCKED-outranks-FAIL).
- 5 `parseFrameMessage` cases.
- 5 service-level bun cases proving end-to-end verdict wiring through the real service (absent→PASS, sent-on-unreachable→FAIL, none→SKIPPED, runId resolution).

## Gates
- vitest: **1178/1178**
- `test:bun`: **214/214**
- prettier / eslint: clean; `package-lock.json` untouched
- `tsc -b --noEmit --force`: **486 = 482 baseline + 4**. The +4 are `TS2673` (bun:sqlite `Database` constructor typed private) + `TS2345` (init-options shape) ×2 project-refs, on the new service bun test — the **identical** type-only quirk already carried by `service.scenarioExpectation.bun.test.ts` and `service.scenarioResume.bun.test.ts` (verified: removing the new file returns to exactly 482, and grep shows the same two errors in both existing files). Runtime-fine; not a new behavior regression. A shared bun-test-DB helper to retire this pattern across all three files is a reasonable separate cleanup.

## Scope note
Verdict is computed + stored but not yet surfaced over RPC — that's Phase 3 (`scenario_report`), which consumes `getScenarioRunResult`. A timeout that completes-without-error (vs. via the error path) isn't yet classified BLOCKED; a typed timeout signal from the runtime is a documented Phase-refinement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added declarative assertions for scenario runs, including OCPP message, payload, status, ordering, and state-transition checks.
  - Scenario runs now produce verdicts: PASS, FAIL, BLOCKED, or SKIPPED.
  - Added per-run result retrieval with run IDs, timestamps, assertion outcomes, and captured frame counts.
  - Scenario execution now records OCPP communication transcripts for verification.
  - Added support for safely finalizing and reporting stopped or blocked scenarios.
- **Tests**
  - Added comprehensive coverage for assertion evaluation, verdict calculation, transcript parsing, and run-result lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->