### PR TITLE
feat(trace): versioned OCPP trace format + log adapter (#188 PoC)

### DIFF
--- a/docs/trace-format.md
+++ b/docs/trace-format.md
@@ -1,0 +1,119 @@
+# OCPP Trace Format (v1.0)
+
+A small, **implementation-independent** JSON/JSONL format for one OCPP message
+exchange. It is intended as a shared contract between tools that _produce_ OCPP
+traffic (this simulator) and tools that _analyze_ it (e.g.
+[OCPP DebugKit](https://github.com/ocpp-debugkit/toolkit)), without coupling
+either side to the other's internal models — see
+[issue #188](https://github.com/shiv3/ocpp-cp-simulator/issues/188).
+
+This is a **proof of concept**: it defines and versions the record shape and
+ships an adapter from the simulator's own logs. Producing trace files from a run
+(a `--trace-output` flag / an `analyze` subcommand) and any DebugKit integration
+are deliberately later steps.
+
+## Status & scope
+
+- **Version `1.0`** (`schemaVersion`). Bump on any breaking change.
+- This iteration recognizes **OCPP-J (JSON/WebSocket)** frames. SOAP transport
+  is a documented follow-up (the format already carries a `transport` field).
+- The format is usable without this simulator or DebugKit; it is a plain JSON
+  object per exchange (JSONL for a stream).
+
+## Record shape
+
+| Field           | Type                                           | Notes                                                                              |
+| --------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `schemaVersion` | string                                         | Trace schema version, e.g. `"1.0"`.                                                |
+| `timestamp`     | string (ISO-8601)                              | When the message was observed.                                                     |
+| `ocppVersion`   | string (optional)                              | OCPP protocol version, e.g. `"1.6"`, `"2.0.1"`.                                    |
+| `transport`     | `"json"` \| `"soap"`                           | Wire transport.                                                                    |
+| `chargePointId` | string (optional)                              | Charge-point identity.                                                             |
+| `connectorId`   | number (optional)                              | Connector id when connector-scoped and known.                                      |
+| `direction`     | `"cp-to-csms"` \| `"csms-to-cp"`               | Relative to the CP/CSMS pair.                                                      |
+| `messageType`   | `"CALL"` \| `"CALLRESULT"` \| `"CALLERROR"`    | OCPP-J frame kind.                                                                 |
+| `messageId`     | string (optional)                              | Correlates a CALL with its CALLRESULT/CALLERROR.                                   |
+| `action`        | string (optional)                              | e.g. `"BootNotification"`. On CALLRESULT/CALLERROR, back-filled by id correlation. |
+| `payload`       | any (optional)                                 | The OCPP message body.                                                             |
+| `error`         | `{ code?, description?, details? }` (optional) | Populated for CALLERROR only.                                                      |
+| `meta`          | object (optional)                              | Transport/execution metadata and analysis-specific extensions.                     |
+
+## Example
+
+```json
+{
+  "schemaVersion": "1.0",
+  "timestamp": "2026-07-14T02:00:00.000Z",
+  "ocppVersion": "1.6",
+  "transport": "json",
+  "chargePointId": "CP001",
+  "direction": "cp-to-csms",
+  "messageType": "CALL",
+  "messageId": "abc-1",
+  "action": "BootNotification",
+  "payload": { "chargePointVendor": "Example", "chargePointModel": "Simulator" }
+}
+```
+
+## Producing records
+
+The adapter in [`src/trace/`](../src/trace/) maps this simulator's JSONL log
+lines (`--log-format json`, the `logs.get` RPC, or the browser log-viewer
+download) into trace records:
+
+```ts
+import { logLinesToTrace } from "../src/trace/logEntryToTrace";
+
+const records = logLinesToTrace(jsonlLogLines, { ocppVersion: "1.6" });
+```
+
+`logLinesToTrace` drops non-wire log lines and back-fills each
+CALLRESULT/CALLERROR `action` from the CALL that established its `messageId`.
+`logLineToTraceRecord` converts a single line (returning `null` for non-wire
+lines). The type lives in `src/trace/OcppTraceRecord.ts` and
+`OCPP_TRACE_SCHEMA_VERSION` is the current version string.
+
+## JSON Schema
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/shiv3/ocpp-cp-simulator/docs/trace-format.md#v1.0",
+  "title": "OcppTraceRecord",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "timestamp",
+    "transport",
+    "direction",
+    "messageType"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "type": "string" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "ocppVersion": { "type": "string" },
+    "transport": { "type": "string", "enum": ["json", "soap"] },
+    "chargePointId": { "type": "string" },
+    "connectorId": { "type": "integer", "minimum": 0 },
+    "direction": { "type": "string", "enum": ["cp-to-csms", "csms-to-cp"] },
+    "messageType": {
+      "type": "string",
+      "enum": ["CALL", "CALLRESULT", "CALLERROR"]
+    },
+    "messageId": { "type": "string" },
+    "action": { "type": "string" },
+    "payload": {},
+    "error": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "code": { "type": "string" },
+        "description": { "type": "string" },
+        "details": {}
+      }
+    },
+    "meta": { "type": "object" }
+  }
+}
+```

--- a/docs/trace-format.md
+++ b/docs/trace-format.md
@@ -114,6 +114,20 @@ lines). The type lives in `src/trace/OcppTraceRecord.ts` and
       }
     },
     "meta": { "type": "object" }
-  }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "messageType": { "const": "CALL" } } },
+      "then": { "required": ["action"] }
+    },
+    {
+      "if": { "properties": { "messageType": { "const": "CALLERROR" } } },
+      "then": { "required": ["error"] },
+      "else": { "properties": { "error": false } }
+    }
+  ]
 }
 ```
