### PR TITLE
feat(soap): derive the SOAP callback URL from --soap-public-base-url (#183)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ All SOAP versions share the same endpoint pattern:
   relies on the daemon's `--web-console-basic-auth-*` gate or a trusted network
   boundary — OCPP-S has no per-message authentication field.
 
+The callback URL the CP advertises to the CSMS is resolved by precedence:
+
+1. `--soap-callback-url <url>` — the full URL, used verbatim.
+2. `--soap-public-base-url <url>` — a public base the CSMS can reach (e.g. a
+   tunnel origin); the callback URL is derived as
+   `<base><soap-path>/<cp-id>/ChargePointService`. Handy when the CSMS is hosted
+   remotely and cannot reach your machine directly — point the base at your
+   tunnel and skip hand-building the full URL. An explicit `--soap-callback-url`
+   still wins.
+
 Pairs with [SteVe](https://github.com/steve-community/steve) (register charge points
 with protocol `ocpp1.2S`, `ocpp1.5S`, or `ocpp1.6S`, status Accepted).
 

--- a/src/cli/__tests__/main.parseArgs.test.ts
+++ b/src/cli/__tests__/main.parseArgs.test.ts
@@ -349,6 +349,67 @@ describe("parseArgs --ocpp-version", () => {
     });
   });
 
