### PR TITLE
ci(codecov): make coverage status checks informational (#131)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+# Codecov configuration (issue #131).
+#
+# Coverage is uploaded from vitest's lcov only (`bun run test:coverage`).
+# A large share of the daemon/runtime code is exercised by Bun tests
+# (`*.bun.test.ts`, run via `bun test bun.test`), whose coverage is NOT yet
+# part of the upload. Codecov therefore under-reports, and its default
+# project/patch status gates fail on Bun-tested changes even when the change is
+# well covered — which is not the intent (codecov here is for visibility, not a
+# merge gate).
+#
+# Keep the status checks informational so they still report the numbers on each
+# PR/commit but never fail. Follow-up: merge Bun coverage into the upload, then
+# these can become real gates.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: false


### PR DESCRIPTION
## Why

Codecov's `project` and `patch` status checks are failing on `main` (e.g. `codecov/patch` reported **3.84% of diff hit**), painting the commit status red even though the functional CI (`test` / `build` / Docker / Pages) is green.

The failure is a **measurement gap**, not a real coverage regression: the coverage upload is vitest's `lcov.info` only (`bun run test:coverage`), but a large share of the daemon/runtime code is exercised by **Bun tests** (`*.bun.test.ts`, run via `bun test bun.test`) whose coverage isn't in the upload. So codecov under-reports and its default gates fail on Bun-tested changes even when they're well covered.

Codecov was set up (#131) for **visibility, not as a merge gate**, and there's no branch protection — so a failing status check here is pure noise.

## Change

Add `codecov.yml` marking `project` and `patch` **`informational: true`** — the numbers still post on every PR/commit, but the checks never fail. Validated against `https://codecov.io/validate` (Valid!).

## Follow-up

Merge Bun-test coverage into the upload (`bun test --coverage` → lcov, combined with vitest's), after which these can be promoted back to real gates with a sensible target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added coverage reporting configuration to provide informational Codecov checks without blocking changes.
  * Improved pull request coverage comments and enabled reporting even when coverage-related changes are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->