+
+The `allOf` conditionals mirror what the adapter emits: a `CALL` always carries
+an `action`, and `error` is present only on `CALLERROR`.

--- a/src/trace/OcppTraceRecord.ts
+++ b/src/trace/OcppTraceRecord.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared, versioned OCPP trace format (issue #188).
+ *
+ * A small, implementation-independent record for one OCPP message exchange,
+ * designed to be usable *without* coupling to this simulator's internal log
+ * model, Socket.IO contracts, persistence, or UI — so it can be consumed by
+ * external analysis tools (e.g. OCPP DebugKit), shared as CI artifacts, or used
+ * for reproducible bug reports and regression fixtures.
+ *
+ * This is the schema definition only. {@link ./logEntryToTrace} adapts the
+ * simulator's own JSONL log lines into these records; a documented JSON Schema
+ * lives in `docs/trace-format.md`.
+ */
+
+/** Bump on any breaking change to the record shape. Consumers should check it. */
+export const OCPP_TRACE_SCHEMA_VERSION = "1.0";
+
+/** Direction relative to the charge point / CSMS pair. */
+export type TraceDirection = "cp-to-csms" | "csms-to-cp";
+
+/** OCPP-J message frame kind. */
+export type TraceMessageType = "CALL" | "CALLRESULT" | "CALLERROR";
+
+/** Wire transport the message travelled over. */
+export type TraceTransport = "json" | "soap";
+
+/** CALLERROR detail, mapped from the OCPP-J `[4, id, code, description, details]` frame. */
+export interface TraceError {
+  code?: string;
+  description?: string;
+  details?: unknown;
+}
+
+/** One OCPP message exchange in the shared, tool-independent trace format. */
+export interface OcppTraceRecord {
+  /** Trace schema version, e.g. "1.0" ({@link OCPP_TRACE_SCHEMA_VERSION}). */
+  schemaVersion: string;
+  /** ISO-8601 timestamp of the message. */
+  timestamp: string;
+  /** OCPP protocol version, e.g. "1.6", "2.0.1" (when known). */
+  ocppVersion?: string;
+  /** Transport the message travelled over. */
+  transport: TraceTransport;
+  /** Charge-point identity (when known). */
+  chargePointId?: string;
+  /** Connector id, when the message is connector-scoped and known. */
+  connectorId?: number;
+  /** Message direction relative to the CP/CSMS pair. */
+  direction: TraceDirection;
+  /** OCPP-J frame kind. */
+  messageType: TraceMessageType;
+  /** OCPP message id used to correlate a CALL with its CALLRESULT/CALLERROR. */
+  messageId?: string;
+  /**
+   * Action name, e.g. "BootNotification". Present on CALL frames; on
+   * CALLRESULT/CALLERROR it is back-filled by message-id correlation when the
+   * originating CALL is available, otherwise omitted (correlate by messageId).
+   */
+  action?: string;
+  /** Request/response payload (the OCPP message body). */
+  payload?: unknown;
+  /** Populated for CALLERROR frames only. */
+  error?: TraceError;
+  /** Optional transport/execution metadata and analysis-specific extensions. */
+  meta?: Record<string, unknown>;
+}

--- a/src/trace/__tests__/logEntryToTrace.test.ts
+++ b/src/trace/__tests__/logEntryToTrace.test.ts
@@ -123,4 +123,24 @@ describe("logLinesToTrace", () => {
     expect(records).toHaveLength(1);
     expect(records[0].action).toBeUndefined();
   });
+
+  it("scopes correlation per charge point when a batch reuses a messageId", () => {
+    // Two CPs both use messageId "1"; each CALLRESULT must inherit its own CP's
+    // action, not the other's.
+    const records = logLinesToTrace([
+      line('Sent: [2,"1","BootNotification",{}]', { cpId: "CP-A" }),
+      line('Sent: [2,"1","Heartbeat",{}]', { cpId: "CP-B" }),
+      line('Received: [3,"1",{"status":"Accepted"}]', { cpId: "CP-A" }),
+      line('Received: [3,"1",{}]', { cpId: "CP-B" }),
+    ]);
+
+    const resultA = records.find(
+      (r) => r.chargePointId === "CP-A" && r.messageType === "CALLRESULT",
+    );
+    const resultB = records.find(
+      (r) => r.chargePointId === "CP-B" && r.messageType === "CALLRESULT",
+    );
+    expect(resultA?.action).toBe("BootNotification");
+    expect(resultB?.action).toBe("Heartbeat");
+  });
 });

