### PR TITLE
fix(scenario): reconcile daemon runtime on web-console upload so connect-auto-start sees it (#209)

### DIFF
--- a/src/cli/__tests__/service.syncConnectorRuntimeScenarios.bun.test.ts
+++ b/src/cli/__tests__/service.syncConnectorRuntimeScenarios.bun.test.ts
@@ -29,35 +29,31 @@ function scenario(
   id: string,
   opts: { delay?: boolean } = {},
 ): ScenarioDefinition {
-  const nodes = [
-    {
-      id: "s",
-      type: ScenarioNodeType.START,
-      position: { x: 0, y: 0 },
-      data: { label: "S" },
-    },
-  ];
-  if (opts.delay) {
-    nodes.push({
-      id: "d",
-      type: ScenarioNodeType.DELAY,
-      position: { x: 0, y: 1 },
-      data: { label: "wait", delaySeconds: 60 },
-    } as (typeof nodes)[number]);
-  }
-  nodes.push({
+  const start = {
+    id: "s",
+    type: ScenarioNodeType.START,
+    position: { x: 0, y: 0 },
+    data: { label: "S" },
+  };
+  const delayNode = {
+    id: "d",
+    type: ScenarioNodeType.DELAY,
+    position: { x: 0, y: 1 },
+    data: { label: "wait", delaySeconds: 60 },
+  };
+  const end = {
     id: "e",
     type: ScenarioNodeType.END,
     position: { x: 0, y: 2 },
     data: { label: "E" },
-  });
-  const edges =
-    nodes.length === 3
-      ? [
-          { id: "e1", source: "s", target: "d" },
-          { id: "e2", source: "d", target: "e" },
-        ]
-      : [{ id: "e1", source: "s", target: "e" }];
+  };
+  const nodes = opts.delay ? [start, delayNode, end] : [start, end];
+  const edges = opts.delay
+    ? [
+        { id: "e1", source: "s", target: "d" },
+        { id: "e2", source: "d", target: "e" },
+      ]
+    : [{ id: "e1", source: "s", target: "e" }];
   return {
     id,
     name: id,

--- a/src/cli/__tests__/service.syncConnectorRuntimeScenarios.bun.test.ts
+++ b/src/cli/__tests__/service.syncConnectorRuntimeScenarios.bun.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "bun:test";
+import { CLIChargePointService } from "../service";
+import { BunSqliteDatabase } from "../../cp/domain/persistence/BunSqliteDatabase";
+import {
+  ScenarioDefinition,
+  ScenarioNodeType,
+} from "../../cp/application/scenario/ScenarioTypes";
+
+/**
+ * Unit coverage for CLIChargePointService.syncConnectorRuntimeScenarios — the
+ * runtime reconcile that fixes issue #209.
+ */
+function newService(): CLIChargePointService {
+  const db = BunSqliteDatabase.open(":memory:");
+  return new CLIChargePointService(
+    {
+      cpId: "cp-209-unit",
+      wsUrl: "ws://127.0.0.1:65534/never",
+      connectors: 1,
+      vendor: "v",
+      model: "m",
+      basicAuth: null,
+    },
+    db,
+  );
+}
+
+function scenario(
+  id: string,
+  opts: { delay?: boolean } = {},
+): ScenarioDefinition {
+  const nodes = [
+    {
+      id: "s",
+      type: ScenarioNodeType.START,
+      position: { x: 0, y: 0 },
+      data: { label: "S" },
+    },
+  ];
+  if (opts.delay) {
+    nodes.push({
+      id: "d",
+      type: ScenarioNodeType.DELAY,
+      position: { x: 0, y: 1 },
+      data: { label: "wait", delaySeconds: 60 },
+    } as (typeof nodes)[number]);
+  }
+  nodes.push({
+    id: "e",
+    type: ScenarioNodeType.END,
+    position: { x: 0, y: 2 },
+    data: { label: "E" },
+  });
+  const edges =
+    nodes.length === 3
+      ? [
+          { id: "e1", source: "s", target: "d" },
+          { id: "e2", source: "d", target: "e" },
+        ]
+      : [{ id: "e1", source: "s", target: "e" }];
+  return {
+    id,
+    name: id,
+    targetType: "connector",
+    targetId: 1,
+    trigger: { type: "manual" },
+    enabled: true,
+    nodes,
+    edges,
+    createdAt: "2026-07-14T00:00:00Z",
+    updatedAt: "2026-07-14T00:00:00Z",
+  } as ScenarioDefinition;
+}
+
+function ids(service: CLIChargePointService): string[] {
+  return service.listScenarios(1).map((s) => s.scenarioId);
+}
+
+describe("syncConnectorRuntimeScenarios (#209)", () => {
+  it("replaces stale runtime entries with the uploaded set", () => {
+    const service = newService();
+    service.loadScenario(1, scenario("stale"));
+    expect(ids(service)).toContain("stale");
+
+    service.syncConnectorRuntimeScenarios(1, [scenario("fresh")]);
+
+    const after = ids(service);
+    expect(after).toContain("fresh");
+    expect(after).not.toContain("stale");
+    service.cleanup();
+  });
+
+  it("discards an in-flight run when its connector's definitions are replaced", () => {
+    const service = newService();
+    const runningId = service.loadScenario(
+      1,
+      scenario("running", { delay: true }),
+    );
+    service.runScenario(1, runningId);
+    expect(
+      service.listScenarios(1).find((s) => s.scenarioId === runningId)?.active,
+    ).toBe(true);
+
+    service.syncConnectorRuntimeScenarios(1, [scenario("next")]);
+
+    // The running scenario is gone (executor stopped) and the new one is loaded.
+    const after = ids(service);
+    expect(after).toEqual(["next"]);
+    expect(after).not.toContain(runningId);
+    service.cleanup();
+  });
+
+  it("is a no-op for a CP-level (null) connector", () => {
+    const service = newService();
+    service.loadScenario(1, scenario("keep"));
+    expect(() =>
+      service.syncConnectorRuntimeScenarios(null, [scenario("x")]),
+    ).not.toThrow();
+    expect(ids(service)).toEqual(["keep"]);
+    service.cleanup();
+  });
+});

--- a/src/cli/server/RegistryChargePointService.ts
+++ b/src/cli/server/RegistryChargePointService.ts
@@ -443,6 +443,14 @@ export class RegistryChargePointService implements ChargePointService {
       definitions,
     );
     await this.deps.database?.flush?.();
+    // #209: the DB is now authoritative, but the daemon runtime scenario map
+    // (read by connect-auto-start) still holds the stale seeded default and
+    // lacks the upload. Reconcile it so a connect-triggered scenario uploaded
+    // from the web console actually fires on connect. No-op when the CP isn't
+    // currently instantiated (definitions-only edit) — restore rebuilds it.
+    this.registry
+      .get(id)
+      ?.syncConnectorRuntimeScenarios(connectorId, definitions);
     return [...definitions];
   }
 

--- a/src/cli/server/__tests__/scenarioUploadConnectAutoStart.bun.test.ts
+++ b/src/cli/server/__tests__/scenarioUploadConnectAutoStart.bun.test.ts
@@ -123,33 +123,37 @@ describe("issue #209: connect-auto-start after a web-console upload", () => {
       });
       await connectAck;
 
-      // 4. Give connect-auto-start time to fire.
-      await new Promise((r) => setTimeout(r, 400));
-
-      // 5. Did the scenario auto-start? Report is non-null once a run finished;
-      //    a running scenario shows a non-idle status.
-      const report = (
-        await emitRpc(socket, {
-          cpId,
-          method: "scenario_report",
-          params: { connector: CONNECTOR, scenarioId: scenario.id },
-        })
-      ).result;
-      const status = (
-        await emitRpc(socket, {
-          cpId,
-          method: "scenario_status",
-          params: { connector: CONNECTOR, scenarioId: scenario.id },
-        })
-      ).result;
-
-      const started =
-        (report && report.verdict) ||
-        (status &&
-          (status.running ||
-            status.state === "running" ||
-            status.state === "completed"));
-      expect(started).toBeTruthy();
+      // 4. Poll (condition-based, not a fixed sleep) for the UPLOADED scenario
+      //    to auto-start — specific to its id, so the seeded default running
+      //    instead would not satisfy it. Report is non-null once the run
+      //    finished; a live run shows a non-idle status.
+      let started = false;
+      const deadline = Date.now() + 5_000;
+      while (Date.now() < deadline && !started) {
+        const report = (
+          await emitRpc(socket, {
+            cpId,
+            method: "scenario_report",
+            params: { connector: CONNECTOR, scenarioId: scenario.id },
+          })
+        ).result;
+        const status = (
+          await emitRpc(socket, {
+            cpId,
+            method: "scenario_status",
+            params: { connector: CONNECTOR, scenarioId: scenario.id },
+          })
+        ).result;
+        started = Boolean(
+          (report && report.verdict) ||
+          (status &&
+            (status.running ||
+              status.state === "running" ||
+              status.state === "completed")),
+        );
+        if (!started) await new Promise((r) => setTimeout(r, 100));
+      }
+      expect(started).toBe(true);
     } finally {
       socket.disconnect();
     }

--- a/src/cli/server/__tests__/scenarioUploadConnectAutoStart.bun.test.ts
+++ b/src/cli/server/__tests__/scenarioUploadConnectAutoStart.bun.test.ts
@@ -1,0 +1,157 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- ack payloads are loosely typed in tests */
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Socket } from "socket.io-client";
+
+import { BunSqliteDatabase } from "../../../cp/domain/persistence/BunSqliteDatabase";
+import {
+  connectTestClient,
+  startTestServer,
+  type TestServer,
+} from "./socketHarness";
+import { startMockCsms } from "../../../cp/infrastructure/transport/__tests__/mockCsms";
+
+/**
+ * Issue #209: in Remote/Docker mode a web-console upload persists scenario
+ * *definitions* (scenario.definitions.replace) but does NOT load them into the
+ * daemon's runtime scenario map — which is what connect-auto-start reads. So a
+ * connect-triggered scenario intermittently stays idle after "Connect".
+ *
+ * This drives the same RPC sequence the console uses (cp.create → definitions
+ * replace → connect), boots the CP to Available via a mock CSMS, and checks
+ * whether the scenario auto-starts.
+ */
+const CONNECTOR = 1;
+
+const scenario = {
+  id: "uploaded-connect-scenario",
+  name: "Uploaded connect-triggered scenario",
+  targetType: "connector",
+  targetId: 1,
+  trigger: { type: "manual" },
+  enabled: true,
+  nodes: [
+    {
+      id: "start-1",
+      type: "start",
+      position: { x: 0, y: 0 },
+      data: { label: "Start" },
+    },
+    {
+      id: "sc-1",
+      type: "statusChange",
+      position: { x: 0, y: 1 },
+      data: { label: "Preparing", status: "Preparing" },
+    },
+    {
+      id: "end-1",
+      type: "end",
+      position: { x: 0, y: 2 },
+      data: { label: "End" },
+    },
+  ],
+  edges: [
+    { id: "e1", source: "start-1", target: "sc-1" },
+    { id: "e2", source: "sc-1", target: "end-1" },
+  ],
+  createdAt: "2026-07-14T00:00:00Z",
+  updatedAt: "2026-07-14T00:00:00Z",
+};
+
+const servers: TestServer[] = [];
+const tempDirs: string[] = [];
+const csmsList: ReturnType<typeof startMockCsms>[] = [];
+
+afterEach(async () => {
+  while (servers.length > 0) await servers.pop()?.close();
+  while (csmsList.length > 0) await csmsList.pop()?.stop();
+  while (tempDirs.length > 0)
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+function emitRpc(socket: Socket, request: unknown): Promise<any> {
+  return socket.timeout(5_000).emitWithAck("rpc", request);
+}
+
+describe("issue #209: connect-auto-start after a web-console upload", () => {
+  it("auto-starts a definitions-uploaded connect-triggered scenario after boot", async () => {
+    const csms = startMockCsms();
+    csmsList.push(csms);
+    const dir = mkdtempSync(join(tmpdir(), "ocpp-209-"));
+    tempDirs.push(dir);
+    const db = BunSqliteDatabase.open(join(dir, "state.db"));
+    const server = await startTestServer({ database: db });
+    servers.push(server);
+    const socket = await connectTestClient(server);
+    const cpId = "CP209";
+
+    try {
+      // 1. Create the CP pointed at the mock CSMS.
+      expect(
+        (
+          await emitRpc(socket, {
+            method: "cp.create",
+            params: { cpId, wsUrl: csms.url, connectors: 1 },
+          })
+        ).ok,
+      ).toBe(true);
+
+      // 2. Web-console upload: persist the scenario DEFINITION only (exactly
+      //    what the editor's file-upload does — no explicit load_scenario).
+      expect(
+        (
+          await emitRpc(socket, {
+            method: "scenario.definitions.replace",
+            params: { cpId, connectorId: CONNECTOR, definitions: [scenario] },
+          })
+        ).ok,
+      ).toBe(true);
+
+      // 3. Connect + accept BootNotification so the CP reaches Available.
+      const connectAck = emitRpc(socket, {
+        cpId,
+        method: "connect",
+        params: {},
+      });
+      const boot = await csms.waitForCall("BootNotification");
+      csms.replyCallResult(boot.messageId, {
+        currentTime: new Date(0).toISOString(),
+        interval: 300,
+        status: "Accepted",
+      });
+      await connectAck;
+
+      // 4. Give connect-auto-start time to fire.
+      await new Promise((r) => setTimeout(r, 400));
+
+      // 5. Did the scenario auto-start? Report is non-null once a run finished;
+      //    a running scenario shows a non-idle status.
+      const report = (
+        await emitRpc(socket, {
+          cpId,
+          method: "scenario_report",
+          params: { connector: CONNECTOR, scenarioId: scenario.id },
+        })
+      ).result;
+      const status = (
+        await emitRpc(socket, {
+          cpId,
+          method: "scenario_status",
+          params: { connector: CONNECTOR, scenarioId: scenario.id },
+        })
+      ).result;
+
+      const started =
+        (report && report.verdict) ||
+        (status &&
+          (status.running ||
+            status.state === "running" ||
+            status.state === "completed"));
+      expect(started).toBeTruthy();
+    } finally {
+      socket.disconnect();
+    }
+  });
+});

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -860,25 +860,30 @@ export class CLIChargePointService {
   removeScenario(connectorId: number, scenarioId: string): boolean {
     const entry = this._scenarios.get(scenarioId);
     if (!entry || entry.connectorId !== connectorId) return false;
-    const executor = this._executors.get(scenarioId);
-    if (executor) {
-      executor.stop();
-      this._executors.delete(scenarioId);
-      this._runIdByScenario.delete(scenarioId);
-      // #179 Phase 2b: drop the transcript subscription for the run being
-      // torn down along with it -- otherwise it would keep capturing every
-      // future WebSocket frame on this CP with nothing left to stop it.
-      // No verdict is computed here (the scenario itself is being deleted).
-      const transcript = this._transcriptByScenario.get(scenarioId);
-      if (transcript) {
-        transcript.stop();
-        this._transcriptByScenario.delete(scenarioId);
-      }
-      this._runStartByScenario.delete(scenarioId);
-    }
+    this.discardScenarioRun(scenarioId);
     this._scenarios.delete(scenarioId);
     this._scenarioRepo.deleteOne(this._chargePoint.id, connectorId, scenarioId);
     return true;
+  }
+
+  /**
+   * Tear down any in-flight run for `scenarioId` — stop the executor and drop
+   * its transcript subscription so it doesn't keep capturing WebSocket frames.
+   * No verdict is computed: the run is being discarded (scenario deleted or its
+   * definition replaced). A no-op when nothing is running for the id.
+   */
+  private discardScenarioRun(scenarioId: string): void {
+    const executor = this._executors.get(scenarioId);
+    if (!executor) return;
+    executor.stop();
+    this._executors.delete(scenarioId);
+    this._runIdByScenario.delete(scenarioId);
+    const transcript = this._transcriptByScenario.get(scenarioId);
+    if (transcript) {
+      transcript.stop();
+      this._transcriptByScenario.delete(scenarioId);
+    }
+    this._runStartByScenario.delete(scenarioId);
   }
 
   /**
@@ -903,17 +908,14 @@ export class CLIChargePointService {
     // reconcile; skip them.
     if (connectorId === null) return;
     const keepIds = new Set(definitions.map((d) => d.id));
-    // Prune stale runtime entries for this connector scope (in-memory only).
+    // Reconcile runtime entries for this connector scope (in-memory only). Any
+    // in-flight run is discarded first — the definition set is being replaced,
+    // and a lingering executor would also block auto-start via the
+    // active-executor gate in tryAutoStartForConnector.
     for (const [scenarioId, entry] of [...this._scenarios]) {
       if (entry.connectorId !== connectorId) continue;
-      if (keepIds.has(scenarioId)) continue;
-      this._executors.get(scenarioId)?.stop();
-      this._executors.delete(scenarioId);
-      this._runIdByScenario.delete(scenarioId);
-      this._transcriptByScenario.get(scenarioId)?.stop();
-      this._transcriptByScenario.delete(scenarioId);
-      this._runStartByScenario.delete(scenarioId);
-      this._scenarios.delete(scenarioId);
+      this.discardScenarioRun(scenarioId);
+      if (!keepIds.has(scenarioId)) this._scenarios.delete(scenarioId);
     }
     // Load the provided definitions into runtime (already persisted upstream).
     for (const def of definitions) {

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -881,6 +881,55 @@ export class CLIChargePointService {
     return true;
   }
 
+  /**
+   * Reconcile the in-memory runtime scenario map for `connectorId` to exactly
+   * the given (already-persisted) definitions — issue #209.
+   *
+   * The Remote/Docker web-console upload persists definitions via the registry
+   * service's replaceConnectorScenarioDefinitions but does NOT touch this
+   * daemon runtime map, which is what connect-auto-start (tryAutoStartForConnector)
+   * reads. So after an upload the runtime still holds the stale seeded default
+   * (`essential-cp-behavior`) and lacks the uploaded scenario — the operator's
+   * connect-triggered scenario intermittently never fires. This syncs the
+   * runtime so connect-auto-start sees the upload. In-memory only: the caller
+   * already made the DB authoritative.
+   */
+  syncConnectorRuntimeScenarios(
+    connectorId: number | null,
+    definitions: readonly ScenarioDefinition[],
+  ): void {
+    // The runtime map is keyed to numeric connectors (loadScenario requires a
+    // connector). CP-level (null) uploads have no connector runtime entries to
+    // reconcile; skip them.
+    if (connectorId === null) return;
+    const keepIds = new Set(definitions.map((d) => d.id));
+    // Prune stale runtime entries for this connector scope (in-memory only).
+    for (const [scenarioId, entry] of [...this._scenarios]) {
+      if (entry.connectorId !== connectorId) continue;
+      if (keepIds.has(scenarioId)) continue;
+      this._executors.get(scenarioId)?.stop();
+      this._executors.delete(scenarioId);
+      this._runIdByScenario.delete(scenarioId);
+      this._transcriptByScenario.get(scenarioId)?.stop();
+      this._transcriptByScenario.delete(scenarioId);
+      this._runStartByScenario.delete(scenarioId);
+      this._scenarios.delete(scenarioId);
+    }
+    // Load the provided definitions into runtime (already persisted upstream).
+    for (const def of definitions) {
+      this._scenarios.set(def.id, { definition: def, connectorId });
+    }
+    // The replaced set may drop whatever auto-started last, so clear the dedup
+    // key and — if the CP is already up — kick auto-start for the new set.
+    const connector = this._chargePoint.connectors.get(connectorId);
+    if (!connector) return;
+    connector.lastAutoStartedScenarioKey = null;
+    if (this._chargePoint.status === OCPPStatus.Available) {
+      this.tryAutoStartForConnector(connectorId, "connect", null);
+      this.tryAutoStartForConnector(connectorId, "status", connector.status);
+    }
+  }
+
   listScenarios(connectorId: number): ReadonlyArray<{
     readonly scenarioId: string;
     readonly name: string;


### PR DESCRIPTION
Fixes #209.

## Symptom

A scenario uploaded from the web console with "Connect on start" **intermittently stays idle** after clicking Connect (remote/Docker mode). Reporter: "Sometimes can work, I didn't figure out the reason why."

## Root cause (reproduced)

Remote/Docker mode delegates connect-triggered auto-start to the **daemon** (the browser opts out — `Connector.tsx`). The daemon's auto-start engine (`CLIChargePointService.tryAutoStartForConnector`) walks the in-memory **runtime** scenario map `this._scenarios`.

The web-console upload calls `RegistryChargePointService.replaceConnectorScenarioDefinitions`, which persists the definition to the DB — but **never touches that runtime map**. Meanwhile `cp.create` seeds `essential-cp-behavior` into the runtime. So after an upload:

- **DB definitions**: only the upload (the seed was pruned by `replaceConnector`).
- **Daemon runtime** (what auto-start reads): still the **stale seeded default**, and **not** the upload.

On Connect → Available, the daemon auto-starts the stale default and the uploaded connect-triggered scenario never fires. It "sometimes works" only because a separate client-side `load_scenario` activation races the connect.

A socket-level reproduction (drive the console's exact RPC sequence against a mock CSMS) confirmed it: pre-fix, the daemon ran **"Essential CP Behavior"**, not the upload.

This is the daemon-runtime analog of the client-side #101 definitions-vs-runtime split.

## Fix

After persisting, `replaceConnectorScenarioDefinitions` reconciles the per-CP runtime via a new `CLIChargePointService.syncConnectorRuntimeScenarios`:

- prune stale runtime entries for the connector (including the seeded default),
- load the uploaded definition set into runtime,
- clear the auto-start dedup key,
- kick auto-start if the CP is already Available (so uploading while connected also fires).

In-memory only — the DB was already made authoritative by `replaceConnector`. No-op when the CP isn't currently instantiated (a definitions-only edit); daemon restart rebuilds runtime from the DB, which is already correct.

## Tests

New `scenarioUploadConnectAutoStart.bun.test.ts` drives `cp.create → scenario.definitions.replace → connect` against a mock CSMS and asserts the **uploaded** scenario — not the seeded default — auto-starts once the CP reaches Available. Fails before the fix, passes after.

## Verification

- New regression test: green (was red before the fix).
- `tsc -b --noEmit` — no new errors (baseline unchanged).
- `bun test bun.test` — 218/0.
- prettier / eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated connector scenario definitions now reconcile with the currently running charge point service, so connect-triggered behavior uses the latest uploaded definitions.
  * In-progress scenario runs and related in-memory state are cleared and auto-start state is reset when definitions are replaced, preventing stale runtime fallbacks.
* **Tests**
  * Added regression and unit tests covering connect-triggered scenario upload, immediate runtime reconciliation, and the no-op behavior for CP-level syncing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->