### PR TITLE
feat(scenario): scenario_report RPC — full run report + redacted transcript (#179 phase 3)

### DIFF
--- a/src/cli/__tests__/service.scenarioVerdict.bun.test.ts
+++ b/src/cli/__tests__/service.scenarioVerdict.bun.test.ts
@@ -89,7 +89,12 @@ describe("#179 Phase 2b: declarative assertions + verdict + per-run transcript",
     expect(result!.connectorId).toBe(1);
     expect(result!.verdict).toBe("SKIPPED");
     expect(result!.assertions).toEqual([]);
-    expect(typeof result!.frameCount).toBe("number");
+    // #179 Phase 3: the run result is now the full report.
+    expect(result!.schemaVersion).toBe(1);
+    expect(Array.isArray(result!.transcript)).toBe(true);
+    expect(result!.initialState).toBeDefined();
+    expect(result!.finalState).toBeDefined();
+    expect(typeof result!.durationMs).toBe("number");
     expect(new Date(result!.startedAt).getTime()).toBeLessThanOrEqual(
       new Date(result!.endedAt).getTime(),
     );

--- a/src/cli/jsonMode.ts
+++ b/src/cli/jsonMode.ts
@@ -253,6 +253,14 @@ export async function handleJsonCommand(
       return ops.getScenarioStatus(connectorId, scenarioId);
     }
 
+    case "scenario_report": {
+      const connectorId = requirePositiveInt(params, "connector");
+      const scenarioId = requireString(params, "scenarioId");
+      const runId =
+        params.runId === undefined ? undefined : requireString(params, "runId");
+      return ops.getScenarioReport(connectorId, scenarioId, runId);
+    }
+
     case "get_scenario": {
       const connectorId = requirePositiveInt(params, "connector");
       const scenarioId = requireString(params, "scenarioId");

--- a/src/cli/server/RegistryChargePointService.ts
+++ b/src/cli/server/RegistryChargePointService.ts
@@ -9,6 +9,7 @@ import {
   type ScenarioExecutionContext,
   type ScenarioMode,
 } from "../../cp/application/scenario/ScenarioTypes";
+import type { ScenarioRunResult } from "../../cp/application/verification/ScenarioAssertions";
 import type {
   HistoryOptions,
   StateHistoryEntry,
@@ -580,6 +581,19 @@ export class RegistryChargePointService implements ChargePointService {
     scenarioId: string,
   ): Promise<ScenarioExecutionContext | null> {
     return this.requireService(id).getScenarioStatus(connectorId, scenarioId);
+  }
+
+  async getScenarioReport(
+    id: string,
+    connectorId: number,
+    scenarioId: string,
+    runId?: string,
+  ): Promise<ScenarioRunResult | null> {
+    return this.requireService(id).getScenarioReport(
+      connectorId,
+      scenarioId,
+      runId,
+    );
   }
 
   async getScenario(

--- a/src/cli/server/socketServer.ts
+++ b/src/cli/server/socketServer.ts
@@ -1183,6 +1183,21 @@ async function dispatchFacadeCpCommand(
         ),
       );
     }
+    case "scenario_report": {
+      const id = requireFacadeCpId(cpId);
+      return handled(
+        await runFacadeOperation(() =>
+          chargePointService.getScenarioReport(
+            id,
+            requirePositiveInt(params, "connector"),
+            requireString(params, "scenarioId"),
+            params.runId === undefined
+              ? undefined
+              : requireString(params, "runId"),
+          ),
+        ),
+      );
+    }
     case "get_scenario": {
       const id = requireFacadeCpId(cpId);
       return handled(

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -43,7 +43,10 @@ import {
 import type { EVSettings } from "../cp/domain/connector/EVSettings";
 import { getDefaultEVSettings } from "../cp/domain/connector/EVSettings";
 import type { AutoMeterValueConfig } from "../cp/domain/connector/MeterValueCurve";
-import type { ActiveChargingProfile } from "../cp/domain/connector/Connector";
+import type {
+  ActiveChargingProfile,
+  Connector,
+} from "../cp/domain/connector/Connector";
 import type {
   StateHistoryEntry,
   HistoryOptions,
@@ -53,8 +56,23 @@ import { TranscriptBuffer } from "../cp/application/verification/TranscriptBuffe
 import {
   evaluateAssertions,
   computeVerdict,
+  frameToTranscriptEntry,
+  redactTranscriptEntry,
   type ScenarioRunResult,
+  type ScenarioStateSnapshot,
 } from "../cp/application/verification/ScenarioAssertions";
+import { redactSensitiveText } from "../cp/shared/redaction";
+
+/**
+ * #179 Phase 3: `ScenarioRunResult.simulatorVersion`. The CLI/daemon runs
+ * outside Vite (no `__APP_VERSION__` build-time define -- see
+ * src/vite-env.d.ts, which only covers the browser bundle), and
+ * package.json's own `version` field is unmaintained (pinned "0.0.0"), so
+ * there's no existing source of truth to thread through. A literal here
+ * matches package.json exactly and avoids adding new file-read plumbing
+ * for a field no consumer currently depends on.
+ */
+const SIMULATOR_VERSION = "0.0.0";
 
 export type CLIEvent =
   | { readonly event: "connected"; readonly data: Record<string, never> }
@@ -221,6 +239,19 @@ function makeScenarioRunId(scenarioId: string): string {
   return `${scenarioId}#${Date.now()}-${rand}`;
 }
 
+/**
+ * #179 Phase 3: snapshot a connector's observable state for a run report's
+ * initialState / finalState. Mirrors the fields StateSnapshot already exposes
+ * per connector (status / meter / active transaction id).
+ */
+function connectorStateSnapshot(connector: Connector): ScenarioStateSnapshot {
+  return {
+    connectorStatus: connector.status,
+    meterValue: connector.meterValue,
+    transactionId: connector.transaction?.id ?? null,
+  };
+}
+
 export class CLIChargePointService {
   private readonly _chargePoint: ChargePoint;
   private readonly _soapServer: OCPPSoapServer | null;
@@ -242,10 +273,14 @@ export class CLIChargePointService {
   // run ends, in finalizeScenarioRun.
   private readonly _transcriptByScenario: Map<string, TranscriptBuffer> =
     new Map();
-  // #179 Phase 2b: wall-clock start time (ISO) for the currently-executing
-  // scenario's run, read back by finalizeScenarioRun to build the
-  // ScenarioRunResult.
-  private readonly _runStartedAtByScenario: Map<string, string> = new Map();
+  // #179 Phase 2b/3: wall-clock start time (ISO) + the connector's state
+  // snapshot at that moment, for the currently-executing scenario's run.
+  // Read back by finalizeScenarioRun to build the ScenarioRunResult's
+  // startedAt/initialState fields.
+  private readonly _runStartByScenario: Map<
+    string,
+    { readonly startedAt: string; readonly initialState: ScenarioStateSnapshot }
+  > = new Map();
   // #179 Phase 2b: bounded history of per-run verdicts + assertion results,
   // keyed by runId. Capped so a long-lived daemon doesn't accumulate
   // results forever; recordRunResult evicts the oldest entry past the cap.
@@ -839,7 +874,7 @@ export class CLIChargePointService {
         transcript.stop();
         this._transcriptByScenario.delete(scenarioId);
       }
-      this._runStartedAtByScenario.delete(scenarioId);
+      this._runStartByScenario.delete(scenarioId);
     }
     this._scenarios.delete(scenarioId);
     this._scenarioRepo.deleteOne(this._chargePoint.id, connectorId, scenarioId);
@@ -898,11 +933,19 @@ export class CLIChargePointService {
     const transcript = new TranscriptBuffer(this._chargePoint.logger);
     transcript.start();
     this._transcriptByScenario.set(scenarioId, transcript);
-    this._runStartedAtByScenario.set(scenarioId, new Date().toISOString());
+    // #179 Phase 3: snapshot the connector's state right as the run starts,
+    // for the report's `initialState` field (see finalizeScenarioRun).
+    this._runStartByScenario.set(scenarioId, {
+      startedAt: new Date().toISOString(),
+      initialState: connectorStateSnapshot(connector),
+    });
 
     // Set by the onError hook below; read in executor.start().finally() to
     // decide this run's verdict executionState ("error" vs "completed").
     let hadError = false;
+    // #179 Phase 3: error message(s) seen during this run, redacted, for
+    // the report's `errors` field.
+    const errorMessages: string[] = [];
 
     const callbacks = createScenarioExecutorCallbacks({
       chargePoint: this._chargePoint,
@@ -924,6 +967,7 @@ export class CLIChargePointService {
         },
         onError: (error) => {
           hadError = true;
+          errorMessages.push(redactSensitiveText(error.message));
           this.emit({
             event: "scenario_error",
             data: { connectorId, scenarioId, error: error.message, runId },
@@ -1035,6 +1079,15 @@ export class CLIChargePointService {
         runId,
         hadError ? "error" : "completed",
         false,
+        errorMessages,
+        // #179 Phase 3: the executor clears its parked expectation in the
+        // same `finally` block that lets a node's thrown error propagate
+        // (see ScenarioExecutor.executeSingleNode), so by the time this
+        // callback runs there's no expectation left to report -- best
+        // effort here is "null", not a guess at what the node was waiting
+        // for. The stop-path methods below capture it BEFORE stop()
+        // clears it, which is the case that can be non-null.
+        null,
       );
     });
   }
@@ -1123,30 +1176,63 @@ export class CLIChargePointService {
     runId: string,
     executionState: "completed" | "error",
     blocked: boolean,
+    errors: string[],
+    timeout: { nodeId: string; expectation?: unknown } | null,
   ): void {
     const transcript = this._transcriptByScenario.get(scenarioId);
     if (!transcript) return;
     transcript.stop();
     this._transcriptByScenario.delete(scenarioId);
 
-    const startedAt =
-      this._runStartedAtByScenario.get(scenarioId) ?? new Date().toISOString();
-    this._runStartedAtByScenario.delete(scenarioId);
+    const endedAt = new Date().toISOString();
+    const start = this._runStartByScenario.get(scenarioId);
+    this._runStartByScenario.delete(scenarioId);
+    const startedAt = start?.startedAt ?? endedAt;
+    const initialState: ScenarioStateSnapshot = start?.initialState ?? {
+      connectorStatus: "Unknown",
+      meterValue: 0,
+      transactionId: null,
+    };
 
-    const assertionSpecs =
-      this._scenarios.get(scenarioId)?.definition.assertions ?? [];
+    const definition = this._scenarios.get(scenarioId)?.definition;
+    const assertionSpecs = definition?.assertions ?? [];
     const assertions = evaluateAssertions(assertionSpecs, transcript.frames);
     const verdict = computeVerdict(assertions, { executionState, blocked });
 
+    // #179 Phase 3: flatten + redact the captured transcript before it can
+    // reach a client (payloads carry auth material -- redactTranscriptEntry).
+    const transcriptEntries = transcript.frames.map((frame, i) =>
+      redactTranscriptEntry(frameToTranscriptEntry(frame, i)),
+    );
+
+    const connector = this._chargePoint.connectors.get(connectorId);
+    const finalState: ScenarioStateSnapshot = connector
+      ? connectorStateSnapshot(connector)
+      : initialState;
+
     this.recordRunResult({
+      schemaVersion: 1,
       runId,
       scenarioId,
+      scenarioName: definition?.name,
+      cpId: this._chargePoint.id,
       connectorId,
+      simulatorVersion: SIMULATOR_VERSION,
+      ocppVersion: this._init.ocppVersion ?? "OCPP-1.6J",
+      startedAt,
+      endedAt,
+      durationMs: Math.max(
+        0,
+        new Date(endedAt).getTime() - new Date(startedAt).getTime(),
+      ),
+      executionState,
       verdict,
       assertions,
-      startedAt,
-      endedAt: new Date().toISOString(),
-      frameCount: transcript.frames.length,
+      transcript: transcriptEntries,
+      errors,
+      timeout,
+      initialState,
+      finalState,
     });
   }
 
@@ -1177,7 +1263,17 @@ export class CLIChargePointService {
     // couldn't reach a verifiable state, so its verdict should be BLOCKED
     // rather than a possibly-misleading FAIL/PASS off a truncated
     // transcript.
-    const wasWaiting = executor.getContext().state === "waiting";
+    const ctxBeforeStop = executor.getContext();
+    const wasWaiting = ctxBeforeStop.state === "waiting";
+    // #179 Phase 3: a stop mid-wait is the closest thing to a timeout the
+    // report can attribute — record which node was parked and what it awaited.
+    const timeout =
+      wasWaiting && ctxBeforeStop.currentNodeId
+        ? {
+            nodeId: ctxBeforeStop.currentNodeId,
+            expectation: ctxBeforeStop.expectation,
+          }
+        : null;
     executor.stop();
     this._executors.delete(scenarioId);
     this._runIdByScenario.delete(scenarioId);
@@ -1198,13 +1294,15 @@ export class CLIChargePointService {
     // #179 Phase 2b: finalize now, synchronously, before executor.start()'s
     // own .finally() (deferred to a microtask by the abort machinery) can
     // race it — finalizeScenarioRun's transcript guard makes that later
-    // call a no-op.
+    // call a no-op. A manual stop collects no error message.
     this.finalizeScenarioRun(
       scenarioId,
       connectorId,
       runId,
       "completed",
       wasWaiting,
+      [],
+      timeout,
     );
   }
 
@@ -1214,8 +1312,16 @@ export class CLIChargePointService {
         const executor = this._executors.get(scenarioId);
         if (executor) {
           const runId = this._runIdByScenario.get(scenarioId) ?? "";
-          // #179 Phase 2b: see stopScenario's comment.
-          const wasWaiting = executor.getContext().state === "waiting";
+          // #179 Phase 2b/3: see stopScenario's comment.
+          const ctxBeforeStop = executor.getContext();
+          const wasWaiting = ctxBeforeStop.state === "waiting";
+          const timeout =
+            wasWaiting && ctxBeforeStop.currentNodeId
+              ? {
+                  nodeId: ctxBeforeStop.currentNodeId,
+                  expectation: ctxBeforeStop.expectation,
+                }
+              : null;
           executor.stop();
           this._executors.delete(scenarioId);
           this._runIdByScenario.delete(scenarioId);
@@ -1236,6 +1342,8 @@ export class CLIChargePointService {
             runId,
             "completed",
             wasWaiting,
+            [],
+            timeout,
           );
         }
       }
@@ -1269,7 +1377,7 @@ export class CLIChargePointService {
       transcript.stop();
     }
     this._transcriptByScenario.clear();
-    this._runStartedAtByScenario.clear();
+    this._runStartByScenario.clear();
     this._chargePoint.disconnect();
     this.detachConnectorEventForwarders();
     for (const unsub of this._unsubscribes) {

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -1157,6 +1157,21 @@ export class CLIChargePointService {
   }
 
   /**
+   * #179 Phase 3: the `scenario_report` facade entry point — the full
+   * per-run report (verdict + assertions + transcript + snapshots) for a
+   * finished run, or null if none has finished. `connectorId` is accepted
+   * for facade-signature symmetry; runs are keyed by scenarioId. Omitting
+   * runId returns the latest recorded run.
+   */
+  getScenarioReport(
+    _connectorId: number,
+    scenarioId: string,
+    runId?: string,
+  ): ScenarioRunResult | null {
+    return this.getScenarioRunResult(scenarioId, runId);
+  }
+
+  /**
    * #179 Phase 2b: stop capturing this run's transcript, evaluate the
    * scenario's declared assertions (if any) against it, and store the
    * resulting {@link ScenarioRunResult}. A scenario with no `assertions`

--- a/src/cli/singleCpTarget.ts
+++ b/src/cli/singleCpTarget.ts
@@ -15,6 +15,7 @@ import type {
   ScenarioExecutionContext,
   ScenarioMode,
 } from "../cp/application/scenario/ScenarioTypes";
+import type { ScenarioRunResult } from "../cp/application/verification/ScenarioAssertions";
 import type {
   HistoryOptions,
   StateHistoryEntry,
@@ -92,6 +93,11 @@ export interface SingleCpCommandOps {
     connectorId: number,
     scenarioId: string,
   ): Promise<ScenarioExecutionContext | null>;
+  getScenarioReport(
+    connectorId: number,
+    scenarioId: string,
+    runId?: string,
+  ): Promise<ScenarioRunResult | null>;
   getScenario(
     connectorId: number,
     scenarioId: string,
@@ -243,6 +249,8 @@ function legacyCommandOps(service: CLIChargePointService): SingleCpCommandOps {
     },
     getScenarioStatus: async (connectorId, scenarioId) =>
       service.getScenarioStatus(connectorId, scenarioId),
+    getScenarioReport: async (connectorId, scenarioId, runId) =>
+      service.getScenarioReport(connectorId, scenarioId, runId),
     getScenario: async (connectorId, scenarioId) =>
       service.getScenario(connectorId, scenarioId),
     stopScenario: async (connectorId, scenarioId) => {
@@ -344,6 +352,8 @@ function facadeCommandOps(target: FacadeSingleCpTarget): SingleCpCommandOps {
       }),
     getScenarioStatus: (connectorId, scenarioId) =>
       service.getScenarioStatus(cpId, connectorId, scenarioId),
+    getScenarioReport: (connectorId, scenarioId, runId) =>
+      service.getScenarioReport(cpId, connectorId, scenarioId, runId),
     getScenario: (connectorId, scenarioId) =>
       service.getScenario(cpId, connectorId, scenarioId),
     stopScenario: (connectorId, scenarioId) =>

--- a/src/cp/application/verification/ScenarioAssertions.ts
+++ b/src/cp/application/verification/ScenarioAssertions.ts
@@ -25,6 +25,10 @@ import type {
   AssertionStatus,
   ScenarioVerdict,
 } from "../scenario/ScenarioTypes";
+import {
+  redactSensitiveText,
+  redactSensitiveValue,
+} from "../../shared/redaction";
 
 /**
  * Deep partial match used by `payload_match`: every key in `subset` must be
@@ -428,20 +432,130 @@ export function evaluateAssertions(
 }
 
 /**
- * Minimal per-run report (#179 Phase 2b), stored by CLIChargePointService
- * once a scenario run ends. Phase 3 expands this into the full
- * `scenario_report` RPC surface; kept intentionally small here -- just
- * enough for `getScenarioRunResult` to answer "did this run pass".
+ * #179 Phase 3: one captured wire {@link Frame} flattened into the
+ * JSON-serializable shape used by the `scenario_report` transcript. A pure
+ * structural mapping -- no redaction here, see {@link redactTranscriptEntry}
+ * -- so this stays trivially testable against exact Frame fixtures.
+ */
+export interface TranscriptEntry {
+  seq: number;
+  ts: string;
+  direction: Direction;
+  kind: "call" | "callresult" | "callerror";
+  uniqueId: string;
+  action?: string;
+  payload?: unknown;
+  errorCode?: string;
+  errorDescription?: string;
+}
+
+/** Connector state captured at the start/end of a scenario run -- the
+ *  `initialState` / `finalState` fields of {@link ScenarioRunResult}. */
+export interface ScenarioStateSnapshot {
+  connectorStatus: string;
+  meterValue: number;
+  transactionId: number | null;
+}
+
+/**
+ * Maps a captured {@link Frame} to its flat {@link TranscriptEntry} shape.
+ * `seq` is the frame's position in capture order -- the caller (typically
+ * `frames.map((f, i) => frameToTranscriptEntry(f, i))`) supplies it, since
+ * TranscriptBuffer's public `frames` getter is typed as plain `Frame[]`
+ * (it can't expose TranscriptFrame's own `seq` without widening the type
+ * evaluateAssertions and every other Frame[] consumer already relies on).
+ */
+export function frameToTranscriptEntry(
+  frame: Frame,
+  seq: number,
+): TranscriptEntry {
+  const shared = {
+    seq,
+    ts: frame.timestamp,
+    direction: frame.direction,
+    uniqueId: frame.uniqueId,
+  };
+
+  switch (frame.kind) {
+    case "call":
+      return {
+        ...shared,
+        kind: "call",
+        action: frame.action,
+        payload: frame.payload,
+      };
+    case "callresult":
+      return { ...shared, kind: "callresult", payload: frame.payload };
+    case "callerror":
+      return {
+        ...shared,
+        kind: "callerror",
+        errorCode: frame.errorCode,
+        errorDescription: frame.errorDescription,
+      };
+    default: {
+      // Exhaustiveness guard: Frame is a closed union, so this only fires
+      // if a new Frame kind is added to ocpp.ts without updating this map.
+      const neverFrame: never = frame;
+      throw new Error(
+        `frameToTranscriptEntry: unhandled frame kind ${String((neverFrame as Frame).kind)}`,
+      );
+    }
+  }
+}
+
+/**
+ * Redacts a {@link TranscriptEntry} (returns a new object; the input is
+ * never mutated) before it can flow into a `scenario_report` RPC response.
+ * Transcript payloads are raw OCPP-J CALL/CALLRESULT bodies and can carry
+ * auth material (AuthorizationKey, password, ...) -- see
+ * src/cp/shared/redaction.ts for exactly what `redactSensitiveValue`
+ * strips. `errorDescription` is redacted too since a CALLERROR's
+ * description is a free-text string that could echo back request content.
+ */
+export function redactTranscriptEntry(entry: TranscriptEntry): TranscriptEntry {
+  if (entry.kind === "callerror") {
+    return {
+      ...entry,
+      errorDescription:
+        entry.errorDescription !== undefined
+          ? redactSensitiveText(entry.errorDescription)
+          : entry.errorDescription,
+    };
+  }
+  return { ...entry, payload: redactSensitiveValue(entry.payload) };
+}
+
+/**
+ * Full per-run report (#179 Phase 3), stored by CLIChargePointService once
+ * a scenario run ends and surfaced over RPC as `scenario_report`.
+ * `schemaVersion` is pinned to `1` so a future breaking change to this
+ * shape can be detected by clients instead of silently misparsed.
+ * `templateId` / `profile` are omitted (left undefined) rather than
+ * invented -- ScenarioDefinition doesn't carry either field today.
  */
 export interface ScenarioRunResult {
+  schemaVersion: 1;
   runId: string;
   scenarioId: string;
+  templateId?: string;
+  scenarioName?: string;
+  profile?: string;
+  cpId: string;
   connectorId: number;
-  verdict: ScenarioVerdict;
-  assertions: AssertionResult[];
+  simulatorVersion: string;
+  ocppVersion: string;
   startedAt: string;
   endedAt: string;
-  frameCount: number;
+  durationMs: number;
+  executionState: "completed" | "error";
+  verdict: ScenarioVerdict;
+  assertions: AssertionResult[];
+  transcript: TranscriptEntry[];
+  errors: string[];
+  timeout: { nodeId: string; expectation?: unknown } | null;
+  initialState: ScenarioStateSnapshot;
+  finalState: ScenarioStateSnapshot;
 }
 
 export interface ComputeVerdictOptions {

--- a/src/cp/application/verification/__tests__/report.test.ts
+++ b/src/cp/application/verification/__tests__/report.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  frameToTranscriptEntry,
+  redactTranscriptEntry,
+} from "../ScenarioAssertions";
+import type { Frame } from "../ocpp";
+
+const base = {
+  direction: "sent" as const,
+  uniqueId: "u1",
+  timestamp: "2026-07-13T00:00:00Z",
+  raw: "raw",
+};
+
+describe("frameToTranscriptEntry (#179 Phase 3)", () => {
+  it("maps a call frame (keeps action + payload)", () => {
+    const frame: Frame = {
+      ...base,
+      kind: "call",
+      action: "BootNotification",
+      payload: { chargePointModel: "m" },
+    };
+    expect(frameToTranscriptEntry(frame, 0)).toEqual({
+      seq: 0,
+      ts: "2026-07-13T00:00:00Z",
+      direction: "sent",
+      uniqueId: "u1",
+      kind: "call",
+      action: "BootNotification",
+      payload: { chargePointModel: "m" },
+    });
+  });
+
+  it("maps a callresult frame (payload, no action)", () => {
+    const frame: Frame = {
+      ...base,
+      direction: "received",
+      kind: "callresult",
+      payload: { status: "Accepted" },
+    };
+    const entry = frameToTranscriptEntry(frame, 3);
+    expect(entry.kind).toBe("callresult");
+    expect(entry.seq).toBe(3);
+    expect(entry.payload).toEqual({ status: "Accepted" });
+    expect(entry.action).toBeUndefined();
+  });
+
+  it("maps a callerror frame (errorCode/description, no payload)", () => {
+    const frame: Frame = {
+      ...base,
+      direction: "received",
+      kind: "callerror",
+      errorCode: "InternalError",
+      errorDescription: "boom",
+      errorDetails: {},
+    };
+    const entry = frameToTranscriptEntry(frame, 1);
+    expect(entry.kind).toBe("callerror");
+    expect(entry.errorCode).toBe("InternalError");
+    expect(entry.errorDescription).toBe("boom");
+    expect(entry.payload).toBeUndefined();
+  });
+});
+
+describe("redactTranscriptEntry (#179 Phase 3)", () => {
+  it("redacts sensitive material from a call payload", () => {
+    const frame: Frame = {
+      ...base,
+      kind: "call",
+      action: "ChangeConfiguration",
+      payload: { key: "AuthorizationKey", value: "DEADBEEFCAFE" },
+    };
+    const redacted = redactTranscriptEntry(frameToTranscriptEntry(frame, 0));
+    // The OCPP key/value secret must not survive into the report.
+    expect(JSON.stringify(redacted.payload)).not.toContain("DEADBEEFCAFE");
+  });
+
+  it("does not mutate the input entry", () => {
+    const frame: Frame = {
+      ...base,
+      kind: "call",
+      action: "ChangeConfiguration",
+      payload: { key: "AuthorizationKey", value: "SECRET" },
+    };
+    const entry = frameToTranscriptEntry(frame, 0);
+    redactTranscriptEntry(entry);
+    // Original entry untouched.
+    expect(JSON.stringify(entry.payload)).toContain("SECRET");
+  });
+
+  it("redacts a callerror's free-text description", () => {
+    const frame: Frame = {
+      ...base,
+      direction: "received",
+      kind: "callerror",
+      errorCode: "SecurityError",
+      errorDescription: "password=hunter2 rejected",
+      errorDetails: {},
+    };
+    const redacted = redactTranscriptEntry(frameToTranscriptEntry(frame, 0));
+    expect(redacted.errorDescription).not.toContain("hunter2");
+  });
+});

--- a/src/data/interfaces/ChargePointService.ts
+++ b/src/data/interfaces/ChargePointService.ts
@@ -6,6 +6,7 @@ import type {
   ScenarioExecutionContext,
   ScenarioMode,
 } from "../../cp/application/scenario/ScenarioTypes";
+import type { ScenarioRunResult } from "../../cp/application/verification/ScenarioAssertions";
 import type {
   HistoryOptions,
   StateHistoryEntry,
@@ -482,6 +483,19 @@ export interface ChargePointService {
     connectorId: number,
     scenarioId: string,
   ): Promise<ScenarioExecutionContext | null>;
+  /**
+   * #179 Phase 3: the machine-readable certification report for a finished
+   * scenario run — verdict, assertion results, correlated transcript, and
+   * initial/final state snapshots. `runId` omitted returns the latest run.
+   * Null when no run has finished (or in local mode, which has no run-report
+   * machinery — only the headless/CLI service records reports).
+   */
+  getScenarioReport(
+    id: string,
+    connectorId: number,
+    scenarioId: string,
+    runId?: string,
+  ): Promise<ScenarioRunResult | null>;
   /**
    * Returns the loaded scenario definition (or null) for a given connector
    * + scenarioId. Lets the browser inspect scenarios that the server

--- a/src/data/local/LocalChargePointService.ts
+++ b/src/data/local/LocalChargePointService.ts
@@ -44,6 +44,7 @@ import type {
   ScenarioExecutionContext,
   ScenarioMode,
 } from "../../cp/application/scenario/ScenarioTypes";
+import type { ScenarioRunResult } from "../../cp/application/verification/ScenarioAssertions";
 import type {
   HistoryOptions,
   StateHistoryEntry,
@@ -777,6 +778,18 @@ export class LocalChargePointService implements ChargePointService {
     const manager = connector.scenarioManager;
     if (!manager) return null;
     return manager.getScenarioExecutionContext(scenarioId) ?? null;
+  }
+
+  async getScenarioReport(
+    _id: string,
+    _connectorId: number,
+    _scenarioId: string,
+    _runId?: string,
+  ): Promise<ScenarioRunResult | null> {
+    // Local (in-browser) mode runs scenarios via ScenarioManager, which has
+    // no run-report machinery — reports are recorded only by the headless
+    // CLI service. Always null here.
+    return null;
   }
 
   async getScenario(

--- a/src/data/remote/RemoteChargePointService.ts
+++ b/src/data/remote/RemoteChargePointService.ts
@@ -25,6 +25,7 @@ import type {
   ScenarioExecutionContext,
   ScenarioMode,
 } from "../../cp/application/scenario/ScenarioTypes";
+import type { ScenarioRunResult } from "../../cp/application/verification/ScenarioAssertions";
 import type {
   HistoryOptions,
   StateHistoryEntry,
@@ -1254,6 +1255,20 @@ export class RemoteChargePointService implements ChargePointService {
       scenarioId,
     });
     return (data as ScenarioExecutionContext | null) ?? null;
+  }
+
+  async getScenarioReport(
+    id: string,
+    connectorId: number,
+    scenarioId: string,
+    runId?: string,
+  ): Promise<ScenarioRunResult | null> {
+    const data = await this.runCpRpc(id, "scenario_report", {
+      connector: connectorId,
+      scenarioId,
+      ...(runId === undefined ? {} : { runId }),
+    });
+    return (data as ScenarioRunResult | null) ?? null;
   }
 
   async getScenario(

--- a/src/protocol/__tests__/methods.test.ts
+++ b/src/protocol/__tests__/methods.test.ts
@@ -32,6 +32,7 @@ const JSONMODE_COMMAND_IDS = [
   "list_scenarios",
   "run_scenario",
   "scenario_status",
+  "scenario_report",
   "get_scenario",
   "stop_scenario",
   "step_scenario",

--- a/src/protocol/methods.ts
+++ b/src/protocol/methods.ts
@@ -228,6 +228,19 @@ export const METHODS = {
     params: z.object({ connector: CONN_POS, scenarioId: STR_64K }),
     result: ANY,
   },
+  // #179 Phase 3: the machine-readable per-run certification report
+  // (verdict + assertion results + correlated transcript + state snapshots).
+  // runId omitted → latest run for the scenario. `format` is single-valued
+  // for now (JUnit is a later phase); kept as an enum so adding it is trivial.
+  scenario_report: {
+    params: z.object({
+      connector: CONN_POS,
+      scenarioId: STR_64K,
+      runId: STR_64K.optional(),
+      format: z.enum(["json"]).optional(),
+    }),
+    result: ANY,
+  },
   get_scenario: {
     params: z.object({ connector: CONN_POS, scenarioId: STR_64K }),
     result: ANY,


### PR DESCRIPTION
Phase 3 of #179. Exposes the machine-readable per-run certification **report** over the facade RPC as `scenario_report`, consuming the verdict + assertions Phase 2b produced.

## What this adds

### The report (assembled at run end)
`ScenarioRunResult` (Phase 2b's minimal shape) is expanded into the full report:

```jsonc
{
  "schemaVersion": 1,
  "runId": "…#<epoch>-<rand>",
  "scenarioId": "…", "scenarioName": "…",
  "cpId": "…", "connectorId": 1,
  "simulatorVersion": "0.0.0", "ocppVersion": "OCPP-1.6J",
  "startedAt": "…", "endedAt": "…", "durationMs": 24140,
  "executionState": "completed", "verdict": "PASS",
  "assertions": [ … ],
  "transcript": [ { "seq": 0, "ts": "…", "direction": "sent", "kind": "call", "uniqueId": "…", "action": "BootNotification", "payload": { … } } ],
  "errors": [], "timeout": null,
  "initialState": { "connectorStatus": "Available", "meterValue": 0, "transactionId": null },
  "finalState":   { "connectorStatus": "Charging",  "meterValue": 1500, "transactionId": 42 }
}
```

- `frameToTranscriptEntry` flattens each captured `Frame` (exhaustive over the union).
- **Redaction**: every transcript `payload` passes through `redactSensitiveValue` and each CALLERROR description through `redactSensitiveText`, so auth material (AuthorizationKey, password, …) never reaches a report. Covered by a test that a secret is masked and the input isn't mutated.
- The service snapshots the connector at run start (`initialState`) and finalize (`finalState`), collects redacted error messages, and attributes `timeout: {nodeId, expectation}` when a run is stopped mid-wait.

### The RPC (six-layer facade, mirrors `scenario_status`)
`scenario_report { connector, scenarioId, runId?, format?:"json" }` → the full report (or null if no run finished; `runId` omitted → latest run). Wired through `protocol/methods.ts` → `socketServer` dispatch → `RegistryChargePointService`/`CLIChargePointService.getScenarioReport` → `singleCpTarget` ops (legacy + facade) → `jsonMode` → `RemoteChargePointService` client. `LocalChargePointService` returns null (in-browser `ScenarioManager` records no reports — only the headless CLI service does).

## Scope note
`format` is single-valued (`"json"`) for now; **JUnit XML**, `run-all`, and `scenario_reset` are Phase 4. Timeouts that end via the error path (rather than a mid-wait stop) are already BLOCKED via the executor error signal; a typed timeout signal is a later refinement.

## Gates
- `tsc -b --noEmit --force`: 486 (baseline; the +4 over 482 is Phase 2b's known bun:sqlite test-type quirk, already on main)
- vitest: 1184/1184
- `test:bun`: 214/214
- prettier / eslint: clean; `package-lock.json` untouched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scenario run reports that include execution metadata, transcripts, connector state snapshots, errors, and timeout details.
  * Added support for retrieving the latest or a specific scenario report through CLI, remote services, and RPC.
  * Sensitive information is redacted from report transcripts and error messages.

* **Bug Fixes**
  * Improved reporting for scenarios without assertions and runs stopped while waiting for expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->