### PR TITLE
feat(trace): trace format v1.1 — raw frames, derived action, versioning rules (#188)

### DIFF
--- a/docs/trace-format.md
+++ b/docs/trace-format.md
@@ -31,25 +31,29 @@ are deliberately later steps.
   conformant implementation outputs is a new version, not an edit.
 - Producer extensions MUST go in `meta`, never in undeclared top-level
   fields.
+- Known v1.1 limitation: a frame that does not parse as an OCPP-J array
+  cannot be represented as a record (`messageType` is required). How the shared
+  format should carry fully-unparseable frames is an open question for the
+  specification repo.
 
 ## Record shape
 
-| Field           | Type                                           | Notes                                                                                                                                         |
-| --------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `schemaVersion` | string                                         | Trace schema version, e.g. `"1.0"`.                                                                                                           |
-| `timestamp`     | string (ISO-8601)                              | When the message was observed.                                                                                                                |
-| `ocppVersion`   | string (optional)                              | OCPP protocol version, e.g. `"1.6"`, `"2.0.1"`.                                                                                               |
-| `transport`     | `"json"` \| `"soap"`                           | Wire transport.                                                                                                                               |
-| `chargePointId` | string (optional)                              | Charge-point identity.                                                                                                                        |
-| `connectorId`   | number (optional)                              | Connector id when connector-scoped and known.                                                                                                 |
-| `direction`     | `"cp-to-csms"` \| `"csms-to-cp"`               | Relative to the CP/CSMS pair.                                                                                                                 |
-| `messageType`   | `"CALL"` \| `"CALLRESULT"` \| `"CALLERROR"`    | OCPP-J frame kind.                                                                                                                            |
-| `messageId`     | string (optional)                              | Correlates a CALL with its CALLRESULT/CALLERROR.                                                                                              |
-| `action`        | string (optional)                              | Derived, optional. On CALLRESULT/CALLERROR back-filled by id correlation; MUST equal the correlated CALL's action when that CALL is present.  |
-| `payload`       | any (optional)                                 | The OCPP message body.                                                                                                                        |
-| `raw`           | string (optional)                              | Verbatim frame text exactly as sent/received. The only lossless representation (byte-exact hashing, malformed frames). May not parse as JSON. |
-| `error`         | `{ code?, description?, details? }` (optional) | Populated for CALLERROR only.                                                                                                                 |
-| `meta`          | object (optional)                              | Transport/execution metadata and analysis-specific extensions.                                                                                |
+| Field           | Type                                           | Notes                                                                                                                                                                        |
+| --------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `schemaVersion` | string                                         | Trace schema version, e.g. `"1.1"`.                                                                                                                                          |
+| `timestamp`     | string (ISO-8601)                              | When the message was observed.                                                                                                                                               |
+| `ocppVersion`   | string (optional)                              | OCPP protocol version, e.g. `"1.6"`, `"2.0.1"`.                                                                                                                              |
+| `transport`     | `"json"` \| `"soap"`                           | Wire transport.                                                                                                                                                              |
+| `chargePointId` | string (optional)                              | Charge-point identity.                                                                                                                                                       |
+| `connectorId`   | number (optional)                              | Connector id when connector-scoped and known.                                                                                                                                |
+| `direction`     | `"cp-to-csms"` \| `"csms-to-cp"`               | Relative to the CP/CSMS pair.                                                                                                                                                |
+| `messageType`   | `"CALL"` \| `"CALLRESULT"` \| `"CALLERROR"`    | OCPP-J frame kind.                                                                                                                                                           |
+| `messageId`     | string (optional)                              | Correlates a CALL with its CALLRESULT/CALLERROR.                                                                                                                             |
+| `action`        | string (optional)                              | Derived, optional. On CALLRESULT/CALLERROR back-filled by id correlation; MUST equal the correlated CALL's action when that CALL is present.                                 |
+| `payload`       | any (optional)                                 | The OCPP message body.                                                                                                                                                       |
+| `raw`           | string (optional)                              | Verbatim frame text exactly as sent/received. The only lossless representation (byte-exact hashing/dedup; preserves frames whose shape or payload violates the OCPP schema). |
+| `error`         | `{ code?, description?, details? }` (optional) | Populated for CALLERROR only.                                                                                                                                                |
+| `meta`          | object (optional)                              | Transport/execution metadata and analysis-specific extensions.                                                                                                               |
 
 ## Example
 
@@ -125,7 +129,7 @@ version string.
     "raw": { "type": "string" },
     "error": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "code": { "type": "string" },
         "description": { "type": "string" },
@@ -150,7 +154,8 @@ version string.
 
 The `additionalProperties: true` allows forward compatibility: consumers must
 accept records from a later minor version, so the schema does not reject
-unknown fields; producers must put extensions in `meta` instead.
+unknown fields; producers must put extensions in `meta` instead, and the same
+applies to the nested `error` object.
 
 The `allOf` conditionals mirror what the adapter emits: a `CALL` always carries
 an `action`, and `error` is present only on `CALLERROR`.

--- a/docs/trace-format.md
+++ b/docs/trace-format.md
@@ -1,4 +1,4 @@
-# OCPP Trace Format (v1.0)
+# OCPP Trace Format (v1.1)
 
 A small, **implementation-independent** JSON/JSONL format for one OCPP message
 exchange. It is intended as a shared contract between tools that _produce_ OCPP
@@ -14,35 +14,48 @@ are deliberately later steps.
 
 ## Status & scope
 
-- **Version `1.0`** (`schemaVersion`). Bump on any breaking change.
+- **Version `1.1`** (`schemaVersion`).
 - This iteration recognizes **OCPP-J (JSON/WebSocket)** frames. SOAP transport
   is a documented follow-up (the format already carries a `transport` field).
 - The format is usable without this simulator or DebugKit; it is a plain JSON
   object per exchange (JSONL for a stream).
 
+## Versioning
+
+- Additive optional fields bump the **minor** version.
+- Consumers **MUST ignore unknown fields** (forward compatibility within a
+  major version).
+- Changing the meaning of an existing field, or removing one, is a new
+  **major** version.
+- A published version is immutable: any change that alters what a
+  conformant implementation outputs is a new version, not an edit.
+- Producer extensions MUST go in `meta`, never in undeclared top-level
+  fields.
+
 ## Record shape
 
-| Field           | Type                                           | Notes                                                                              |
-| --------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `schemaVersion` | string                                         | Trace schema version, e.g. `"1.0"`.                                                |
-| `timestamp`     | string (ISO-8601)                              | When the message was observed.                                                     |
-| `ocppVersion`   | string (optional)                              | OCPP protocol version, e.g. `"1.6"`, `"2.0.1"`.                                    |
-| `transport`     | `"json"` \| `"soap"`                           | Wire transport.                                                                    |
-| `chargePointId` | string (optional)                              | Charge-point identity.                                                             |
-| `connectorId`   | number (optional)                              | Connector id when connector-scoped and known.                                      |
-| `direction`     | `"cp-to-csms"` \| `"csms-to-cp"`               | Relative to the CP/CSMS pair.                                                      |
-| `messageType`   | `"CALL"` \| `"CALLRESULT"` \| `"CALLERROR"`    | OCPP-J frame kind.                                                                 |
-| `messageId`     | string (optional)                              | Correlates a CALL with its CALLRESULT/CALLERROR.                                   |
-| `action`        | string (optional)                              | e.g. `"BootNotification"`. On CALLRESULT/CALLERROR, back-filled by id correlation. |
-| `payload`       | any (optional)                                 | The OCPP message body.                                                             |
-| `error`         | `{ code?, description?, details? }` (optional) | Populated for CALLERROR only.                                                      |
-| `meta`          | object (optional)                              | Transport/execution metadata and analysis-specific extensions.                     |
+| Field           | Type                                           | Notes                                                                                                                                         |
+| --------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `schemaVersion` | string                                         | Trace schema version, e.g. `"1.0"`.                                                                                                           |
+| `timestamp`     | string (ISO-8601)                              | When the message was observed.                                                                                                                |
+| `ocppVersion`   | string (optional)                              | OCPP protocol version, e.g. `"1.6"`, `"2.0.1"`.                                                                                               |
+| `transport`     | `"json"` \| `"soap"`                           | Wire transport.                                                                                                                               |
+| `chargePointId` | string (optional)                              | Charge-point identity.                                                                                                                        |
+| `connectorId`   | number (optional)                              | Connector id when connector-scoped and known.                                                                                                 |
+| `direction`     | `"cp-to-csms"` \| `"csms-to-cp"`               | Relative to the CP/CSMS pair.                                                                                                                 |
+| `messageType`   | `"CALL"` \| `"CALLRESULT"` \| `"CALLERROR"`    | OCPP-J frame kind.                                                                                                                            |
+| `messageId`     | string (optional)                              | Correlates a CALL with its CALLRESULT/CALLERROR.                                                                                              |
+| `action`        | string (optional)                              | Derived, optional. On CALLRESULT/CALLERROR back-filled by id correlation; MUST equal the correlated CALL's action when that CALL is present.  |
+| `payload`       | any (optional)                                 | The OCPP message body.                                                                                                                        |
+| `raw`           | string (optional)                              | Verbatim frame text exactly as sent/received. The only lossless representation (byte-exact hashing, malformed frames). May not parse as JSON. |
+| `error`         | `{ code?, description?, details? }` (optional) | Populated for CALLERROR only.                                                                                                                 |
+| `meta`          | object (optional)                              | Transport/execution metadata and analysis-specific extensions.                                                                                |
 
 ## Example
 
 ```json
 {
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.1",
   "timestamp": "2026-07-14T02:00:00.000Z",
   "ocppVersion": "1.6",
   "transport": "json",
@@ -51,7 +64,11 @@ are deliberately later steps.
   "messageType": "CALL",
   "messageId": "abc-1",
   "action": "BootNotification",
-  "payload": { "chargePointVendor": "Example", "chargePointModel": "Simulator" }
+  "payload": {
+    "chargePointVendor": "Example",
+    "chargePointModel": "Simulator"
+  },
+  "raw": "[2,\"abc-1\",\"BootNotification\",{\"chargePointVendor\":\"Example\",\"chargePointModel\":\"Simulator\"}]"
 }
 ```
 
@@ -67,18 +84,19 @@ import { logLinesToTrace } from "../src/trace/logEntryToTrace";
 const records = logLinesToTrace(jsonlLogLines, { ocppVersion: "1.6" });
 ```
 
-`logLinesToTrace` drops non-wire log lines and back-fills each
-CALLRESULT/CALLERROR `action` from the CALL that established its `messageId`.
-`logLineToTraceRecord` converts a single line (returning `null` for non-wire
-lines). The type lives in `src/trace/OcppTraceRecord.ts` and
-`OCPP_TRACE_SCHEMA_VERSION` is the current version string.
+`logLinesToTrace` drops non-wire log lines, emits the verbatim frame text in
+the `raw` field, and back-fills each CALLRESULT/CALLERROR `action` from the
+CALL that established its `messageId`. `logLineToTraceRecord` converts a single
+line (returning `null` for non-wire lines). The type lives in
+`src/trace/OcppTraceRecord.ts` and `OCPP_TRACE_SCHEMA_VERSION` is the current
+version string.
 
 ## JSON Schema
 
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/shiv3/ocpp-cp-simulator/docs/trace-format.md#v1.0",
+  "$id": "https://github.com/shiv3/ocpp-cp-simulator/docs/trace-format.md#v1.1",
   "title": "OcppTraceRecord",
   "type": "object",
   "required": [
@@ -88,7 +106,7 @@ lines). The type lives in `src/trace/OcppTraceRecord.ts` and
     "direction",
     "messageType"
   ],
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "schemaVersion": { "type": "string" },
     "timestamp": { "type": "string", "format": "date-time" },
@@ -104,6 +122,7 @@ lines). The type lives in `src/trace/OcppTraceRecord.ts` and
     "messageId": { "type": "string" },
     "action": { "type": "string" },
     "payload": {},
+    "raw": { "type": "string" },
     "error": {
       "type": "object",
       "additionalProperties": false,
@@ -129,5 +148,14 @@ lines). The type lives in `src/trace/OcppTraceRecord.ts` and
 }
 ```
 
+The `additionalProperties: true` allows forward compatibility: consumers must
+accept records from a later minor version, so the schema does not reject
+unknown fields; producers must put extensions in `meta` instead.
+
 The `allOf` conditionals mirror what the adapter emits: a `CALL` always carries
 an `action`, and `error` is present only on `CALLERROR`.
+
+## Changelog
+
+- **v1.1**: Added `raw` field (verbatim frame text), clarified `action` semantics (derived, optional), documented versioning rules.
+- **v1.0**: Initial proof-of-concept.

--- a/src/trace/OcppTraceRecord.ts
+++ b/src/trace/OcppTraceRecord.ts
@@ -33,7 +33,7 @@ export interface TraceError {
 
 /** One OCPP message exchange in the shared, tool-independent trace format. */
 export interface OcppTraceRecord {
-  /** Trace schema version, e.g. "1.0" ({@link OCPP_TRACE_SCHEMA_VERSION}). */
+  /** Trace schema version, e.g. "1.1" ({@link OCPP_TRACE_SCHEMA_VERSION}). */
   schemaVersion: string;
   /** ISO-8601 timestamp of the message. */
   timestamp: string;
@@ -63,9 +63,11 @@ export interface OcppTraceRecord {
   /**
    * Verbatim frame text exactly as sent or received on the wire (v1.1+).
    * Producers that have the original bytes SHOULD emit it; it is the only
-   * lossless representation (byte-exact hashing/dedup, malformed frames).
-   * Consumers MUST NOT assume it parses as JSON; when the frame is
-   * well-formed, `JSON.parse(raw)` yields the OCPP-J array.
+   * lossless representation (byte-exact hashing/dedup; preserves frames whose
+   * shape or payload violates the OCPP schema). Note a frame that does not
+   * parse as an OCPP-J array cannot be represented as a record at all in
+   * v1.1 (`messageType` is required) — carrying such frames is an open
+   * question for the shared spec.
    */
   raw?: string;
   /** Populated for CALLERROR frames only. */

--- a/src/trace/OcppTraceRecord.ts
+++ b/src/trace/OcppTraceRecord.ts
@@ -12,8 +12,8 @@
  * lives in `docs/trace-format.md`.
  */
 
-/** Bump on any breaking change to the record shape. Consumers should check it. */
-export const OCPP_TRACE_SCHEMA_VERSION = "1.0";
+/** Trace schema version. Additive optional fields bump the minor version; semantic changes bump the major. Consumers MUST ignore unknown fields. */
+export const OCPP_TRACE_SCHEMA_VERSION = "1.1";
 
 /** Direction relative to the charge point / CSMS pair. */
 export type TraceDirection = "cp-to-csms" | "csms-to-cp";
@@ -52,13 +52,22 @@ export interface OcppTraceRecord {
   /** OCPP message id used to correlate a CALL with its CALLRESULT/CALLERROR. */
   messageId?: string;
   /**
-   * Action name, e.g. "BootNotification". Present on CALL frames; on
-   * CALLRESULT/CALLERROR it is back-filled by message-id correlation when the
-   * originating CALL is available, otherwise omitted (correlate by messageId).
+   * Action name, e.g. "BootNotification". Present on CALL frames. On
+   * CALLRESULT/CALLERROR it is DERIVED by message-id correlation and
+   * optional: producers MAY back-fill it, and when the CALL with the same
+   * `messageId` is present in the trace it MUST equal that CALL's action.
    */
   action?: string;
   /** Request/response payload (the OCPP message body). */
   payload?: unknown;
+  /**
+   * Verbatim frame text exactly as sent or received on the wire (v1.1+).
+   * Producers that have the original bytes SHOULD emit it; it is the only
+   * lossless representation (byte-exact hashing/dedup, malformed frames).
+   * Consumers MUST NOT assume it parses as JSON; when the frame is
+   * well-formed, `JSON.parse(raw)` yields the OCPP-J array.
+   */
+  raw?: string;
   /** Populated for CALLERROR frames only. */
   error?: TraceError;
   /** Optional transport/execution metadata and analysis-specific extensions. */

--- a/src/trace/__tests__/logEntryToTrace.test.ts
+++ b/src/trace/__tests__/logEntryToTrace.test.ts
@@ -40,6 +40,7 @@ describe("logLineToTraceRecord", () => {
       messageId: "abc-1",
       action: "BootNotification",
       payload: { chargePointVendor: "Example" },
+      raw: '[2,"abc-1","BootNotification",{"chargePointVendor":"Example"}]',
     });
   });
 
@@ -90,6 +91,33 @@ describe("logLineToTraceRecord", () => {
   });
 });
 
+describe("trace format v1.1", () => {
+  it("stamps records with schemaVersion 1.1", () => {
+    expect(OCPP_TRACE_SCHEMA_VERSION).toBe("1.1");
+  });
+
+  it("carries the verbatim frame text in raw, preserving spacing and key order", () => {
+    // Deliberately non-canonical JSON: spacing and key order must survive
+    // byte-exactly (hashing/dedup on raw is a consumer use case).
+    const frameText = '[2, "abc-1", "BootNotification", {"b": 1, "a": 2} ]';
+    const record = logLineToTraceRecord(line(`Sent: ${frameText}`));
+    expect(record?.raw).toBe(frameText);
+  });
+
+  it("round-trips a well-formed frame through JSON.parse(raw)", () => {
+    const record = logLineToTraceRecord(
+      line('Received: [4,"m-9","NotSupported","Boom",{"x":1}]'),
+    );
+    expect(JSON.parse(record?.raw ?? "")).toEqual([
+      4,
+      "m-9",
+      "NotSupported",
+      "Boom",
+      { x: 1 },
+    ]);
+  });
+});
+
 describe("logLinesToTrace", () => {
   it("drops non-wire lines and back-fills CALLRESULT action by messageId", () => {
     const records = logLinesToTrace([
@@ -122,6 +150,17 @@ describe("logLinesToTrace", () => {
     ]);
     expect(records).toHaveLength(1);
     expect(records[0].action).toBeUndefined();
+  });
+
+  it("emits raw on every record in a batch", () => {
+    const records = logLinesToTrace([
+      line('Sent: [2,"m-1","Heartbeat",{}]'),
+      line('Received: [3,"m-1",{}]'),
+    ]);
+    expect(records.map((r) => r.raw)).toEqual([
+      '[2,"m-1","Heartbeat",{}]',
+      '[3,"m-1",{}]',
+    ]);
   });
 
   it("scopes correlation per charge point when a batch reuses a messageId", () => {

--- a/src/trace/logEntryToTrace.ts
+++ b/src/trace/logEntryToTrace.ts
@@ -51,6 +51,7 @@ interface ParsedFrame {
   action?: string;
   payload?: unknown;
   error?: TraceError;
+  raw: string;
 }
 
 function parseOcppJArray(
@@ -75,6 +76,7 @@ function parseOcppJArray(
       messageId,
       action: parsed[2],
       payload: parsed[3],
+      raw: json,
     };
   }
   if (type === OCPPJ_CALLRESULT) {
@@ -83,6 +85,7 @@ function parseOcppJArray(
       messageType: "CALLRESULT",
       messageId,
       payload: parsed[2],
+      raw: json,
     };
   }
   if (type === OCPPJ_CALLERROR) {
@@ -95,6 +98,7 @@ function parseOcppJArray(
         description: typeof parsed[3] === "string" ? parsed[3] : undefined,
         details: parsed[4],
       },
+      raw: json,
     };
   }
   return null;
@@ -133,6 +137,7 @@ function toRecord(
   if (frame.action !== undefined) record.action = frame.action;
   if (frame.payload !== undefined) record.payload = frame.payload;
   if (frame.error !== undefined) record.error = frame.error;
+  record.raw = frame.raw;
   return record;
 }
 


### PR DESCRIPTION
Follow-up to #211, addressing the format review feedback from the DebugKit side on [#188](https://github.com/shiv3/ocpp-cp-simulator/issues/188) / [#211 (review)](https://github.com/shiv3/ocpp-cp-simulator/pull/211#issuecomment-4969245960): trace format **v1.1**.

## What changes

Three additions to the shared trace contract, all additive (v1.0 records remain valid v1.1 records):

- **`raw` (optional string)** — the verbatim frame text exactly as sent/received on the wire. Producers that have the original bytes SHOULD emit it; it is the only lossless representation (byte-exact hashing/dedup, malformed frames). It is a *string*, not a parsed array: a truncated frame isn't valid JSON, so an array-typed `raw` couldn't carry exactly the malformed frames it exists for, and byte-exact hashing only works on the original text. Well-formed frames still yield the OCPP-J array via `JSON.parse(raw)`. The log adapter now fills it (the frame text after the `Sent: ` / `Received: ` prefix, untouched).
- **`action` semantics spelled out** — on CALLRESULT/CALLERROR it is *derived* by message-id correlation and *optional*; when the CALL with the same `messageId` is present in the trace it MUST equal that CALL's action. A producer that correlates wrongly now violates the spec rather than silently asserting a false fact.
- **Versioning rules made explicit** — additive optional fields bump the minor version; consumers MUST ignore unknown fields; changing the meaning of a field (or removing one) is a new major version; a published version is immutable (a change that alters conformant output is a new version, not an edit); producer extensions go in `meta`, never in undeclared top-level fields. Consequently the JSON Schema's `additionalProperties` flips to `true` so a pinned consumer can validate records from a later minor without rejecting them.

`OCPP_TRACE_SCHEMA_VERSION` is now `"1.1"`; `docs/trace-format.md` gains the Versioning section, updated field table/example/schema (`$id` → `#v1.1`), and a changelog.

## Why now

The fixture conversion planned on #188 (DebugKit's 15 scenario traces into the shared format) is blocked on the `raw` decision — landing v1.1 here lets the future `open-ocpp-trace/specification` repo seed from v1.1 as-is instead of starting on a known-stale v1.0.

## Verification

- `vitest` — 1323/1323 green (4 new v1.1 tests, incl. byte-exact preservation of non-canonical spacing/key order and `JSON.parse(raw)` round-trip).
- `bun test bun.test` — 221/221 green.
- `tsc -b --noEmit` — no new errors (baseline unchanged).
- eslint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trace records can now include the original, verbatim OCPP-J frame text via an optional `raw` field (when available).
  * The trace format is updated to version 1.1, including clarified `action` semantics for `CALLRESULT`/`CALLERROR`.
* **Documentation**
  * Expanded trace format documentation with updated versioning, forward-compatibility guidance, record-shape details, and schema updates.
* **Tests**
  * Added assertions to verify `raw` preservation and correct schema version handling across trace outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->