### PR TITLE
docs(examples): Java + Testcontainers harness prototype (#111)

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -269,6 +269,10 @@ await rpc({ method: "server.shutdown", params: {} });
 socket.disconnect();
 ```
 
+For a JVM/Testcontainers harness that drives this same control plane (start the
+container, `cp.create`, `run_scenario`, assert the machine-readable verdict), see
+[`examples/testcontainers-java/`](../examples/testcontainers-java/) (issue #111).
+
 ## Controlling a Running Daemon from the CLI
 
 A daemon does not have to be driven by a raw Socket.IO client or the web

--- a/examples/testcontainers-java/README.md
+++ b/examples/testcontainers-java/README.md
@@ -1,0 +1,63 @@
+# Java + Testcontainers harness (prototype)
+
+A minimal example of driving `ocpp-cp-simulator` as a **turnkey charge-point
+stub** from a JVM test suite — the "WireMock of OCPP" idea from
+[issue #111](https://github.com/shiv3/ocpp-cp-simulator/issues/111).
+
+A CSMS project can spin up the simulator container, create a charge point
+pointed at its CSMS-under-test, run a built-in certification scenario
+([#110](https://github.com/shiv3/ocpp-cp-simulator/issues/110)), and assert the
+machine-readable verdict ([#179](https://github.com/shiv3/ocpp-cp-simulator/issues/179))
+— without reimplementing the charge-point side per project.
+
+## What it does
+
+`CertificationScenarioIT` drives the daemon entirely over the documented
+[Socket.IO control plane](../../docs/server.md):
+
+1. start the simulator image with Testcontainers and wait on `GET /v1/healthz`;
+2. connect a Socket.IO client and `cp.create` a charge point;
+3. `events.subscribe` to that CP's event room;
+4. `load_scenario` (an inline scenario here) and `run_scenario`;
+5. poll `scenario_report` and assert `verdict == "PASS"`.
+
+The example is **self-contained**: the CP's `wsUrl` points at a dead port, so it
+never connects to a CSMS and an `ocpp_absent` assertion for `Reset` is
+deterministically satisfied. To exercise a real certification flow, point
+`cp.create`'s `wsUrl` at your CSMS-under-test and `run_scenario` a built-in
+`TC_xxx` template (`list_scenario_templates` / `run_scenario_template`).
+
+## Prerequisites
+
+- JDK 17+
+- Maven 3.9+
+- A Docker daemon (Testcontainers needs it)
+- The simulator image available locally:
+
+  ```bash
+  # from the repository root
+  docker build -t ocpp-cp-simulator:local .
+  ```
+
+## Run
+
+```bash
+# from examples/testcontainers-java/
+mvn verify
+```
+
+Point at a published/tagged image instead of a local build:
+
+```bash
+OCPP_SIM_IMAGE=ghcr.io/shiv3/ocpp-cp-simulator:latest mvn verify
+```
+
+## Status
+
+This is a **prototype** authored against the documented control-plane contract;
+it is not wired into the simulator's own CI (which is TypeScript). The identical
+RPC sequence is covered by a TypeScript integration test that **does** run in CI
+and drives the real socket server —
+`src/cli/server/__tests__/harnessScenarioVerdict.bun.test.ts` — so the flow this
+example demonstrates is guarded there. Contributions to grow this into a proper
+Testcontainers module + thin client are welcome.

--- a/examples/testcontainers-java/pom.xml
+++ b/examples/testcontainers-java/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!--
+    Prototype: drive the ocpp-cp-simulator daemon from a JVM test harness
+    (issue #111 — "the WireMock of OCPP"). Spins up the simulator Docker image
+    with Testcontainers, waits on GET /v1/healthz, drives everything over the
+    documented Socket.IO control plane (docs/server.md), and asserts a
+    machine-readable scenario verdict (#179). No live CSMS required.
+  -->
+  <groupId>io.github.shiv3</groupId>
+  <artifactId>ocpp-cp-simulator-testcontainers</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <testcontainers.version>1.20.4</testcontainers.version>
+    <junit.version>5.11.4</junit.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Socket.IO Java client for the control plane (brings org.json + OkHttp). -->
+    <dependency>
+      <groupId>io.socket</groupId>
+      <artifactId>socket.io-client</artifactId>
+      <version>2.1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Pin org.json explicitly rather than lean on a transitive version. -->
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20240303</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.16</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!--
+        These tests need a Docker daemon and the built simulator image, so they
+        run in the integration-test phase via failsafe: `mvn verify`.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.5.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/testcontainers-java/src/test/java/io/github/shiv3/ocppsim/CertificationScenarioIT.java
+++ b/examples/testcontainers-java/src/test/java/io/github/shiv3/ocppsim/CertificationScenarioIT.java
@@ -1,0 +1,157 @@
+package io.github.shiv3.ocppsim;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Prototype for issue #111: drive the simulator entirely over the documented
+ * Socket.IO control plane and assert a machine-readable verdict (#179), the way
+ * a CSMS project's certification IT would — but with the charge-point side
+ * supplied turnkey by the container instead of hand-coded per project.
+ *
+ * <p>This example is self-contained: the CP is never connected to a CSMS
+ * (its wsUrl points at a dead port), so an {@code ocpp_absent} assertion for
+ * {@code Reset} is deterministically satisfied and the run yields
+ * {@code verdict = "PASS"}. Pointing {@code cp.create}'s {@code wsUrl} at a real
+ * CSMS-under-test and running a built-in certification scenario (issue #110)
+ * is the same shape.
+ */
+@Testcontainers
+class CertificationScenarioIT {
+
+  @Container
+  static final OcppCpSimulatorContainer SIMULATOR = new OcppCpSimulatorContainer();
+
+  private static final String CP_ID = "CP-HARNESS";
+  private static final int CONNECTOR = 1;
+
+  /** A scenario that completes on its own with no external waits or CSMS. */
+  private static final String INLINE_SCENARIO =
+      """
+      {
+        "id": "harness-pass-demo",
+        "name": "Harness PASS demo",
+        "targetType": "connector",
+        "targetId": 1,
+        "nodes": [
+          { "id": "start-1", "type": "start",      "position": { "x": 0, "y": 0 }, "data": { "label": "S" } },
+          { "id": "mv-1",    "type": "meterValue", "position": { "x": 0, "y": 1 }, "data": { "label": "MV", "value": 100, "sendMessage": false } },
+          { "id": "end-1",   "type": "end",        "position": { "x": 0, "y": 2 }, "data": { "label": "E" } }
+        ],
+        "edges": [
+          { "id": "e1", "source": "start-1", "target": "mv-1" },
+          { "id": "e2", "source": "mv-1", "target": "end-1" }
+        ],
+        "assertions": [
+          { "id": "no-reset", "type": "ocpp_absent", "action": "Reset" }
+        ]
+      }
+      """;
+
+  @Test
+  void runsABuiltInStyleScenarioAndReadsThePassVerdict() throws Exception {
+    try (SimulatorControlClient client = SimulatorControlClient.connect(SIMULATOR.baseUrl())) {
+      List<JSONObject> events = new CopyOnWriteArrayList<>();
+      client.onEvent(events::add);
+
+      // 1. Create a charge point. wsUrl points at a dead port on purpose so the
+      //    CP stays disconnected and the run needs no live CSMS.
+      client.rpc(
+          "cp.create",
+          new JSONObject()
+              .put("cpId", CP_ID)
+              .put("wsUrl", "ws://127.0.0.1:65534/never")
+              .put("connectors", 1));
+
+      // The registry should now list it.
+      JSONArray cps = (JSONArray) client.rpc("cp.list", new JSONObject());
+      assertTrue(containsCp(cps, CP_ID), "cp.list should include " + CP_ID);
+
+      // 2. Subscribe to this CP's event room before running anything.
+      client.rpc("events.subscribe", new JSONObject().put("scope", CP_ID));
+
+      // 3. Load the inline scenario, then run it.
+      Object loaded =
+          client.rpc(
+              CP_ID,
+              "load_scenario",
+              new JSONObject()
+                  .put("connector", CONNECTOR)
+                  .put("scenario", new JSONObject(INLINE_SCENARIO)));
+      String scenarioId = scenarioIdOf(loaded);
+
+      client.rpc(
+          CP_ID,
+          "run_scenario",
+          new JSONObject().put("connector", CONNECTOR).put("scenarioId", scenarioId));
+
+      // 4. Poll the machine-readable report (#179) until the run has finished.
+      JSONObject report = awaitReport(client, scenarioId);
+
+      // 5. Assert the verdict the way a CSMS certification IT would.
+      assertEquals(1, report.getInt("schemaVersion"));
+      assertEquals("PASS", report.getString("verdict"), "expected a PASS verdict");
+
+      JSONArray assertions = report.getJSONArray("assertions");
+      assertEquals(1, assertions.length());
+      JSONObject first = assertions.getJSONObject(0);
+      assertEquals("no-reset", first.getString("id"));
+      assertEquals("passed", first.getString("status"));
+
+      // The event stream carried the scenario lifecycle too (demonstration).
+      assertTrue(
+          events.stream().anyMatch(e -> "cp".equals(e.optString("kind"))),
+          "expected at least one CP event push");
+    }
+  }
+
+  private static JSONObject awaitReport(SimulatorControlClient client, String scenarioId)
+      throws InterruptedException {
+    long deadline = System.currentTimeMillis() + 15_000;
+    while (System.currentTimeMillis() < deadline) {
+      Object result =
+          client.rpc(
+              CP_ID,
+              "scenario_report",
+              new JSONObject().put("connector", CONNECTOR).put("scenarioId", scenarioId));
+      if (result instanceof JSONObject report && report.has("verdict")) {
+        return report;
+      }
+      Thread.sleep(200);
+    }
+    throw new AssertionError("scenario_report never produced a verdict for " + scenarioId);
+  }
+
+  private static boolean containsCp(JSONArray cps, String cpId) {
+    for (int i = 0; i < cps.length(); i++) {
+      if (cpId.equals(cps.getJSONObject(i).optString("cpId"))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** load_scenario returns the (possibly retargeted) scenario id. */
+  private static String scenarioIdOf(Object loaded) {
+    if (loaded instanceof String s && !s.isBlank()) {
+      return s;
+    }
+    if (loaded instanceof JSONObject o) {
+      String id = o.optString("id", "");
+      if (!id.isBlank()) {
+        return id;
+      }
+    }
+    return "harness-pass-demo";
+  }
+}

--- a/examples/testcontainers-java/src/test/java/io/github/shiv3/ocppsim/OcppCpSimulatorContainer.java
+++ b/examples/testcontainers-java/src/test/java/io/github/shiv3/ocppsim/OcppCpSimulatorContainer.java
@@ -1,0 +1,57 @@
+package io.github.shiv3.ocppsim;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+
+/**
+ * Testcontainers wrapper around the ocpp-cp-simulator daemon image.
+ *
+ * <p>The image entrypoint starts the daemon with
+ * {@code --http-host 0.0.0.0 --unsafe-remote --web-console 9700}, so the
+ * Socket.IO control plane and the health endpoint are reachable over the mapped
+ * port with no authentication. See {@code docs/server.md} and {@code Dockerfile}.
+ *
+ * <p>Build the image first from the repository root:
+ * <pre>{@code docker build -t ocpp-cp-simulator:local .}</pre>
+ * or point {@code OCPP_SIM_IMAGE} at a published tag.
+ */
+public class OcppCpSimulatorContainer extends GenericContainer<OcppCpSimulatorContainer> {
+
+  /** Daemon port inside the container (Dockerfile: EXPOSE 9700). */
+  public static final int DAEMON_PORT = 9700;
+
+  /** Default health path; overridable at image build time via HEALTH_PATH. */
+  private static final String HEALTH_PATH = "/v1/healthz";
+
+  /** Overridable so CI can pin a published tag instead of a locally built image. */
+  private static final String DEFAULT_IMAGE = "ocpp-cp-simulator:local";
+
+  public OcppCpSimulatorContainer() {
+    this(resolveImage());
+  }
+
+  public OcppCpSimulatorContainer(String image) {
+    super(DockerImageName.parse(image));
+    withExposedPorts(DAEMON_PORT);
+    // The daemon answers { "ok": true } on the health path once it is ready to
+    // accept Socket.IO connections.
+    waitingFor(
+        Wait.forHttp(HEALTH_PATH)
+            .forPort(DAEMON_PORT)
+            .forStatusCode(200)
+            .withStartupTimeout(Duration.ofSeconds(60)));
+  }
+
+  private static String resolveImage() {
+    String fromEnv = System.getenv("OCPP_SIM_IMAGE");
+    return (fromEnv != null && !fromEnv.isBlank()) ? fromEnv : DEFAULT_IMAGE;
+  }
+
+  /** Base HTTP origin for the Socket.IO client, e.g. {@code http://localhost:32768}. */
+  public String baseUrl() {
+    return "http://" + getHost() + ":" + getMappedPort(DAEMON_PORT);
+  }
+}

--- a/examples/testcontainers-java/src/test/java/io/github/shiv3/ocppsim/SimulatorControlClient.java
+++ b/examples/testcontainers-java/src/test/java/io/github/shiv3/ocppsim/SimulatorControlClient.java
@@ -1,0 +1,127 @@
+package io.github.shiv3.ocppsim;
+
+import io.socket.client.Ack;
+import io.socket.client.IO;
+import io.socket.client.Socket;
+import org.json.JSONObject;
+
+import java.net.URISyntaxException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+/**
+ * Thin blocking wrapper over the daemon's Socket.IO control plane
+ * (docs/server.md). Every request/response call goes through the {@code "rpc"}
+ * event: emit {@code { cpId?, method, params }} and receive an ack of
+ * {@code { ok: true, result }} or {@code { ok: false, error: { code, message } }}.
+ * Server-to-client pushes arrive on the {@code "event"} event.
+ */
+public class SimulatorControlClient implements AutoCloseable {
+
+  private static final long ACK_TIMEOUT_SECONDS = 30;
+
+  private final Socket socket;
+
+  private SimulatorControlClient(Socket socket) {
+    this.socket = socket;
+  }
+
+  /** Connect to {@code baseUrl} and block until the socket is established. */
+  public static SimulatorControlClient connect(String baseUrl)
+      throws URISyntaxException, InterruptedException, TimeoutException {
+    Socket socket = IO.socket(baseUrl);
+    CountDownLatch connected = new CountDownLatch(1);
+    AtomicReference<Object> connectError = new AtomicReference<>();
+
+    socket.on(Socket.EVENT_CONNECT, args -> connected.countDown());
+    socket.on(
+        Socket.EVENT_CONNECT_ERROR,
+        args -> {
+          connectError.set(args.length > 0 ? args[0] : "unknown connect error");
+          connected.countDown();
+        });
+
+    socket.connect();
+    if (!connected.await(ACK_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      socket.close();
+      throw new TimeoutException("timed out connecting to " + baseUrl);
+    }
+    if (connectError.get() != null) {
+      socket.close();
+      throw new IllegalStateException("connect_error: " + connectError.get());
+    }
+    return new SimulatorControlClient(socket);
+  }
+
+  /**
+   * Invoke a daemon-level method (no cpId), e.g. {@code cp.create},
+   * {@code events.subscribe}. Returns the {@code result} field (a
+   * {@link JSONObject}, a {@link String}, or {@code null}); throws on
+   * {@code ok: false}.
+   */
+  public Object rpc(String method, JSONObject params) {
+    return rpc(null, method, params);
+  }
+
+  /**
+   * Invoke a per-CP command method (e.g. {@code load_scenario},
+   * {@code run_scenario}, {@code scenario_report}). Returns the {@code result}
+   * field; throws on {@code ok: false}.
+   */
+  public Object rpc(String cpId, String method, JSONObject params) {
+    JSONObject request = new JSONObject();
+    if (cpId != null) {
+      request.put("cpId", cpId);
+    }
+    request.put("method", method);
+    request.put("params", params != null ? params : new JSONObject());
+
+    CompletableFuture<JSONObject> ackFuture = new CompletableFuture<>();
+    Ack ack =
+        ackArgs -> {
+          if (ackArgs.length == 0 || !(ackArgs[0] instanceof JSONObject)) {
+            ackFuture.completeExceptionally(
+                new IllegalStateException("malformed ack for " + method));
+            return;
+          }
+          ackFuture.complete((JSONObject) ackArgs[0]);
+        };
+    socket.emit("rpc", request, ack);
+
+    JSONObject ackBody;
+    try {
+      ackBody = ackFuture.get(ACK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      throw new RuntimeException("rpc " + method + " failed", e);
+    }
+    if (!ackBody.optBoolean("ok", false)) {
+      JSONObject error = ackBody.optJSONObject("error");
+      throw new IllegalStateException(
+          "rpc " + method + " returned error: " + (error != null ? error : ackBody));
+    }
+    // JSONObject.NULL is normalized to a real null for the caller's convenience.
+    Object result = ackBody.opt("result");
+    return JSONObject.NULL.equals(result) ? null : result;
+  }
+
+  /** Register a listener for server-to-client {@code "event"} pushes. */
+  public void onEvent(Consumer<JSONObject> handler) {
+    socket.on(
+        "event",
+        args -> {
+          if (args.length > 0 && args[0] instanceof JSONObject) {
+            handler.accept((JSONObject) args[0]);
+          }
+        });
+  }
+
+  @Override
+  public void close() {
+    socket.disconnect();
+    socket.close();
+  }
+}

--- a/src/cli/server/__tests__/harnessScenarioVerdict.bun.test.ts
+++ b/src/cli/server/__tests__/harnessScenarioVerdict.bun.test.ts
@@ -132,8 +132,10 @@ describe("issue #111: drive a scenario verdict over the Socket.IO control plane"
       expect(ran.ok).toBe(true);
 
       // 4. Poll the machine-readable report until the run has finished.
+      // ~15s max at 200ms intervals, matching the Java awaitReport contract in
+      // examples/testcontainers-java so both harnesses tolerate slow CI equally.
       let report: any = null;
-      for (let i = 0; i < 25 && !report; i++) {
+      for (let i = 0; i < 75 && !report; i++) {
         const ack = await emitRpc(socket, {
           cpId: CP_ID,
           method: "scenario_report",
@@ -144,7 +146,7 @@ describe("issue #111: drive a scenario verdict over the Socket.IO control plane"
           report = ack.result;
           break;
         }
-        await new Promise((r) => setTimeout(r, 100));
+        await new Promise((r) => setTimeout(r, 200));
       }
 
       // 5. Assert the verdict the way a CSMS certification IT would.

--- a/src/cli/server/__tests__/harnessScenarioVerdict.bun.test.ts
+++ b/src/cli/server/__tests__/harnessScenarioVerdict.bun.test.ts
@@ -1,0 +1,167 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- ack/report payloads are loosely typed in tests */
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Socket } from "socket.io-client";
+
+import { BunSqliteDatabase } from "../../../cp/domain/persistence/BunSqliteDatabase";
+import {
+  connectTestClient,
+  startTestServer,
+  type TestServer,
+} from "./socketHarness";
+
+/**
+ * Issue #111: exercise the exact Socket.IO control-plane sequence an external
+ * JVM/Testcontainers harness uses (examples/testcontainers-java) — cp.create →
+ * load_scenario (inline) → run_scenario → scenario_report — and assert the
+ * machine-readable PASS verdict (#179). This runs the real socket server, so it
+ * both validates the documented contract and guards the Java prototype's flow.
+ *
+ * The CP is never connected (wsUrl points at a dead port), so an ocpp_absent
+ * assertion for Reset is deterministically satisfied → verdict PASS, with no
+ * live CSMS required.
+ */
+const CP_ID = "CP-HARNESS";
+const CONNECTOR = 1;
+
+const INLINE_SCENARIO = {
+  id: "harness-pass-demo",
+  name: "Harness PASS demo",
+  targetType: "connector",
+  targetId: 1,
+  nodes: [
+    {
+      id: "start-1",
+      type: "start",
+      position: { x: 0, y: 0 },
+      data: { label: "S" },
+    },
+    {
+      id: "mv-1",
+      type: "meterValue",
+      position: { x: 0, y: 1 },
+      data: { label: "MV", value: 100, sendMessage: false },
+    },
+    {
+      id: "end-1",
+      type: "end",
+      position: { x: 0, y: 2 },
+      data: { label: "E" },
+    },
+  ],
+  edges: [
+    { id: "e1", source: "start-1", target: "mv-1" },
+    { id: "e2", source: "mv-1", target: "end-1" },
+  ],
+  assertions: [{ id: "no-reset", type: "ocpp_absent", action: "Reset" }],
+};
+
+const servers: TestServer[] = [];
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    await servers.pop()?.close();
+  }
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function emitRpc(socket: Socket, request: unknown): Promise<any> {
+  return socket.timeout(5_000).emitWithAck("rpc", request);
+}
+
+async function serverWithDb(): Promise<TestServer> {
+  const dir = mkdtempSync(join(tmpdir(), "ocpp-harness-verdict-"));
+  tempDirs.push(dir);
+  const db = BunSqliteDatabase.open(join(dir, "state.db"));
+  const server = await startTestServer({ database: db });
+  servers.push(server);
+  return server;
+}
+
+describe("issue #111: drive a scenario verdict over the Socket.IO control plane", () => {
+  it("cp.create → load_scenario → run_scenario → scenario_report yields PASS", async () => {
+    const server = await serverWithDb();
+    const socket = await connectTestClient(server);
+    const events: any[] = [];
+    socket.on("event", (envelope: any) => events.push(envelope));
+
+    try {
+      // 1. Create a CP pointed at a dead port so it never connects to a CSMS.
+      const created = await emitRpc(socket, {
+        method: "cp.create",
+        params: {
+          cpId: CP_ID,
+          wsUrl: "ws://127.0.0.1:65534/never",
+          connectors: 1,
+        },
+      });
+      expect(created.ok).toBe(true);
+
+      // The registry lists it.
+      const list = await emitRpc(socket, { method: "cp.list", params: {} });
+      expect(list.ok).toBe(true);
+      expect(list.result.some((cp: any) => cp.cpId === CP_ID)).toBe(true);
+
+      // 2. Subscribe to this CP's events before running.
+      const subscribed = await emitRpc(socket, {
+        method: "events.subscribe",
+        params: { scope: CP_ID },
+      });
+      expect(subscribed.ok).toBe(true);
+
+      // 3. Load the inline scenario, then run it.
+      const loaded = await emitRpc(socket, {
+        cpId: CP_ID,
+        method: "load_scenario",
+        params: { connector: CONNECTOR, scenario: INLINE_SCENARIO },
+      });
+      expect(loaded.ok).toBe(true);
+      const scenarioId: string =
+        typeof loaded.result === "string" ? loaded.result : INLINE_SCENARIO.id;
+
+      const ran = await emitRpc(socket, {
+        cpId: CP_ID,
+        method: "run_scenario",
+        params: { connector: CONNECTOR, scenarioId },
+      });
+      expect(ran.ok).toBe(true);
+
+      // 4. Poll the machine-readable report until the run has finished.
+      let report: any = null;
+      for (let i = 0; i < 25 && !report; i++) {
+        const ack = await emitRpc(socket, {
+          cpId: CP_ID,
+          method: "scenario_report",
+          params: { connector: CONNECTOR, scenarioId },
+        });
+        expect(ack.ok).toBe(true);
+        if (ack.result && ack.result.verdict) {
+          report = ack.result;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 100));
+      }
+
+      // 5. Assert the verdict the way a CSMS certification IT would.
+      expect(report).not.toBeNull();
+      expect(report.schemaVersion).toBe(1);
+      expect(report.verdict).toBe("PASS");
+      expect(report.assertions).toHaveLength(1);
+      expect(report.assertions[0]).toMatchObject({
+        id: "no-reset",
+        type: "ocpp_absent",
+        status: "passed",
+      });
+
+      // The event stream carried the scenario lifecycle too.
+      expect(events.some((e) => e.kind === "cp")).toBe(true);
+    } finally {
+      socket.disconnect();
+    }
+  });
+});


### PR DESCRIPTION
Addresses #111 (the "WireMock of OCPP" idea) with a concrete starting point.

## What this adds

`examples/testcontainers-java/` — a minimal prototype of driving the simulator as a **turnkey OCPP charge-point stub** from a JVM test suite. A CSMS project can spin up the simulator container, `cp.create` a charge point pointed at its CSMS-under-test, `run_scenario` a built-in certification scenario (#110), and assert the machine-readable verdict (#179) — without hand-coding the charge-point side per project.

`CertificationScenarioIT` drives the daemon entirely over the documented [Socket.IO control plane](../docs/server.md):

1. start the image with Testcontainers, wait on `GET /v1/healthz`;
2. connect Socket.IO, `cp.create`;
3. `events.subscribe`;
4. `load_scenario` (inline) + `run_scenario`;
5. poll `scenario_report`, assert `verdict == "PASS"`.

Self-contained: the CP's `wsUrl` points at a dead port, so it never connects to a CSMS and an `ocpp_absent` assertion for `Reset` is deterministically satisfied → PASS. Pointing `wsUrl` at a real CSMS-under-test and running a `TC_xxx` template is the same shape.

## Why it's trustworthy despite not running in CI

The Java is authored against `docs/server.md` and is **not** wired into this repo's (TypeScript) CI. To guard the exact flow it demonstrates, this PR also adds `src/cli/server/__tests__/harnessScenarioVerdict.bun.test.ts`, which drives the **identical RPC sequence against the real socket server** and asserts the PASS verdict — so the contract the example depends on is covered by CI.

## On #111's other asks

- The one named **code gap** — `securityProfile` / `authorizationKey` / SOAP callback config on `cp.create`/`cp.update` — is **already closed and wired** (schema in `src/protocol/methods.ts`, persisted + validated in `CPRegistry`). So a harness can already drive secured and SOAP certification scenarios.
- The **API-stability commitment** (is the Socket.IO control plane a versioned contract external harnesses can rely on?) is a maintainer decision, left open here.
- A full Testcontainers **module + thin client** is a natural follow-up; the issue author offered to prototype the Java side, and this is a foundation for that.

## Verification

- New bun test: green (drives cp.create → load_scenario → run_scenario → scenario_report → PASS over the real socket server).
- `tsc -b --noEmit` — no new errors (baseline unchanged).
- `bun test bun.test` — 217/0 (includes the new test).
- prettier / eslint clean. The Java prototype was not compiled here (no JVM in CI); it targets stable Testcontainers / socket.io-client APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Java + Testcontainers example harness for running end-to-end simulator certification scenarios.
  - Updated documentation with setup, prerequisites, execution steps, and configuration options for the harness.
  - Added an end-to-end control-plane flow (Socket.IO) that creates a charge point, runs an inline scenario, and validates the resulting verdict.

- **Tests**
  - Added Bun end-to-end coverage for the full certification scenario lifecycle and `PASS` verdict reporting.
  - Added a Java integration test using Testcontainers to exercise the same certification flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->