--- a/src/trace/__tests__/logEntryToTrace.test.ts
+++ b/src/trace/__tests__/logEntryToTrace.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { OCPP_TRACE_SCHEMA_VERSION } from "../OcppTraceRecord";
+import {
+  logLineToTraceRecord,
+  logLinesToTrace,
+  type SerializedLogLine,
+} from "../logEntryToTrace";
+
+function line(
+  message: string,
+  extra: Partial<SerializedLogLine> = {},
+): SerializedLogLine {
+  return {
+    timestamp: "2026-07-14T02:00:00.000Z",
+    level: "INFO",
+    type: "WebSocket",
+    message,
+    ...extra,
+  };
+}
+
+describe("logLineToTraceRecord", () => {
+  it("maps a sent CALL frame to a cp-to-csms record with action and payload", () => {
+    const record = logLineToTraceRecord(
+      line(
+        'Sent: [2,"abc-1","BootNotification",{"chargePointVendor":"Example"}]',
+        { cpId: "CP001" },
+      ),
+      { ocppVersion: "1.6" },
+    );
+
+    expect(record).toEqual({
+      schemaVersion: OCPP_TRACE_SCHEMA_VERSION,
+      timestamp: "2026-07-14T02:00:00.000Z",
+      transport: "json",
+      ocppVersion: "1.6",
+      chargePointId: "CP001",
+      direction: "cp-to-csms",
+      messageType: "CALL",
+      messageId: "abc-1",
+      action: "BootNotification",
+      payload: { chargePointVendor: "Example" },
+    });
+  });
+
+  it("maps a received CALLRESULT frame to a csms-to-cp record (no action on its own)", () => {
+    const record = logLineToTraceRecord(
+      line('Received: [3,"abc-1",{"status":"Accepted"}]'),
+    );
+    expect(record).toMatchObject({
+      direction: "csms-to-cp",
+      messageType: "CALLRESULT",
+      messageId: "abc-1",
+      payload: { status: "Accepted" },
+    });
+    expect(record?.action).toBeUndefined();
+  });
+
+  it("maps a CALLERROR frame into the error field", () => {
+    const record = logLineToTraceRecord(
+      line('Received: [4,"abc-2","NotSupported","Boom",{"x":1}]'),
+    );
+    expect(record).toMatchObject({
+      messageType: "CALLERROR",
+      messageId: "abc-2",
+      error: { code: "NotSupported", description: "Boom", details: { x: 1 } },
+    });
+  });
+
+  it("returns null for a non-wire log line", () => {
+    expect(logLineToTraceRecord(line("Boot notification accepted"))).toBeNull();
+    expect(
+      logLineToTraceRecord(line("Suppressing StatusNotification: boot gate")),
+    ).toBeNull();
+  });
+
+  it("prefers the line's cpId over the context fallback", () => {
+    const record = logLineToTraceRecord(
+      line('Sent: [2,"id","Heartbeat",{}]', { cpId: "CP-LINE" }),
+      { chargePointId: "CP-CTX" },
+    );
+    expect(record?.chargePointId).toBe("CP-LINE");
+  });
+
+  it("falls back to the context chargePointId when the line has none", () => {
+    const record = logLineToTraceRecord(line('Sent: [2,"id","Heartbeat",{}]'), {
+      chargePointId: "CP-CTX",
+    });
+    expect(record?.chargePointId).toBe("CP-CTX");
+  });
+});
+
+describe("logLinesToTrace", () => {
+  it("drops non-wire lines and back-fills CALLRESULT action by messageId", () => {
+    const records = logLinesToTrace([
+      line("Boot notification accepted"),
+      line('Sent: [2,"m-1","BootNotification",{"chargePointVendor":"V"}]', {
+        cpId: "CP001",
+      }),
+      line("Some diagnostic chatter"),
+      line('Received: [3,"m-1",{"status":"Accepted"}]', { cpId: "CP001" }),
+    ]);
+
+    expect(records).toHaveLength(2);
+    expect(records[0]).toMatchObject({
+      messageType: "CALL",
+      action: "BootNotification",
+      direction: "cp-to-csms",
+    });
+    // The CALLRESULT inherits the action from the correlated CALL.
+    expect(records[1]).toMatchObject({
+      messageType: "CALLRESULT",
+      messageId: "m-1",
+      action: "BootNotification",
+      direction: "csms-to-cp",
+    });
+  });
+
+  it("leaves an uncorrelated CALLRESULT action undefined", () => {
+    const records = logLinesToTrace([
+      line('Received: [3,"orphan",{"status":"Accepted"}]'),
+    ]);
+    expect(records).toHaveLength(1);
+    expect(records[0].action).toBeUndefined();
+  });
+});

