### PR TITLE
fix(scenario): remote editor hydrates from persisted definitions, not runtime (#101)

### DIFF
--- a/src/components/ConnectorSidePanel.tsx
+++ b/src/components/ConnectorSidePanel.tsx
@@ -583,38 +583,55 @@ const FullPanelContent: React.FC<{
     }
   }, [mode, scenarios]);
 
-  // Remote mode: hydrate the editor with scenarios the daemon has loaded
-  // (e.g. via --scenario-template-file). Refetch on scenario lifecycle
-  // events so newly loaded templates appear without a manual reload.
+  // Remote mode: hydrate the editor with the connector's PERSISTED scenario
+  // definitions — the same source local mode selects from (#101 fix A).
+  //
+  // Previously this hydrated from `listScenarios` (the daemon's *runtime*
+  // loaded set). But `replaceConnectorScenarioDefinitions` (the editor
+  // upload/replace path) prunes only the persisted definitions, NOT the
+  // runtime — so a seeded default (CPRegistry.seedDefaultScenarios) that the
+  // user replaced still lingered in the runtime, got re-selected as `valid[0]`
+  // on the next refresh, and the editor's autosave then re-persisted it with a
+  // fresh timestamp, permanently shadowing the uploaded scenario. Sourcing
+  // from the persisted definitions (which the replace path DID prune) makes the
+  // upload survive a refresh, matching local mode. The runtime `list_scenarios`
+  // is now consulted only for the "which one is currently running" preference.
   useEffect(() => {
     if (mode !== "remote") return;
     let cancelled = false;
     const refresh = async () => {
       try {
-        const list = await chargePointService.listScenarios(cpId, connectorId);
-        if (cancelled) return;
-        setRemoteScenarioListError(false);
-        if (list.length === 0) return;
-        const defs = await Promise.all(
-          list.map((item) =>
-            chargePointService
-              .getScenario(cpId, connectorId, item.scenarioId)
-              .catch(() => null),
-          ),
+        const valid = await chargePointService.listScenarioDefinitions(
+          cpId,
+          connectorId,
         );
         if (cancelled) return;
-        const valid = defs.filter((d): d is ScenarioDefinition => d !== null);
+        setRemoteScenarioListError(false);
         if (valid.length === 0) return;
+        // The active-scenario preference comes from the runtime list, but only
+        // honor it when the active scenario is still one of the persisted
+        // definitions (so a stale runtime-only entry can't win). Runtime-list
+        // errors are non-fatal — it's just a selection hint.
+        let activeId: string | null = null;
+        try {
+          const runtime = await chargePointService.listScenarios(
+            cpId,
+            connectorId,
+          );
+          activeId = runtime.find((item) => item.active)?.scenarioId ?? null;
+        } catch {
+          /* selection hint only */
+        }
+        if (cancelled) return;
         setScenario((current) => {
           if (current) {
             const match = valid.find((s) => s.id === current.id);
             if (match) return match;
           }
-          // Prefer an active scenario, otherwise the first loaded one.
-          const activeItem = list.find((item) => item.active);
-          const preferred = activeItem
-            ? valid.find((d) => d.id === activeItem.scenarioId)
-            : null;
+          const preferred =
+            activeId != null ? valid.find((d) => d.id === activeId) : null;
+          // Otherwise the newest persisted definition (listByConnector orders
+          // by updated_at DESC, so valid[0] is the most recently saved).
           const next = preferred ?? valid[0];
           scenarioRef.current = next;
           return next;

--- a/src/components/scenario/ScenarioEditor.tsx
+++ b/src/components/scenario/ScenarioEditor.tsx
@@ -442,6 +442,14 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
       setDefaultExecutionMode(scenarioProp.defaultExecutionMode || "oneshot");
       setScenarioEnabled(scenarioProp.enabled !== false);
       setScenarioEvSettings(scenarioProp.evSettings ?? {});
+      // #101 fix C: a scenario just hydrated from the daemon is already
+      // persisted verbatim — suppress the autosave this state change would
+      // otherwise trigger. Without this, re-hydrating a scenario re-saves it
+      // with a fresh updated_at, which (combined with the runtime/definition
+      // desync) let a seeded default keep winning the newest-wins selection and
+      // shadow the user's uploaded scenario across refreshes. The suppression
+      // is fingerprint-based, so the first real user edit still autosaves.
+      armAppliedScenarioAutosaveSuppression(scenarioProp);
       resetHistory();
       return;
     }
@@ -489,6 +497,7 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
     chargePointService,
     setNodes,
     setEdges,
+    armAppliedScenarioAutosaveSuppression,
   ]);
 
   // Update execution context from props


### PR DESCRIPTION
Fixes #101 (uploaded scenario vanishes after refresh) — the **remote/daemon** (Docker web console) case that survived #104 / #132 / #165.

## Reproduction (end-to-end, real browser vs a real daemon)

Ran the daemon locally (`--web-console --unsafe-remote`, Docker-parity `bun run build` UI) and drove the browser via DevTools — matching CHENJIANMIN's Docker setup (remote mode), which GitHub Pages (local mode) never exercises:

1. Upload a scenario → **the daemon's SQLite persists it correctly** (`repro-101-upload`, connector 1). ✅ (this is why #165's "daemon persist" looked fixed)
2. **Refresh** → the editor shows the seeded 11-node **"Essential CP Behavior"** default, and the daemon DB gains a *second* row `essential-cp-behavior-…` with a **newer** `updated_at` than the upload. The upload is still in the DB but hidden → "disappeared".

## Root cause (remote-mode only)

1. The daemon seeds a default scenario into the connector's **runtime + definitions** on CP create (`CPRegistry.seedDefaultScenarios("essential-cp-behavior")`).
2. The editor upload/replace path (`replaceConnectorScenarioDefinitions`) prunes only the **persisted definitions**, *not* the daemon runtime — so the replaced default lingers in the runtime.
3. `ConnectorSidePanel`'s remote-hydrate effect sourced the scenario set from `listScenarios` (the **runtime** set, still holding the stale default) and picked `valid[0]`; the editor's autosave then **re-persisted that default with a fresh `updated_at`**, permanently shadowing the upload on every refresh.
4. **Local mode was unaffected** because it hydrates from the persisted `listScenarioDefinitions` (via `useScenarios`) — which the replace path *did* prune.

## Fix

- **A — source unification:** the remote-hydrate effect now sources the connector's scenario set from `listScenarioDefinitions` (persisted, the same source local mode uses), so a replaced default can't leak back in. `list_scenarios` is consulted only for the "which one is currently running" active-selection hint (and only honored when the active scenario is also in the persisted set).
- **C — break the re-persist cycle:** a scenario just hydrated from the daemon is already persisted verbatim, so the prop-reload effect now arms the (fingerprint-based) autosave suppression for it. The first real user edit still autosaves.

## Verification (same harness, with the fix)

After upload + refresh the editor now shows the **2-node upload** (was the 11-node default), and the daemon DB holds **only the upload** — no re-persisted default. Confirmed via DevTools (node count) + `sqlite3` on the daemon's state.db.

## Gates
- `tsc -b --noEmit --force`: 486 (baseline)
- vitest: 1184/1184
- `test:bun`: 216/216
- prettier / eslint: clean

## Note
Both changed files are browser-only (`ConnectorSidePanel`, `ScenarioEditor`), and CI doesn't run `vite build` — this was verified against the Docker-parity `bun` build directly. A `ConnectorSidePanel` dom regression test is a good follow-up (the component needs a fairly complete mock service + a mocked lazy ReactFlow editor), but the fix is verified end-to-end here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote scenario refresh behavior by preserving the selected scenario when it remains available.
  * Added more reliable fallback selection when the preferred scenario is unavailable.
  * Prevented unintended autosaves while reloading scenarios that were already saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->