+  it("derives the SOAP callback URL from --soap-public-base-url", () => {
+    const result = runParseArgs([
+      "--cp-id",
+      "CP-1",
+      "--ws-url",
+      "http://127.0.0.1:8180/steve/services/CentralSystemService",
+      "--ocpp-version",
+      "OCPP-1.6S",
+      "--soap-public-base-url",
+      "https://abcd.ngrok-free.app",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ocppVersion: "OCPP-1.6S",
+      soapCallbackUrl:
+        "https://abcd.ngrok-free.app/ocpp/soap/CP-1/ChargePointService",
+    });
+    expect(result.stderr).toContain(
+      "SOAP callback URL resolved from --soap-public-base-url",
+    );
+  });
+
+  it("lets an explicit --soap-callback-url win over --soap-public-base-url", () => {
+    const result = runParseArgs([
+      "--cp-id",
+      "CP-1",
+      "--ws-url",
+      "http://127.0.0.1:8180/steve/services/CentralSystemService",
+      "--ocpp-version",
+      "OCPP-1.6S",
+      "--soap-callback-url",
+      "http://explicit.test/ocpp/soap/CP-1/ChargePointService",
+      "--soap-public-base-url",
+      "https://abcd.ngrok-free.app",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      soapCallbackUrl: "http://explicit.test/ocpp/soap/CP-1/ChargePointService",
+    });
+  });
+
+  it("rejects a non-http(s) --soap-public-base-url", () => {
+    const result = runParseArgs([
+      "--cp-id",
+      "CP-1",
+      "--ws-url",
+      "http://127.0.0.1:8180/steve/services/CentralSystemService",
+      "--ocpp-version",
+      "OCPP-1.6S",
+      "--soap-public-base-url",
+      "ws://abcd.ngrok-free.app",
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Error: --soap-public-base-url must be an absolute http(s) URL",
+    );
+  });
+
   it("rejects unsupported versions", () => {
     const result = runParseArgs([
       "--cp-id",

--- a/src/cli/__tests__/soapCallbackUrl.test.ts
+++ b/src/cli/__tests__/soapCallbackUrl.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSoapCallbackUrl,
+  isHttpUrl,
+  resolveSoapCallbackUrl,
+} from "../soapCallbackUrl";
+
+describe("isHttpUrl", () => {
+  it("accepts absolute http/https URLs", () => {
+    expect(isHttpUrl("http://example.test")).toBe(true);
+    expect(isHttpUrl("https://foo.ngrok-free.app/base")).toBe(true);
+  });
+
+  it("rejects non-http(s) and non-absolute values", () => {
+    expect(isHttpUrl("ftp://example.test")).toBe(false);
+    expect(isHttpUrl("ws://example.test")).toBe(false);
+    expect(isHttpUrl("example.test")).toBe(false);
+    expect(isHttpUrl("/ocpp/soap")).toBe(false);
+    expect(isHttpUrl("")).toBe(false);
+  });
+});
+
+describe("buildSoapCallbackUrl", () => {
+  it("derives {base}{soapPath}/{cpId}/ChargePointService", () => {
+    expect(
+      buildSoapCallbackUrl("https://abcd.ngrok-free.app", "CP-1", "/ocpp/soap"),
+    ).toBe("https://abcd.ngrok-free.app/ocpp/soap/CP-1/ChargePointService");
+  });
+
+  it("tolerates a trailing slash on the base URL", () => {
+    expect(
+      buildSoapCallbackUrl(
+        "https://abcd.ngrok-free.app/",
+        "CP-1",
+        "/ocpp/soap",
+      ),
+    ).toBe("https://abcd.ngrok-free.app/ocpp/soap/CP-1/ChargePointService");
+  });
+
+  it("preserves a path prefix on the base URL", () => {
+    expect(
+      buildSoapCallbackUrl(
+        "https://host.test/behind/proxy",
+        "CP-1",
+        "/ocpp/soap",
+      ),
+    ).toBe("https://host.test/behind/proxy/ocpp/soap/CP-1/ChargePointService");
+  });
+
+  it("honors a custom soap path", () => {
+    expect(
+      buildSoapCallbackUrl("https://host.test", "CP-1", "/custom/soap"),
+    ).toBe("https://host.test/custom/soap/CP-1/ChargePointService");
+  });
+
+  it("normalizes a soap path without a leading slash or with a trailing slash", () => {
+    expect(
+      buildSoapCallbackUrl("https://host.test", "CP-1", "ocpp/soap/"),
+    ).toBe("https://host.test/ocpp/soap/CP-1/ChargePointService");
+  });
+
+  it("collapses a root soap path to a single slash", () => {
+    expect(buildSoapCallbackUrl("https://host.test", "CP-1", "/")).toBe(
+      "https://host.test/CP-1/ChargePointService",
+    );
+  });
+
+  it("percent-encodes a cpId with URL-significant characters", () => {
+    // decodeURIComponent(segment) must round-trip back to the exact cpId so the
+    // server's route match (decodeURIComponent(match[2]) === cpId) holds.
+    const url = buildSoapCallbackUrl(
+      "https://host.test",
+      "CP 01/A",
+      "/ocpp/soap",
+    );
+    expect(url).toBe(
+      "https://host.test/ocpp/soap/CP%2001%2FA/ChargePointService",
+    );
+    const segment = /\/([^/]+)\/ChargePointService$/.exec(
+      new URL(url).pathname,
+    )![1];
+    expect(decodeURIComponent(segment)).toBe("CP 01/A");
+  });
+
+  it("throws on a non-http(s) base URL", () => {
+    expect(() =>
+      buildSoapCallbackUrl("ws://host.test", "CP-1", "/ocpp/soap"),
+    ).toThrow(/Invalid SOAP public base URL/);
+  });
+});
+
+describe("resolveSoapCallbackUrl precedence", () => {
+  it("uses the explicit callback URL verbatim, ignoring the public base", () => {
+    expect(
+      resolveSoapCallbackUrl({
+        explicitCallbackUrl:
+          "http://127.0.0.1:9700/ocpp/soap/CP-1/ChargePointService",
+        publicBaseUrl: "https://abcd.ngrok-free.app",
+        cpId: "CP-1",
+        soapPath: "/ocpp/soap",
+      }),
+    ).toBe("http://127.0.0.1:9700/ocpp/soap/CP-1/ChargePointService");
+  });
+
+  it("derives from the public base when no explicit URL is given", () => {
+    expect(
+      resolveSoapCallbackUrl({
+        explicitCallbackUrl: null,
+        publicBaseUrl: "https://abcd.ngrok-free.app",
+        cpId: "CP-1",
+        soapPath: "/ocpp/soap",
+      }),
+    ).toBe("https://abcd.ngrok-free.app/ocpp/soap/CP-1/ChargePointService");
+  });
+
+  it("returns null when neither source is configured", () => {
+    expect(
+      resolveSoapCallbackUrl({
+        explicitCallbackUrl: null,
+        publicBaseUrl: null,
+        cpId: "CP-1",
+        soapPath: "/ocpp/soap",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when a public base is set but the cpId is blank (e.g. daemon mode)", () => {
+    expect(
+      resolveSoapCallbackUrl({
+        publicBaseUrl: "https://abcd.ngrok-free.app",
+        cpId: "",
+        soapPath: "/ocpp/soap",
+      }),
+    ).toBeNull();
+  });
+
+  it("treats a blank/whitespace explicit URL as absent and falls through", () => {
+    expect(
+      resolveSoapCallbackUrl({
+        explicitCallbackUrl: "   ",
+        publicBaseUrl: "https://abcd.ngrok-free.app",
+        cpId: "CP-1",
+        soapPath: "/ocpp/soap",
+      }),
+    ).toBe("https://abcd.ngrok-free.app/ocpp/soap/CP-1/ChargePointService");
+  });
+});

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,6 +6,7 @@ import { CLIChargePointService } from "./service";
 import { startRepl } from "./repl";
 import { startJsonMode } from "./jsonMode";
 import { resolveClientLocation } from "./clientLocation";
+import { isHttpUrl, resolveSoapCallbackUrl } from "./soapCallbackUrl";
 import { BunSqliteDatabase } from "../cp/domain/persistence/BunSqliteDatabase";
 import type { Database } from "../cp/domain/persistence/Database";
 import { SqliteScenarioRepository } from "../cp/domain/persistence/SqliteScenarioRepository";
@@ -140,6 +141,7 @@ export function parseArgs(argv: string[]): CLIOptions {
   const extraWsHeaders: Record<string, string> = {};
   const extraWsSubprotocols: string[] = [];
   let soapCallbackUrl: string | null = null;
+  let soapPublicBaseUrl: string | null = null;
   let soapPath = "/ocpp/soap";
   let securityProfile: CLIOptions["securityProfile"];
   let authorizationKey: string | undefined;
@@ -350,6 +352,22 @@ export function parseArgs(argv: string[]): CLIOptions {
           process.exit(1);
         }
         soapCallbackUrl = next;
+        i++;
+        break;
+      case "--soap-public-base-url":
+        if (!next || next.startsWith("--")) {
+          process.stderr.write(
+            "Error: --soap-public-base-url requires a URL\n",
+          );
+          process.exit(1);
+        }
+        if (!isHttpUrl(next)) {
+          process.stderr.write(
+            "Error: --soap-public-base-url must be an absolute http(s) URL\n",
+          );
+          process.exit(1);
+        }
+        soapPublicBaseUrl = next;
         i++;
         break;
       case "--soap-path":
@@ -584,6 +602,21 @@ export function parseArgs(argv: string[]): CLIOptions {
     }
   }
 
+  // Resolve the SOAP callback URL by precedence: an explicit --soap-callback-url
+  // wins; otherwise --soap-public-base-url derives it. (A tunnel provider such
+  // as ngrok would slot in below the public base — see soapCallbackUrl.ts.)
+  const resolvedSoapCallbackUrl = resolveSoapCallbackUrl({
+    explicitCallbackUrl: soapCallbackUrl,
+    publicBaseUrl: soapPublicBaseUrl,
+    cpId,
+    soapPath,
+  });
+  if (!soapCallbackUrl && soapPublicBaseUrl && resolvedSoapCallbackUrl) {
+    process.stderr.write(
+      `SOAP callback URL resolved from --soap-public-base-url: ${resolvedSoapCallbackUrl}\n`,
+    );
+  }
+
   return {
     wsUrl,
     cpId,
@@ -618,7 +651,7 @@ export function parseArgs(argv: string[]): CLIOptions {
     healthPath,
     extraWsHeaders,
     extraWsSubprotocols,
-    soapCallbackUrl,
+    soapCallbackUrl: resolvedSoapCallbackUrl,
     soapPath,
     securityProfile,
     authorizationKey,
@@ -740,7 +773,13 @@ Options:
                            remote-mode auto-detect probe lines up.
   --soap-callback-url <url>
                            SOAP ChargePointService callback URL for OCPP 1.2, 1.5,
-                           or 1.6S. Required when using any SOAP version.
+                           or 1.6S. Required for SOAP versions unless
+                           --soap-public-base-url is given instead.
+  --soap-public-base-url <url>
+                           Public base URL (e.g. a tunnel origin) the CSMS can
+                           reach; the full callback URL is derived as
+                           {base}{soap-path}/{cp-id}/ChargePointService. An
+                           explicit --soap-callback-url takes precedence.
   --soap-path <path>       Base path reserved for the SOAP callback server
                            (default: /ocpp/soap).
                            OCPP-S has no per-message auth; rely on

--- a/src/cli/server/httpServer.ts
+++ b/src/cli/server/httpServer.ts
@@ -11,6 +11,10 @@ import {
   isSoapVersion,
 } from "../../cp/domain/types/OcppVersion";
 import { soapFaultResponse } from "../../cp/infrastructure/transport/soap/OCPPSoapServer";
+import {
+  SOAP_CHARGE_POINT_SERVICE_ROUTE,
+  normalizeSoapPath,
+} from "../soapPath";
 
 /**
  * Serve files out of a directory as a 404 fallback for the HTTP router.
@@ -224,7 +228,7 @@ function matchSoapChargePointService(
   pathname: string,
   registry: CPRegistry,
 ): SoapChargePointServiceRoute | null {
-  const match = /^(.*)\/([^/]+)\/ChargePointService$/.exec(pathname);
+  const match = SOAP_CHARGE_POINT_SERVICE_ROUTE.exec(pathname);
   if (!match) return null;
   const basePath = normalizeSoapPath(match[1] || "/");
   try {
@@ -263,7 +267,7 @@ function soapCallbackBasePath(
   if (!callbackUrl) return null;
   try {
     const pathname = new URL(callbackUrl).pathname;
-    const match = /^(.*)\/([^/]+)\/ChargePointService$/.exec(pathname);
+    const match = SOAP_CHARGE_POINT_SERVICE_ROUTE.exec(pathname);
     if (!match) return null;
     return decodeURIComponent(match[2]) === cpId
       ? normalizeSoapPath(match[1] || "/")
@@ -271,11 +275,6 @@ function soapCallbackBasePath(
   } catch {
     return null;
   }
-}
-
-function normalizeSoapPath(value: string): string {
-  const trimmed = value.replace(/\/+$/, "");
-  return trimmed.length > 0 ? trimmed : "/";
 }
 
 function isRegisteredSoapService(service: CLIChargePointService): boolean {

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -356,7 +356,7 @@ export class CLIChargePointService {
     const centralSystemUrl = init.centralSystemUrl ?? init.wsUrl;
     if (isSoapVersion(ocppVersion) && !init.soapCallbackUrl) {
       throw new Error(
-        "OCPP SOAP versions require soapCallbackUrl (--soap-callback-url)",
+        "OCPP SOAP versions require a callback URL (--soap-callback-url, or --soap-public-base-url to derive one)",
       );
     }
 

--- a/src/cli/soapCallbackUrl.ts
+++ b/src/cli/soapCallbackUrl.ts
@@ -19,7 +19,7 @@
  * URL and then reuse buildSoapCallbackUrl(), keeping this precedence intact.
  */
 
-const SOAP_SERVICE_SUFFIX = "ChargePointService";
+import { SOAP_SERVICE_SUFFIX, normalizeSoapPath } from "./soapPath";
 
 export interface SoapCallbackUrlInput {
   /** --soap-callback-url: the full callback URL, used verbatim when present. */
@@ -86,11 +86,4 @@ export function resolveSoapCallbackUrl(
     return buildSoapCallbackUrl(base, input.cpId, input.soapPath);
   }
   return null;
-}
-
-/** Mirror httpServer.normalizeSoapPath: ensure a leading slash, strip trailing. */
-function normalizeSoapPath(value: string): string {
-  const withLeading = value.startsWith("/") ? value : `/${value}`;
-  const trimmed = withLeading.replace(/\/+$/, "");
-  return trimmed.length > 0 ? trimmed : "/";
 }

--- a/src/cli/soapCallbackUrl.ts
+++ b/src/cli/soapCallbackUrl.ts
@@ -1,0 +1,96 @@
+/**
+ * SOAP ChargePointService callback-URL resolution (issue #183).
+ *
+ * SOAP-based OCPP (1.2 / 1.5 / 1.6S) requires the charge point to advertise a
+ * callback endpoint — the `wsa:From` address the CSMS calls back on:
+ *
+ *     {publicBase}{soapPath}/{cpId}/ChargePointService
+ *
+ * The effective URL is resolved by precedence, so the explicit flag always wins
+ * and additional providers can be layered underneath without touching callers:
+ *
+ *   1. explicit  --soap-callback-url <url>       → used verbatim
+ *   2.           --soap-public-base-url <base>   → derived from the base origin
+ *   3. (future)  --soap-tunnel ngrok             → provider yields a base, then (2)
+ *   4. none                                       → null (caller: local-only / error)
+ *
+ * Only steps 1–2 are implemented here. A tunnel provider (ngrok, Cloudflare
+ * Tunnel, …) is intentionally out of scope: it will resolve to a public base
+ * URL and then reuse buildSoapCallbackUrl(), keeping this precedence intact.
+ */
+
+const SOAP_SERVICE_SUFFIX = "ChargePointService";
+
+export interface SoapCallbackUrlInput {
+  /** --soap-callback-url: the full callback URL, used verbatim when present. */
+  readonly explicitCallbackUrl?: string | null;
+  /** --soap-public-base-url: public origin, optionally with a path prefix. */
+  readonly publicBaseUrl?: string | null;
+  /**
+   * Charge-point id that identifies the callback route segment. May be null in
+   * daemon-only mode, in which case no URL is derived from the public base.
+   */
+  readonly cpId: string | null;
+  /** Base path reserved for the SOAP callback server, e.g. "/ocpp/soap". */
+  readonly soapPath: string;
+}
+
+/** True when `value` parses as an absolute http(s) URL. */
+export function isHttpUrl(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  return url.protocol === "http:" || url.protocol === "https:";
+}
+
+/**
+ * Build the full SOAP callback URL a CP advertises, given a public base URL.
+ * `publicBaseUrl` is an absolute http(s) URL (origin, optionally with a path
+ * prefix); a trailing slash is tolerated. The cpId is percent-encoded so the
+ * server's `decodeURIComponent(segment) === cpId` route match holds. Throws if
+ * `publicBaseUrl` is not a valid http(s) URL.
+ */
+export function buildSoapCallbackUrl(
+  publicBaseUrl: string,
+  cpId: string,
+  soapPath: string,
+): string {
+  if (!isHttpUrl(publicBaseUrl)) {
+    throw new Error(
+      `Invalid SOAP public base URL: ${publicBaseUrl} (expected an absolute http(s) URL)`,
+    );
+  }
+  const base = publicBaseUrl.replace(/\/+$/, "");
+  const path = normalizeSoapPath(soapPath);
+  const prefix = path === "/" ? "" : path;
+  const segment = encodeURIComponent(cpId);
+  return `${base}${prefix}/${segment}/${SOAP_SERVICE_SUFFIX}`;
+}
+
+/**
+ * Resolve the effective SOAP callback URL by precedence (see module doc).
+ * Returns null when neither an explicit URL nor a usable public base is
+ * configured — the caller decides whether that is an error (SOAP) or a no-op
+ * (JSON). A blank cpId also yields null: there is no callback route to build.
+ */
+export function resolveSoapCallbackUrl(
+  input: SoapCallbackUrlInput,
+): string | null {
+  const explicit = input.explicitCallbackUrl?.trim();
+  if (explicit) return explicit;
+  const base = input.publicBaseUrl?.trim();
+  if (base && input.cpId) {
+    return buildSoapCallbackUrl(base, input.cpId, input.soapPath);
+  }
+  return null;
+}
+
+/** Mirror httpServer.normalizeSoapPath: ensure a leading slash, strip trailing. */
+function normalizeSoapPath(value: string): string {
+  const withLeading = value.startsWith("/") ? value : `/${value}`;
+  const trimmed = withLeading.replace(/\/+$/, "");
+  return trimmed.length > 0 ? trimmed : "/";
+}

--- a/src/cli/soapPath.ts
+++ b/src/cli/soapPath.ts
@@ -1,0 +1,26 @@
+/**
+ * SOAP ChargePointService path convention, shared by the callback server
+ * (httpServer route matching) and callback-URL derivation (soapCallbackUrl).
+ * Keeping the normalizer, the service suffix, and the route pattern in one
+ * place stops the advertised callback URL from drifting away from the routes
+ * that must accept it.
+ */
+
+/** Final path segment of a SOAP ChargePointService endpoint. */
+export const SOAP_SERVICE_SUFFIX = "ChargePointService";
+
+/**
+ * Matches "<basePath>/<cpId>/ChargePointService": group 1 = base path (may be
+ * ""), group 2 = the (percent-encoded) cpId segment. No global flag, so it is
+ * safe to share this instance across .exec() calls.
+ */
+export const SOAP_CHARGE_POINT_SERVICE_ROUTE = new RegExp(
+  `^(.*)/([^/]+)/${SOAP_SERVICE_SUFFIX}$`,
+);
+
+/** Ensure a leading slash and strip trailing slashes; "" and "/" collapse to "/". */
+export function normalizeSoapPath(value: string): string {
+  const withLeading = value.startsWith("/") ? value : `/${value}`;
+  const trimmed = withLeading.replace(/\/+$/, "");
+  return trimmed.length > 0 ? trimmed : "/";
+}


### PR DESCRIPTION
Addresses #183 (first slice — no dependency, no tunnel process).

## Problem

SOAP-based OCPP (1.2 / 1.5 / 1.6S) requires the charge point to advertise a callback URL — the `wsa:From` address the CSMS calls back on. Today that means hand-building the full `--soap-callback-url` (`{base}/ocpp/soap/<cpId>/ChargePointService`), which is awkward when the CSMS is hosted remotely and can only reach the simulator through a tunnel.

## What this adds

`--soap-public-base-url <url>`: give it a public origin the CSMS can reach (e.g. a tunnel origin) and the full callback URL is derived automatically as `{base}{soap-path}/{cpId}/ChargePointService`.

Callback URL resolution now follows a documented precedence, so the explicit flag always wins and future providers slot in underneath without touching callers:

1. `--soap-callback-url` → used verbatim
2. `--soap-public-base-url` → derived from the base origin
3. *(future)* `--soap-tunnel ngrok` → a tunnel provider yields a base, then as (2)
4. none → `null` (SOAP: clear validation error; JSON: no-op)

This PR implements 1–2 only. The ngrok/tunnel provider (issue #183's headline) is deliberately deferred: it will resolve to a public base URL and reuse the same builder, keeping this precedence intact. This slice adds **no dependency and starts no process**, and already unblocks remote-CSMS / remote-SteVe testing.

## Design

- `src/cli/soapCallbackUrl.ts` — a pure, unit-tested resolver (`resolveSoapCallbackUrl` / `buildSoapCallbackUrl` / `isHttpUrl`). This is the "generic callback-exposure abstraction" the issue suggested; the tunnel provider is the next layer.
- `main.ts` validates `--soap-public-base-url` is an absolute http(s) URL, resolves the effective URL **at parse time** (so nothing downstream changes — no new field threaded through types/persistence/RPC), and logs the derived URL to stderr.
- The cpId segment is percent-encoded so the server's `decodeURIComponent(segment) === cpId` route match holds; the derived base path is self-consistent with `soapBasePathsForService` in `httpServer.ts`.
- `service.ts` validation message now points at both flags.

## Scope / follow-ups

- The daemon "add CP via web console" (RPC register) path is unchanged — it still takes an explicit callback URL. Wiring `--soap-public-base-url` into that UI overlaps with the console redesign in #191, so it's intentionally out of scope here.
- The ngrok/Cloudflare tunnel provider is the natural next PR on top of this.

## Tests

- `soapCallbackUrl.test.ts` (15): precedence, base-URL normalization (trailing slash, path prefix, custom/root soap-path), cpId encoding round-trip, blank-cpId (daemon) → null, invalid base rejected.
- `main.parseArgs.test.ts` (+3): `--soap-public-base-url` derives the callback URL; explicit `--soap-callback-url` wins; non-http(s) base rejected.

## Verification

- `tsc -b --noEmit` — no new errors (baseline unchanged).
- `vitest` — CLI + SOAP suites green (278); new resolver 15/15.
- `bun test bun.test` — 216/0.
- prettier / eslint clean. `--help` and README updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--soap-public-base-url` CLI option to derive SOAP callback URLs automatically.
  * Kept precedence so explicit `--soap-callback-url` overrides any derived value.
  * Validates that `--soap-public-base-url` is an absolute HTTP(S) URL.

* **Documentation**
  * Updated the README to describe how the charge point callback URL is resolved for CSMS-initiated SOAP calls, including the precedence order.

* **Tests**
  * Added unit tests covering URL validation, construction, path normalization, cpId encoding, and precedence handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->