--- a/src/trace/logEntryToTrace.ts
+++ b/src/trace/logEntryToTrace.ts
@@ -1,0 +1,176 @@
+/**
+ * Adapt this simulator's JSONL log lines into the shared, versioned OCPP trace
+ * format (issue #188). Neutral by design: it maps *from* the simulator's own
+ * text log *to* the tool-independent {@link OcppTraceRecord}, so the format
+ * stays decoupled from the simulator's internals.
+ *
+ * Only OCPP-J (JSON/WebSocket) wire frames are recognized in this first
+ * iteration; SOAP transport is a documented follow-up. Non-wire log lines
+ * (diagnostics, scenario/general logs) map to `null`.
+ */
+
+import {
+  OCPP_TRACE_SCHEMA_VERSION,
+  type OcppTraceRecord,
+  type TraceDirection,
+  type TraceError,
+  type TraceMessageType,
+  type TraceTransport,
+} from "./OcppTraceRecord";
+
+/** A serialized simulator log line (`--log-format json`, `logs.get`, or the
+ *  browser log-viewer download): `{ timestamp, level, type, message, cpId? }`. */
+export interface SerializedLogLine {
+  timestamp: string;
+  level?: string;
+  type?: string;
+  message: string;
+  cpId?: string;
+}
+
+export interface TraceContext {
+  /** OCPP protocol version to stamp on records, e.g. "1.6". */
+  ocppVersion?: string;
+  /** Transport override; defaults to "json" (OCPP-J / WebSocket). */
+  transport?: TraceTransport;
+  /** Charge-point id fallback when a log line carries no `cpId`. */
+  chargePointId?: string;
+}
+
+const WS_SENT_PREFIX = "Sent: ";
+const WS_RECEIVED_PREFIX = "Received: ";
+
+const OCPPJ_CALL = 2;
+const OCPPJ_CALLRESULT = 3;
+const OCPPJ_CALLERROR = 4;
+
+interface ParsedFrame {
+  direction: TraceDirection;
+  messageType: TraceMessageType;
+  messageId?: string;
+  action?: string;
+  payload?: unknown;
+  error?: TraceError;
+}
+
+function parseOcppJArray(
+  json: string,
+  direction: TraceDirection,
+): ParsedFrame | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed) || parsed.length < 3) return null;
+  const [type, id] = parsed;
+  if (typeof id !== "string" && typeof id !== "number") return null;
+  const messageId = String(id);
+
+  if (type === OCPPJ_CALL && typeof parsed[2] === "string") {
+    return {
+      direction,
+      messageType: "CALL",
+      messageId,
+      action: parsed[2],
+      payload: parsed[3],
+    };
+  }
+  if (type === OCPPJ_CALLRESULT) {
+    return {
+      direction,
+      messageType: "CALLRESULT",
+      messageId,
+      payload: parsed[2],
+    };
+  }
+  if (type === OCPPJ_CALLERROR) {
+    return {
+      direction,
+      messageType: "CALLERROR",
+      messageId,
+      error: {
+        code: typeof parsed[2] === "string" ? parsed[2] : undefined,
+        description: typeof parsed[3] === "string" ? parsed[3] : undefined,
+        details: parsed[4],
+      },
+    };
+  }
+  return null;
+}
+
+function parseWireFrame(message: string): ParsedFrame | null {
+  if (message.startsWith(WS_SENT_PREFIX)) {
+    return parseOcppJArray(message.slice(WS_SENT_PREFIX.length), "cp-to-csms");
+  }
+  if (message.startsWith(WS_RECEIVED_PREFIX)) {
+    return parseOcppJArray(
+      message.slice(WS_RECEIVED_PREFIX.length),
+      "csms-to-cp",
+    );
+  }
+  return null;
+}
+
+function toRecord(
+  line: SerializedLogLine,
+  frame: ParsedFrame,
+  context: TraceContext,
+): OcppTraceRecord {
+  const record: OcppTraceRecord = {
+    schemaVersion: OCPP_TRACE_SCHEMA_VERSION,
+    timestamp: line.timestamp,
+    transport: context.transport ?? "json",
+    direction: frame.direction,
+    messageType: frame.messageType,
+  };
+  const ocppVersion = context.ocppVersion;
+  if (ocppVersion) record.ocppVersion = ocppVersion;
+  const chargePointId = line.cpId ?? context.chargePointId;
+  if (chargePointId) record.chargePointId = chargePointId;
+  if (frame.messageId !== undefined) record.messageId = frame.messageId;
+  if (frame.action !== undefined) record.action = frame.action;
+  if (frame.payload !== undefined) record.payload = frame.payload;
+  if (frame.error !== undefined) record.error = frame.error;
+  return record;
+}
+
+/**
+ * Convert a single log line to a trace record, or `null` if it is not an
+ * OCPP-J wire frame. CALLRESULT/CALLERROR records carry no `action` (there is
+ * no cross-line context here); use {@link logLinesToTrace} to back-fill it.
+ */
+export function logLineToTraceRecord(
+  line: SerializedLogLine,
+  context: TraceContext = {},
+): OcppTraceRecord | null {
+  const frame = parseWireFrame(line.message);
+  if (!frame) return null;
+  return toRecord(line, frame, context);
+}
+
+/**
+ * Convert a chronological batch of log lines to trace records, dropping
+ * non-wire lines and back-filling each CALLRESULT/CALLERROR `action` from the
+ * CALL that established its `messageId`.
+ */
+export function logLinesToTrace(
+  lines: readonly SerializedLogLine[],
+  context: TraceContext = {},
+): OcppTraceRecord[] {
+  const actionByMessageId = new Map<string, string>();
+  const records: OcppTraceRecord[] = [];
+  for (const line of lines) {
+    const record = logLineToTraceRecord(line, context);
+    if (!record) continue;
+    if (record.action && record.messageId) {
+      actionByMessageId.set(record.messageId, record.action);
+    } else if (!record.action && record.messageId) {
+      const resolved = actionByMessageId.get(record.messageId);
+      if (resolved) record.action = resolved;
+    }
+    records.push(record);
+  }
+  return records;
+}

