### PR TITLE
feat(scenario): scenario-scoped reset via scenario_reset RPC (#179 phase 4)

### DIFF
--- a/src/cli/__tests__/service.scenarioVerdict.bun.test.ts
+++ b/src/cli/__tests__/service.scenarioVerdict.bun.test.ts
@@ -8,6 +8,7 @@ import {
   ScenarioDefinition,
   ScenarioNodeType,
 } from "../../cp/application/scenario/ScenarioTypes";
+import { OCPPStatus } from "../../cp/domain/types/OcppTypes";
 
 /**
  * #179 Phase 2b: a scenario with no external waits, completing on its own
@@ -169,5 +170,38 @@ describe("#179 Phase 2b: declarative assertions + verdict + per-run transcript",
     // A runId that doesn't belong to this scenario resolves to null, not a
     // stale/foreign result.
     expect(svc.getScenarioRunResult(id, "not-a-real-run-id")).toBeNull();
+  });
+});
+
+describe("#179 Phase 4: scenario_reset", () => {
+  function connector1(svc: CLIChargePointService) {
+    return svc.getStatus().connectors.find((c) => c.id === 1)!;
+  }
+
+  it("returns the target connector to a clean baseline", () => {
+    const svc = newService();
+    const id = svc.loadScenario(1, completingScenario("reset-me"));
+
+    // Dirty the connector: Charging + a non-zero meter.
+    svc.updateConnectorStatus(1, OCPPStatus.Charging);
+    svc.setMeterValue(1, 500);
+    const before = connector1(svc);
+    expect(before.status).toBe("Charging");
+    expect(before.meterValue).toBe(500);
+
+    svc.resetScenario(1, id);
+
+    const after = connector1(svc);
+    expect(after.status).toBe("Available");
+    expect(after.meterValue).toBe(0);
+    expect(after.transactionId).toBeNull();
+  });
+
+  it("is a no-op-safe call when nothing is running or dirty", () => {
+    const svc = newService();
+    const id = svc.loadScenario(1, completingScenario("reset-idle"));
+    // Should not throw even though no run happened and the connector is clean.
+    expect(() => svc.resetScenario(1, id)).not.toThrow();
+    expect(connector1(svc).status).toBe("Available");
   });
 });

--- a/src/cli/jsonMode.ts
+++ b/src/cli/jsonMode.ts
@@ -274,6 +274,13 @@ export async function handleJsonCommand(
       return undefined;
     }
 
+    case "scenario_reset": {
+      const connectorId = requirePositiveInt(params, "connector");
+      const scenarioId = requireString(params, "scenarioId");
+      await ops.resetScenario(connectorId, scenarioId);
+      return undefined;
+    }
+
     case "step_scenario": {
       const connectorId = requirePositiveInt(params, "connector");
       const scenarioId = requireString(params, "scenarioId");

--- a/src/cli/server/RegistryChargePointService.ts
+++ b/src/cli/server/RegistryChargePointService.ts
@@ -554,6 +554,14 @@ export class RegistryChargePointService implements ChargePointService {
     this.requireService(id).stopScenario(connectorId, scenarioId);
   }
 
+  async resetScenario(
+    id: string,
+    connectorId: number,
+    scenarioId: string,
+  ): Promise<void> {
+    this.requireService(id).resetScenario(connectorId, scenarioId);
+  }
+
   async stepScenario(
     id: string,
     connectorId: number,

--- a/src/cli/server/socketServer.ts
+++ b/src/cli/server/socketServer.ts
@@ -1221,6 +1221,17 @@ async function dispatchFacadeCpCommand(
       );
       return handled(undefined);
     }
+    case "scenario_reset": {
+      const id = requireFacadeCpId(cpId);
+      await runFacadeOperation(() =>
+        chargePointService.resetScenario(
+          id,
+          requirePositiveInt(params, "connector"),
+          requireString(params, "scenarioId"),
+        ),
+      );
+      return handled(undefined);
+    }
     case "step_scenario": {
       const id = requireFacadeCpId(cpId);
       await runFacadeOperation(() =>

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -1321,6 +1321,42 @@ export class CLIChargePointService {
     );
   }
 
+  /**
+   * #179 Phase 4: scenario-scoped reset. Unlike the global `state.reset`
+   * (`resetAllState` wipes every CP + the DB), this returns just ONE connector
+   * to a clean baseline so a campaign can run the next scenario without
+   * leakage from the previous one. Steps: stop the run if active (reusing
+   * `stopScenario`, which aborts the executor, finalizes + drops its
+   * transcript, and clears armed response overrides), then clear any active
+   * transaction and reservation on the connector, zero its meter, return it to
+   * Available (emitting the StatusNotification so a CSMS stays in sync), and
+   * drop the persisted scenario position.
+   */
+  resetScenario(connectorId: number, scenarioId: string): void {
+    if (this._executors.has(scenarioId)) {
+      this.stopScenario(connectorId, scenarioId);
+    }
+
+    const connector = this._chargePoint.connectors.get(connectorId);
+    if (!connector) return;
+
+    connector.transaction = null;
+
+    const reservation =
+      this._chargePoint.reservationManager.getReservationForConnector(
+        connectorId,
+      );
+    if (reservation) {
+      this._chargePoint.reservationManager.cancelReservation(
+        reservation.reservationId,
+      );
+    }
+
+    this._chargePoint.setMeterValue(connectorId, 0);
+    this._chargePoint.updateConnectorStatus(connectorId, OCPPStatus.Available);
+    this._scenarioPositionByConnector.delete(connectorId);
+  }
+
   stopAllScenarios(connectorId: number): void {
     for (const [scenarioId, entry] of this._scenarios) {
       if (entry.connectorId === connectorId) {

--- a/src/cli/singleCpTarget.ts
+++ b/src/cli/singleCpTarget.ts
@@ -103,6 +103,7 @@ export interface SingleCpCommandOps {
     scenarioId: string,
   ): Promise<ScenarioDefinition | null>;
   stopScenario(connectorId: number, scenarioId: string): Promise<void>;
+  resetScenario(connectorId: number, scenarioId: string): Promise<void>;
   stepScenario(
     connectorId: number,
     scenarioId: string,
@@ -256,6 +257,9 @@ function legacyCommandOps(service: CLIChargePointService): SingleCpCommandOps {
     stopScenario: async (connectorId, scenarioId) => {
       service.stopScenario(connectorId, scenarioId);
     },
+    resetScenario: async (connectorId, scenarioId) => {
+      service.resetScenario(connectorId, scenarioId);
+    },
     stepScenario: async (connectorId, scenarioId, force) => {
       service.stepScenario(connectorId, scenarioId, force);
     },
@@ -358,6 +362,8 @@ function facadeCommandOps(target: FacadeSingleCpTarget): SingleCpCommandOps {
       service.getScenario(cpId, connectorId, scenarioId),
     stopScenario: (connectorId, scenarioId) =>
       service.stopScenario(cpId, connectorId, scenarioId),
+    resetScenario: (connectorId, scenarioId) =>
+      service.resetScenario(cpId, connectorId, scenarioId),
     stepScenario: (connectorId, scenarioId, force) =>
       service.stepScenario(cpId, connectorId, scenarioId, force),
     stopAllScenarios: (connectorId) =>

--- a/src/data/interfaces/ChargePointService.ts
+++ b/src/data/interfaces/ChargePointService.ts
@@ -463,6 +463,11 @@ export interface ChargePointService {
     connectorId: number,
     scenarioId: string,
   ): Promise<void>;
+  resetScenario(
+    id: string,
+    connectorId: number,
+    scenarioId: string,
+  ): Promise<void>;
   stepScenario(
     id: string,
     connectorId: number,

--- a/src/data/local/LocalChargePointService.ts
+++ b/src/data/local/LocalChargePointService.ts
@@ -725,6 +725,16 @@ export class LocalChargePointService implements ChargePointService {
     manager?.stopScenario(scenarioId);
   }
 
+  async resetScenario(
+    id: string,
+    connectorId: number,
+    scenarioId: string,
+  ): Promise<void> {
+    const connector = this.requireConnector(id, connectorId);
+    const manager = connector.scenarioManager;
+    manager?.stopScenario(scenarioId);
+  }
+
   async stepScenario(
     id: string,
     connectorId: number,

--- a/src/data/remote/RemoteChargePointService.ts
+++ b/src/data/remote/RemoteChargePointService.ts
@@ -1209,6 +1209,17 @@ export class RemoteChargePointService implements ChargePointService {
     });
   }
 
+  async resetScenario(
+    id: string,
+    connectorId: number,
+    scenarioId: string,
+  ): Promise<void> {
+    await this.runCpRpc(id, "scenario_reset", {
+      connector: connectorId,
+      scenarioId,
+    });
+  }
+
   async stepScenario(
     id: string,
     connectorId: number,

--- a/src/protocol/__tests__/methods.test.ts
+++ b/src/protocol/__tests__/methods.test.ts
@@ -35,6 +35,7 @@ const JSONMODE_COMMAND_IDS = [
   "scenario_report",
   "get_scenario",
   "stop_scenario",
+  "scenario_reset",
   "step_scenario",
   "stop_all_scenarios",
   "remove_scenario",

--- a/src/protocol/methods.ts
+++ b/src/protocol/methods.ts
@@ -249,6 +249,10 @@ export const METHODS = {
     params: z.object({ connector: CONN_POS, scenarioId: STR_64K }),
     result: ANY,
   },
+  scenario_reset: {
+    params: z.object({ connector: CONN_POS, scenarioId: STR_64K }),
+    result: ANY,
+  },
   step_scenario: {
     params: z.object({
       connector: CONN_POS,


### PR DESCRIPTION
Phase 4 of #179 — completes the last **hard** acceptance criterion: scenario-scoped cleanup that prevents state leakage between campaign cases.

## Why

The only existing reset is the global `state.reset` (`resetAllState`), which wipes **every** CP + the DB — far too broad for "run the next scenario on this connector cleanly". `scenario_reset` returns just **one connector** to a clean baseline.

## What

`CLIChargePointService.resetScenario(connectorId, scenarioId)`:
1. Stops the run if active — reuses `stopScenario` (aborts the executor, finalizes + drops its transcript, clears armed response overrides).
2. Clears any active **transaction** and **reservation** on the connector.
3. Zeroes the **meter**, returns the connector to **Available** (emitting the `StatusNotification` so a CSMS stays in sync).
4. Drops the persisted **scenario position**.

Exposed as the `scenario_reset` facade RPC across all six layers, mirroring `stop_scenario` exactly: `protocol/methods` → `socketServer` dispatch → `RegistryChargePointService`/`CLIChargePointService` → `singleCpTarget` ops (legacy + facade) → `jsonMode` → `RemoteChargePointService` client. `LocalChargePointService` does a best-effort manager stop (the browser path has no per-connector reset machinery).

## Tests
- `resetScenario` returns a dirtied connector (Charging + non-zero meter) to Available / meter-0 / no-transaction.
- No-op-safe when idle/clean.

## Scope
JUnit XML export and a `run-all` CLI convenience are the issue's **explicitly-optional** extras and are intentionally not in this PR. With `scenario_reset`, all of #179's hard acceptance criteria are met.

## Gates
- `tsc -b --noEmit --force`: 486 (baseline)
- vitest: 1184/1184
- `test:bun`: 216/216
- prettier / eslint: clean; `package-lock.json` untouched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `scenario_reset` command for resetting an individual connector and scenario.
  * Resetting stops the active scenario and clears transactions, reservations, meter readings, status, and saved scenario progress.
  * Added support across local, remote, JSON, and service interfaces.
  * Reset requests validate the connector and scenario details before processing.

* **Bug Fixes**
  * Resetting an already clean or inactive connector is now safe and has no unintended effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->