--- a/src/trace/logEntryToTrace.ts
+++ b/src/trace/logEntryToTrace.ts
@@ -150,25 +150,35 @@ export function logLineToTraceRecord(
   return toRecord(line, frame, context);
 }
 
+/** Correlation key scoped per charge point: a batch can interleave multiple CPs
+ *  (e.g. the daemon's JSON log), and two CPs may reuse the same messageId. The
+ *  JSON tuple stays unambiguous whatever the cpId/messageId contain. */
+function correlationKey(record: OcppTraceRecord): string {
+  return JSON.stringify([record.chargePointId ?? "", record.messageId]);
+}
+
 /**
  * Convert a chronological batch of log lines to trace records, dropping
  * non-wire lines and back-filling each CALLRESULT/CALLERROR `action` from the
- * CALL that established its `messageId`.
+ * CALL that established its `messageId` (correlated per charge point).
  */
 export function logLinesToTrace(
   lines: readonly SerializedLogLine[],
   context: TraceContext = {},
 ): OcppTraceRecord[] {
-  const actionByMessageId = new Map<string, string>();
+  const actionByKey = new Map<string, string>();
   const records: OcppTraceRecord[] = [];
   for (const line of lines) {
     const record = logLineToTraceRecord(line, context);
     if (!record) continue;
-    if (record.action && record.messageId) {
-      actionByMessageId.set(record.messageId, record.action);
-    } else if (!record.action && record.messageId) {
-      const resolved = actionByMessageId.get(record.messageId);
-      if (resolved) record.action = resolved;
+    if (record.messageId !== undefined) {
+      const key = correlationKey(record);
+      if (record.action) {
+        actionByKey.set(key, record.action);
+      } else {
+        const resolved = actionByKey.get(key);
+        if (resolved) record.action = resolved;
+      }
     }
     records.push(record);
   }


### PR DESCRIPTION
Addresses [#188](https://github.com/shiv3/ocpp-cp-simulator/issues/188) — the first step of its proof of concept: **document and version a shared OCPP trace format**, and adapt the simulator's own logs into it.

## What this adds

A small, **implementation-independent** trace format (`schemaVersion "1.0"`) for one OCPP message exchange, so simulator output can be consumed by external analysis tools (e.g. [OCPP DebugKit](https://github.com/ocpp-debugkit/toolkit)), shared as CI artifacts, or used for reproducible bug reports — **without coupling either side's internal models**.

- `src/trace/OcppTraceRecord.ts` — the versioned record type + `OCPP_TRACE_SCHEMA_VERSION`. Fields follow #188's proposal: `schemaVersion`, `timestamp`, `ocppVersion`, `transport`, `chargePointId`, `connectorId`, `direction`, `messageType`, `messageId`, `action`, `payload`, `error`, `meta`.
- `src/trace/logEntryToTrace.ts` — an adapter **from** the simulator's JSONL log lines (`--log-format json` / `logs.get` / the log-viewer download) **to** neutral trace records. `logLinesToTrace` drops non-wire lines and back-fills each CALLRESULT/CALLERROR `action` from the correlated CALL by `messageId`; `logLineToTraceRecord` handles a single line.
- `docs/trace-format.md` — field table, example, and a JSON Schema.
- Unit tests for the adapter.

## Scope (deliberately a PoC)

- **OCPP-J (JSON/WebSocket)** frames only in this iteration; SOAP is a documented follow-up (the format already carries a `transport` field).
- Producing trace files from a run (a `--trace-output` flag / an `analyze` subcommand) and any DebugKit integration are **out of scope** here, per the issue's staged plan.
- Direction is normalized to `cp-to-csms` / `csms-to-cp`; the format stays usable without this simulator or DebugKit.

## On the open questions in #188

Schema ownership (this repo vs. a dedicated repo vs. a published JSON Schema package), whether to depend on `@ocpp-debugkit/toolkit` directly or via an adapter, and the UI/analysis integration are **strategic/collaboration decisions** left to the maintainers and the DebugKit side — this PR just lands a concrete, versioned starting point to discuss against.

## Verification

- `vitest` — new adapter tests green (8).
- `tsc -b --noEmit` — no new errors (baseline unchanged).
- `bun test bun.test` — unaffected.
- prettier / eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a standardized, versioned “OCPP Trace Format” contract for sharing trace records as JSON/JSONL.
  * Added a converter that transforms simulator WebSocket log lines into structured trace records, including transport, direction, message type, correlation, payload/action, and error details.
  * Automatically correlates CALL with subsequent CALLRESULT/CALLERROR, scoped correctly per charge point.
* **Documentation**
  * Added a new documentation spec with required/optional fields, examples, and validation rules via JSON Schema.
* **Tests**
  * Added test coverage for parsing, correlation, filtering of non-wire lines, and error mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->