### PR TITLE
feat(cli): analyze subcommand — DebugKit-powered trace reports (#188)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "ocpp-cp-simulator",
       "dependencies": {
+        "@ocpp-debugkit/toolkit": "0.4.0",
         "@peculiar/x509": "^2.0.0",
         "@radix-ui/react-checkbox": "^1.3.7",
         "@radix-ui/react-dialog": "^1.1.19",
@@ -260,6 +261,8 @@
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
     "@nodable/entities": ["@nodable/entities@2.2.0", "", {}, "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg=="],
+
+    "@ocpp-debugkit/toolkit": ["@ocpp-debugkit/toolkit@0.4.0", "", { "dependencies": { "commander": "^13.0.0", "zod": "^4.4.3" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"], "bin": { "ocpp-debugkit": "dist/cli/index.js" } }, "sha512-A/k7RdH0hNJhxSeB2wxYDrVoAzF28J7nypjyzQFcknchp780F4RfR4d447zOZJcL30SsfREpKQ/mcL4fgs/1cw=="],
 
     "@oozcitak/dom": ["@oozcitak/dom@2.0.2", "", { "dependencies": { "@oozcitak/infra": "^2.0.2", "@oozcitak/url": "^3.0.0", "@oozcitak/util": "^10.0.0" } }, "sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w=="],
 
@@ -746,6 +749,8 @@
     "cli-truncate": ["cli-truncate@5.2.0", "", { "dependencies": { "slice-ansi": "^8.0.0", "string-width": "^8.2.0" } }, "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
     "comment-json": ["comment-json@4.5.1", "", { "dependencies": { "array-timsort": "^1.0.3", "core-util-is": "^1.0.3", "esprima": "^4.0.1" } }, "sha512-taEtr3ozUmOB7it68Jll7s0Pwm+aoiHyXKrEC8SEodL4rNpdfDLqa7PfBlrgFoCNNdR8ImL+muti5IGvktJAAg=="],
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -293,6 +293,113 @@ file. `--scenario` and `--scenario-template` fan out the same way when
 > removed. External clients should migrate to the Socket.IO `rpc` event and
 > `event` push envelopes. See [docs/migration.md](migration.md).
 
+## analyze
+
+```bash
+ocpp-cp-sim analyze <trace.jsonl> [--output <file>] [--format html|markdown]
+```
+
+Runs [OCPP DebugKit](https://github.com/ocpp-debugkit/toolkit)'s
+failure-pattern detection over a v1.1 trace file
+([docs/trace-format.md](./trace-format.md)) and writes a report. Unlike every
+mode above, `analyze` never bootstraps a charge point, opens a socket, or
+starts a server — it only reads the given file and writes a report.
+
+```bash
+# Markdown to stdout (default)
+ocpp-cp-sim analyze trace.jsonl
+
+# Self-contained HTML report written to a file
+ocpp-cp-sim analyze trace.jsonl --output report.html
+
+# Force a format regardless of the --output extension
+ocpp-cp-sim analyze trace.jsonl --output report.txt --format html
+```
+
+### Formats
+
+| Value               | When it's used                                         | Output                                                               |
+| ------------------- | ------------------------------------------------------ | -------------------------------------------------------------------- |
+| `--format markdown` | Default, unless `--output` ends in `.html`             | Markdown text                                                        |
+| `--format html`     | Default when `--output` ends in `.html`; can be forced | A single self-contained HTML file (inline CSS, no external requests) |
+
+### Multi charge-point traces
+
+The DebugKit toolkit's analysis pipeline has no concept of `chargePointId` —
+it was built around a single-station 1.6J model. Handing it a trace that
+mixes several charge points as-is would silently flatten them into one
+station, and two charge points that happen to reuse the same OCPP
+`messageId` (routine, since messageIds are only unique per connection) could
+have their CALLs/CALLRESULTs cross-correlate, hiding a real failure on one of
+them.
+
+`analyze` compensates by splitting the trace by `chargePointId` **before**
+handing anything to the toolkit, and analyzing each charge point
+independently:
+
+- A trace with exactly one charge point (or only unattributed records)
+  produces one report. With `--output <file>`, it is written to exactly that
+  path.
+- A trace with multiple charge points produces one report per charge point.
+  With `--output out.html`, each is written as `out.<chargePointId>.html`
+  (the charge point id is inserted before the extension and sanitized for
+  the filesystem: anything outside `[A-Za-z0-9._-]` becomes `_`). Records
+  with no `chargePointId` at all are grouped together and reported as charge
+  point `(no chargePointId)`.
+- With no `--output`, all reports are printed to stdout in Markdown, each
+  under its own `# Charge point <id>` heading.
+
+### Excluded records
+
+The toolkit only understands OCPP 1.6J. Records transported over SOAP
+(`transport: "soap"`) and records with a non-1.6 `ocppVersion` (e.g.
+`2.0.1`, `2.1`) are excluded before analysis rather than being silently
+misread as 1.6J frames — analyzing them would produce meaningless results.
+Records with no `ocppVersion` at all are kept (treated as 1.6J, matching the
+trace format's own default). Non-zero exclusion counts are printed to
+stderr, e.g.:
+
+```
+excluded: 2 soap record(s), 1 non-1.6 record(s), 0 unparseable line(s)
+```
+
+A line that fails to parse as JSON, or parses to something other than a JSON
+object, is counted as an unparseable line and skipped — it never aborts the
+run.
+
+### Disclaimer
+
+Failure-pattern detection is not a conformance checker: it recognizes a
+fixed catalog of known failure shapes, not the OCPP specification itself.
+Every `analyze` run — regardless of format or outcome — prints this sentence
+to stderr, appends it as a trailing paragraph to every Markdown report, and
+injects it as a `<p>` immediately before `</body>` in every HTML report:
+
+> Failure-pattern detection is not OCPP compliance certification: "no known
+> failure detected" does not mean "OCPP compliant".
+
+### Timeline is transaction-focused
+
+The toolkit's session timeline is built around transactions
+(`StartTransaction`/`StopTransaction`/`MeterValues`). Events outside a
+transaction — `StatusNotification`, some bare `CALLRESULT`s — are folded
+into a catch-all "no session" bucket rather than shown against the
+transaction they happened alongside. This is the toolkit's own model, not
+something `analyze` works around; read the report's timeline as
+transaction-focused, not as a complete blow-by-blow of every wire message
+(the Event Appendix at the end of each report still lists every event).
+
+### Dependency
+
+`analyze` requires `@ocpp-debugkit/toolkit`, pinned to an exact version
+(currently `0.4.0`, no `^` range) in `package.json` — this is a third-party
+analysis engine whose detection rules can change behavior between versions,
+so upgrades are a deliberate, coordinated change (re-verify the test matrix
+in `src/cli/analyze/__tests__/`), not an automatic dependency bump. The
+toolkit's `/core` and `/reporter` entry points are loaded via dynamic
+`import()` only inside the `analyze` code path, so every other CLI mode is
+unaffected if the dependency is ever missing.
+
 ## Events
 
 Events are emitted in all modes:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -345,9 +345,20 @@ independently:
   (the charge point id is inserted before the extension and sanitized for
   the filesystem: anything outside `[A-Za-z0-9._-]` becomes `_`). Records
   with no `chargePointId` at all are grouped together and reported as charge
-  point `(no chargePointId)`.
-- With no `--output`, all reports are printed to stdout in Markdown, each
-  under its own `# Charge point <id>` heading.
+  point `(no chargePointId)`. If two charge point ids sanitize to the same
+  filename (e.g. `CP/A` and `CP_A`), the later one in the trace gets a
+  numeric suffix instead of overwriting the first (`out.CP_A.html`,
+  `out.CP_A.2.html`, ...), and a note identifying the original charge point
+  id and the path used is printed to stderr.
+- With no `--output`: by default (no `--format`), all reports are printed to
+  stdout as Markdown, each under its own `# Charge point <id>` heading. With
+  an explicit `--format html`, each report is instead a self-contained HTML
+  document, and since an HTML document has no sensible place for that
+  heading, reports are separated by an `<!-- Charge point <id> -->` comment
+  marker instead (still one valid concatenated stream to redirect to a
+  file). An explicit `--format` always wins over the `--output` extension
+  (see [Formats](#formats) above) — this applies with or without
+  `--output`.
 
 ### Excluded records
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "gen:ocpp": "bun run scripts/generate-ocpp.ts"
   },
   "dependencies": {
+    "@ocpp-debugkit/toolkit": "0.4.0",
     "@peculiar/x509": "^2.0.0",
     "@radix-ui/react-checkbox": "^1.3.7",
     "@radix-ui/react-dialog": "^1.1.19",

--- a/src/cli/__tests__/analyze.bun.test.ts
+++ b/src/cli/__tests__/analyze.bun.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// End-to-end spawn test for the `analyze` subcommand (issue #188 Track 3):
+// exercises the real CLI entry point (src/cli/main.ts's top-of-main()
+// dispatch), not just runAnalyze() in-process, so a wiring regression in
+// main.ts (argv parsing, process.exit() codes) is caught even though every
+// other analyze test calls runAnalyze()/parseAnalyzeArgs() directly.
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+
+function rec(o: Record<string, unknown>): string {
+  return JSON.stringify({
+    schemaVersion: "1.1",
+    ocppVersion: "1.6",
+    transport: "json",
+    chargePointId: "CP001",
+    ...o,
+  });
+}
+
+describe("analyze subcommand (e2e spawn, #188)", () => {
+  it("analyzes a trace file and writes a self-contained HTML report", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "analyze-e2e-"));
+    try {
+      const tracePath = path.join(dir, "trace.jsonl");
+      const outPath = path.join(dir, "report.html");
+      const lines = [
+        rec({
+          timestamp: "2026-01-01T00:00:00.000Z",
+          direction: "cp-to-csms",
+          messageType: "CALL",
+          messageId: "1",
+          action: "BootNotification",
+          payload: {},
+        }),
+        rec({
+          timestamp: "2026-01-01T00:00:01.000Z",
+          direction: "csms-to-cp",
+          messageType: "CALLRESULT",
+          messageId: "1",
+          payload: {
+            status: "Accepted",
+            currentTime: "2026-01-01T00:00:01.000Z",
+            interval: 300,
+          },
+        }),
+      ];
+      fs.writeFileSync(tracePath, lines.join("\n") + "\n");
+
+      const proc = Bun.spawnSync(
+        ["bun", "src/cli/main.ts", "analyze", tracePath, "-o", outPath],
+        { cwd: repoRoot, stdout: "pipe", stderr: "pipe" },
+      );
+
+      const stderr = proc.stderr.toString();
+      if (proc.exitCode !== 0) {
+        console.error(stderr);
+      }
+      expect(proc.exitCode).toBe(0);
+
+      const html = fs.readFileSync(outPath, "utf8");
+      expect(html.startsWith("<!DOCTYPE html>")).toBe(true);
+      expect(html).toContain(
+        'Failure-pattern detection is not OCPP compliance certification: "no known failure detected" does not mean "OCPP compliant".',
+      );
+      expect(stderr).toContain("CP001: 2 events, 0 failures");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("exits 1 with a usage line when no trace file is given", () => {
+    const proc = Bun.spawnSync(["bun", "src/cli/main.ts", "analyze"], {
+      cwd: repoRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(proc.exitCode).toBe(1);
+    const stderr = proc.stderr.toString();
+    expect(stderr).toContain("Error: analyze requires a trace file path");
+    expect(stderr).toContain("Usage: ocpp-cp-sim analyze");
+  });
+});

--- a/src/cli/analyze/__tests__/parseAnalyzeArgs.test.ts
+++ b/src/cli/analyze/__tests__/parseAnalyzeArgs.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { ANALYZE_USAGE, parseAnalyzeArgs } from "../parseAnalyzeArgs";
+
+describe("parseAnalyzeArgs", () => {
+  it("parses a bare file argument", () => {
+    const result = parseAnalyzeArgs(["trace.jsonl"]);
+    expect(result).toEqual({
+      ok: true,
+      args: { file: "trace.jsonl", output: undefined, format: undefined },
+    });
+  });
+
+  it("parses --output and -o", () => {
+    expect(parseAnalyzeArgs(["trace.jsonl", "--output", "out.html"])).toEqual({
+      ok: true,
+      args: { file: "trace.jsonl", output: "out.html", format: undefined },
+    });
+    expect(parseAnalyzeArgs(["trace.jsonl", "-o", "out.md"])).toEqual({
+      ok: true,
+      args: { file: "trace.jsonl", output: "out.md", format: undefined },
+    });
+  });
+
+  it("parses --format html|markdown", () => {
+    expect(parseAnalyzeArgs(["trace.jsonl", "--format", "html"])).toEqual({
+      ok: true,
+      args: { file: "trace.jsonl", output: undefined, format: "html" },
+    });
+    expect(parseAnalyzeArgs(["trace.jsonl", "--format", "markdown"])).toEqual({
+      ok: true,
+      args: { file: "trace.jsonl", output: undefined, format: "markdown" },
+    });
+  });
+
+  it("accepts flags in any position relative to the positional file", () => {
+    const result = parseAnalyzeArgs([
+      "--format",
+      "html",
+      "trace.jsonl",
+      "-o",
+      "out.html",
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      args: { file: "trace.jsonl", output: "out.html", format: "html" },
+    });
+  });
+
+  it("rejects an invalid --format value", () => {
+    const result = parseAnalyzeArgs(["trace.jsonl", "--format", "xml"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("--format must be");
+    }
+  });
+
+  it("rejects --output with a missing value", () => {
+    const result = parseAnalyzeArgs(["trace.jsonl", "--output"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("--output requires a value");
+    }
+  });
+
+  it("rejects an unknown flag", () => {
+    const result = parseAnalyzeArgs(["trace.jsonl", "--bogus"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Unknown option: --bogus");
+    }
+  });
+
+  it("rejects a second positional argument as unknown", () => {
+    const result = parseAnalyzeArgs(["trace.jsonl", "extra.jsonl"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Unknown option: extra.jsonl");
+    }
+  });
+
+  it("reports a missing file with the usage line", () => {
+    const result = parseAnalyzeArgs([]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain(
+        "Error: analyze requires a trace file path",
+      );
+      expect(result.message).toContain(ANALYZE_USAGE);
+    }
+  });
+
+  it("reports a missing file when only flags are given", () => {
+    const result = parseAnalyzeArgs(["--format", "html"]);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/cli/analyze/__tests__/runAnalyze.format.test.ts
+++ b/src/cli/analyze/__tests__/runAnalyze.format.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  ANALYZE_DISCLAIMER,
+  appendMarkdownDisclaimer,
+  injectHtmlDisclaimer,
+  perGroupOutputPath,
+  resolveReportFormat,
+  sanitizeCpIdForFilename,
+} from "../runAnalyze";
+
+describe("resolveReportFormat", () => {
+  it("honors an explicit --format over the --output extension", () => {
+    expect(resolveReportFormat("out.html", "markdown")).toBe("markdown");
+    expect(resolveReportFormat("out.md", "html")).toBe("html");
+  });
+
+  it("infers html from a .html --output extension when --format is absent", () => {
+    expect(resolveReportFormat("report.html", undefined)).toBe("html");
+    expect(resolveReportFormat("report.HTML", undefined)).toBe("html");
+  });
+
+  it("defaults to markdown when there is no --format and no .html extension", () => {
+    expect(resolveReportFormat("report.md", undefined)).toBe("markdown");
+    expect(resolveReportFormat("report", undefined)).toBe("markdown");
+    expect(resolveReportFormat(undefined, undefined)).toBe("markdown");
+  });
+});
+
+describe("sanitizeCpIdForFilename", () => {
+  it("passes through a plain charge point id", () => {
+    expect(sanitizeCpIdForFilename("CP001")).toBe("CP001");
+  });
+
+  it("replaces characters unsafe for a filesystem path with underscores", () => {
+    expect(sanitizeCpIdForFilename("CP 001/foo")).toBe("CP_001_foo");
+    expect(sanitizeCpIdForFilename("(no chargePointId)")).toBe(
+      "_no_chargePointId_",
+    );
+  });
+
+  it("leaves dots, underscores, and hyphens untouched", () => {
+    expect(sanitizeCpIdForFilename("CP-001_v1.6")).toBe("CP-001_v1.6");
+  });
+});
+
+describe("perGroupOutputPath", () => {
+  it("inserts the sanitized chargePointId before the extension", () => {
+    expect(perGroupOutputPath("out.html", "CP001")).toBe("out.CP001.html");
+    expect(perGroupOutputPath("report.md", "CP-B")).toBe("report.CP-B.md");
+  });
+
+  it("handles an --output path with no extension", () => {
+    expect(perGroupOutputPath("report", "CP001")).toBe("report.CP001");
+  });
+
+  it("handles an --output path with a directory component", () => {
+    expect(perGroupOutputPath("/tmp/out/report.html", "CP001")).toBe(
+      "/tmp/out/report.CP001.html",
+    );
+  });
+
+  it("sanitizes the chargePointId for filesystem safety", () => {
+    expect(perGroupOutputPath("out.html", "(no chargePointId)")).toBe(
+      "out._no_chargePointId_.html",
+    );
+  });
+});
+
+describe("appendMarkdownDisclaimer", () => {
+  it("appends the disclaimer as a trailing paragraph", () => {
+    const md = "# Report\n\nsome content\n";
+    const withDisclaimer = appendMarkdownDisclaimer(md);
+    expect(withDisclaimer.startsWith(md)).toBe(true);
+    expect(withDisclaimer).toContain(ANALYZE_DISCLAIMER);
+  });
+});
+
+describe("injectHtmlDisclaimer", () => {
+  it("inserts a <p> disclaimer immediately before </body>", () => {
+    const html = "<html><body><h1>Report</h1></body></html>";
+    const result = injectHtmlDisclaimer(html);
+    expect(result).toBe(
+      `<html><body><h1>Report</h1><p>${ANALYZE_DISCLAIMER}</p></body></html>`,
+    );
+  });
+
+  it("appends at the end when </body> is missing", () => {
+    const html = "<html><h1>Report</h1></html>";
+    const result = injectHtmlDisclaimer(html);
+    expect(result).toBe(
+      `<html><h1>Report</h1></html><p>${ANALYZE_DISCLAIMER}</p>`,
+    );
+  });
+});

--- a/src/cli/analyze/__tests__/runAnalyze.test.ts
+++ b/src/cli/analyze/__tests__/runAnalyze.test.ts
@@ -1,0 +1,352 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ANALYZE_DISCLAIMER, runAnalyze } from "../runAnalyze";
+
+// Real @ocpp-debugkit/toolkit@0.4.0 — deliberately not mocked. These tests
+// pin the pre-splitting guarantee (3a) against the toolkit's actual,
+// verified behavior: it has no concept of chargePointId, so without
+// splitTrace first, two charge points reusing a messageId can have their
+// CALLs/CALLRESULTs cross-correlate and hide a real per-CP failure.
+
+function rec(cpId: string, o: Record<string, unknown>): string {
+  return JSON.stringify({
+    schemaVersion: "1.1",
+    ocppVersion: "1.6",
+    transport: "json",
+    chargePointId: cpId,
+    ...o,
+  });
+}
+
+async function withCapturedIo<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; stdout: string; stderr: string }> {
+  const originalStdout = process.stdout.write.bind(process.stdout);
+  const originalStderr = process.stderr.write.bind(process.stderr);
+  let stdout = "";
+  let stderr = "";
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdout += chunk.toString();
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += chunk.toString();
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const result = await fn();
+    return { result, stdout, stderr };
+  } finally {
+    process.stdout.write = originalStdout;
+    process.stderr.write = originalStderr;
+  }
+}
+
+describe("runAnalyze (integration, real @ocpp-debugkit/toolkit)", () => {
+  let dir: string;
+
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reports a clean 1.6 session with 0 failures and the disclaimer", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "analyze-clean-"));
+    const tracePath = path.join(dir, "trace.jsonl");
+    const outPath = path.join(dir, "report.md");
+
+    const lines = [
+      rec("CP001", {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "1",
+        action: "BootNotification",
+        payload: { chargePointVendor: "V", chargePointModel: "M" },
+      }),
+      rec("CP001", {
+        timestamp: "2026-01-01T00:00:01.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "1",
+        payload: {
+          status: "Accepted",
+          currentTime: "2026-01-01T00:00:01.000Z",
+          interval: 300,
+        },
+      }),
+      rec("CP001", {
+        timestamp: "2026-01-01T00:00:02.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "2",
+        action: "Authorize",
+        payload: { idTag: "TAG1" },
+      }),
+      rec("CP001", {
+        timestamp: "2026-01-01T00:00:03.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "2",
+        payload: { idTagInfo: { status: "Accepted" } },
+      }),
+      rec("CP001", {
+        connectorId: 1,
+        timestamp: "2026-01-01T00:00:04.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "3",
+        action: "StartTransaction",
+        payload: {
+          connectorId: 1,
+          idTag: "TAG1",
+          meterStart: 0,
+          timestamp: "2026-01-01T00:00:04.000Z",
+        },
+      }),
+      rec("CP001", {
+        timestamp: "2026-01-01T00:00:05.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "3",
+        payload: { idTagInfo: { status: "Accepted" }, transactionId: 1001 },
+      }),
+      rec("CP001", {
+        connectorId: 1,
+        timestamp: "2026-01-01T00:00:30.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "4",
+        action: "MeterValues",
+        payload: {
+          connectorId: 1,
+          transactionId: 1001,
+          meterValue: [
+            {
+              timestamp: "2026-01-01T00:00:30.000Z",
+              sampledValue: [{ value: "1000" }],
+            },
+          ],
+        },
+      }),
+      rec("CP001", {
+        timestamp: "2026-01-01T00:00:31.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "4",
+        payload: {},
+      }),
+      rec("CP001", {
+        timestamp: "2026-01-01T00:01:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "5",
+        action: "StopTransaction",
+        payload: {
+          transactionId: 1001,
+          meterStop: 2000,
+          timestamp: "2026-01-01T00:01:00.000Z",
+          idTag: "TAG1",
+          reason: "Local",
+        },
+      }),
+      rec("CP001", {
+        timestamp: "2026-01-01T00:01:01.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "5",
+        payload: {},
+      }),
+    ];
+    fs.writeFileSync(tracePath, lines.join("\n") + "\n");
+
+    const { result: code } = await withCapturedIo(() =>
+      runAnalyze({ file: tracePath, output: outPath }),
+    );
+
+    expect(code).toBe(0);
+    const content = fs.readFileSync(outPath, "utf8");
+    expect(content).toContain("StartTransaction");
+    expect(content).toContain("No failures detected");
+    expect(content).toContain(ANALYZE_DISCLAIMER);
+  });
+
+  it("detects FAILED_AUTHORIZATION from an Invalid Authorize response", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "analyze-authfail-"));
+    const tracePath = path.join(dir, "trace.jsonl");
+    const outPath = path.join(dir, "report.md");
+
+    const lines = [
+      rec("CP001", {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "1",
+        action: "BootNotification",
+        payload: {},
+      }),
+      rec("CP001", {
+        timestamp: "2026-01-01T00:00:01.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "1",
+        payload: {
+          status: "Accepted",
+          currentTime: "2026-01-01T00:00:01.000Z",
+          interval: 300,
+        },
+      }),
+      rec("CP001", {
+        timestamp: "2026-01-01T00:00:02.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "2",
+        action: "Authorize",
+        payload: { idTag: "TAG1" },
+      }),
+      rec("CP001", {
+        timestamp: "2026-01-01T00:00:03.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "2",
+        payload: { idTagInfo: { status: "Invalid" } },
+      }),
+    ];
+    fs.writeFileSync(tracePath, lines.join("\n") + "\n");
+
+    const { result: code } = await withCapturedIo(() =>
+      runAnalyze({ file: tracePath, output: outPath }),
+    );
+
+    expect(code).toBe(0);
+    const content = fs.readFileSync(outPath, "utf8");
+    expect(content).toContain("FAILED_AUTHORIZATION");
+  });
+
+  it("splits CP-A and CP-B before analysis so a shared messageId can't cross-correlate a failure away", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "analyze-multicp-"));
+    const tracePath = path.join(dir, "trace.jsonl");
+    const outPath = path.join(dir, "out.md");
+
+    const lines = [
+      // CP-A: Authorize "dup" answered normally.
+      rec("CP-A", {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "dup",
+        action: "Authorize",
+        payload: { idTag: "TAG-A" },
+      }),
+      rec("CP-A", {
+        timestamp: "2026-01-01T00:00:01.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "dup",
+        payload: { idTagInfo: { status: "Accepted" } },
+      }),
+      // CP-B: same messageId "dup", but the CSMS never answers it.
+      rec("CP-B", {
+        timestamp: "2026-01-01T00:00:02.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "dup",
+        action: "Authorize",
+        payload: { idTag: "TAG-B" },
+      }),
+    ];
+    fs.writeFileSync(tracePath, lines.join("\n") + "\n");
+
+    const { result: code } = await withCapturedIo(() =>
+      runAnalyze({ file: tracePath, output: outPath }),
+    );
+
+    expect(code).toBe(0);
+    const cpAPath = path.join(dir, "out.CP-A.md");
+    const cpBPath = path.join(dir, "out.CP-B.md");
+    expect(fs.existsSync(cpAPath)).toBe(true);
+    expect(fs.existsSync(cpBPath)).toBe(true);
+
+    const cpAContent = fs.readFileSync(cpAPath, "utf8");
+    const cpBContent = fs.readFileSync(cpBPath, "utf8");
+
+    // Each report names only its own charge point.
+    expect(cpAContent).toContain("CP-A");
+    expect(cpAContent).not.toContain("CP-B");
+    expect(cpBContent).toContain("CP-B");
+    expect(cpBContent).not.toContain("CP-A");
+
+    // The pre-splitting guarantee: CP-B's unanswered Call is UNRESPONSIVE_CSMS
+    // only in CP-B's report, not masked by CP-A's response to the same
+    // messageId, and not leaked into CP-A's report either.
+    expect(cpBContent).toContain("UNRESPONSIVE_CSMS");
+    expect(cpAContent).not.toContain("UNRESPONSIVE_CSMS");
+  });
+
+  it("excludes soap and non-1.6 records and reports the counts on stderr", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "analyze-excluded-"));
+    const tracePath = path.join(dir, "trace.jsonl");
+    const outPath = path.join(dir, "report.md");
+
+    const lines = [
+      rec("CP001", {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "1",
+        action: "Heartbeat",
+        payload: {},
+      }),
+      rec("CP001", {
+        timestamp: "2026-01-01T00:00:01.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "1",
+        payload: { currentTime: "2026-01-01T00:00:01.000Z" },
+      }),
+      rec("CP-SOAP", {
+        transport: "soap",
+        timestamp: "2026-01-01T00:00:02.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "2",
+        action: "BootNotification",
+        payload: {},
+      }),
+      rec("CP-201", {
+        ocppVersion: "2.0.1",
+        timestamp: "2026-01-01T00:00:03.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "3",
+        action: "BootNotification",
+        payload: {},
+      }),
+    ];
+    fs.writeFileSync(tracePath, lines.join("\n") + "\n");
+
+    const { result: code, stderr } = await withCapturedIo(() =>
+      runAnalyze({ file: tracePath, output: outPath }),
+    );
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(
+      "excluded: 1 soap record(s), 1 non-1.6 record(s), 0 unparseable line(s)",
+    );
+    // Only the single 1.6 CP001 record made it into the report.
+    const content = fs.readFileSync(outPath, "utf8");
+    expect(content).toContain("Heartbeat");
+    expect(content).not.toContain("CP-SOAP");
+    expect(content).not.toContain("CP-201");
+  });
+
+  it("returns exit code 1 and an error on stderr when the trace file is missing", async () => {
+    const { result: code, stderr } = await withCapturedIo(() =>
+      runAnalyze({ file: "/nonexistent/does-not-exist.jsonl" }),
+    );
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("Error: cannot read trace file:");
+  });
+});

--- a/src/cli/analyze/__tests__/runAnalyze.test.ts
+++ b/src/cli/analyze/__tests__/runAnalyze.test.ts
@@ -20,6 +20,45 @@ function rec(cpId: string, o: Record<string, unknown>): string {
   });
 }
 
+/** Computes the verbatim OCPP-J frame text for a CALL/CALLRESULT record's
+ *  own decomposed fields. Used only to build a realistic `raw` field below
+ *  (Fix 5, issue #188 review) -- not a general-purpose helper for other
+ *  fixtures in this file. */
+function ocppJFrame(o: {
+  messageType: string;
+  messageId?: string;
+  action?: string;
+  payload?: unknown;
+}): string {
+  switch (o.messageType) {
+    case "CALL":
+      return JSON.stringify([2, o.messageId, o.action, o.payload]);
+    case "CALLRESULT":
+      return JSON.stringify([3, o.messageId, o.payload]);
+    default:
+      throw new Error(`ocppJFrame: unsupported messageType ${o.messageType}`);
+  }
+}
+
+/** Same as `rec`, but also attaches a `raw` field holding the verbatim
+ *  OCPP-J frame matching the record's own decomposed fields -- real
+ *  `--trace-output` files always carry `raw`, and a fixture without it
+ *  under-tests the no-re-stringify constraint (Fix 5, issue #188 review).
+ *  Only the clean-session fixture below uses this; other fixtures in this
+ *  file are left untouched. */
+function recWithRaw(
+  cpId: string,
+  o: {
+    messageType: string;
+    messageId?: string;
+    action?: string;
+    payload?: unknown;
+    [key: string]: unknown;
+  },
+): string {
+  return rec(cpId, { ...o, raw: ocppJFrame(o) });
+}
+
 async function withCapturedIo<T>(
   fn: () => Promise<T>,
 ): Promise<{ result: T; stdout: string; stderr: string }> {
@@ -57,7 +96,7 @@ describe("runAnalyze (integration, real @ocpp-debugkit/toolkit)", () => {
     const outPath = path.join(dir, "report.md");
 
     const lines = [
-      rec("CP001", {
+      recWithRaw("CP001", {
         timestamp: "2026-01-01T00:00:00.000Z",
         direction: "cp-to-csms",
         messageType: "CALL",
@@ -65,7 +104,7 @@ describe("runAnalyze (integration, real @ocpp-debugkit/toolkit)", () => {
         action: "BootNotification",
         payload: { chargePointVendor: "V", chargePointModel: "M" },
       }),
-      rec("CP001", {
+      recWithRaw("CP001", {
         timestamp: "2026-01-01T00:00:01.000Z",
         direction: "csms-to-cp",
         messageType: "CALLRESULT",
@@ -76,7 +115,7 @@ describe("runAnalyze (integration, real @ocpp-debugkit/toolkit)", () => {
           interval: 300,
         },
       }),
-      rec("CP001", {
+      recWithRaw("CP001", {
         timestamp: "2026-01-01T00:00:02.000Z",
         direction: "cp-to-csms",
         messageType: "CALL",
@@ -84,14 +123,14 @@ describe("runAnalyze (integration, real @ocpp-debugkit/toolkit)", () => {
         action: "Authorize",
         payload: { idTag: "TAG1" },
       }),
-      rec("CP001", {
+      recWithRaw("CP001", {
         timestamp: "2026-01-01T00:00:03.000Z",
         direction: "csms-to-cp",
         messageType: "CALLRESULT",
         messageId: "2",
         payload: { idTagInfo: { status: "Accepted" } },
       }),
-      rec("CP001", {
+      recWithRaw("CP001", {
         connectorId: 1,
         timestamp: "2026-01-01T00:00:04.000Z",
         direction: "cp-to-csms",
@@ -105,14 +144,14 @@ describe("runAnalyze (integration, real @ocpp-debugkit/toolkit)", () => {
           timestamp: "2026-01-01T00:00:04.000Z",
         },
       }),
-      rec("CP001", {
+      recWithRaw("CP001", {
         timestamp: "2026-01-01T00:00:05.000Z",
         direction: "csms-to-cp",
         messageType: "CALLRESULT",
         messageId: "3",
         payload: { idTagInfo: { status: "Accepted" }, transactionId: 1001 },
       }),
-      rec("CP001", {
+      recWithRaw("CP001", {
         connectorId: 1,
         timestamp: "2026-01-01T00:00:30.000Z",
         direction: "cp-to-csms",
@@ -130,14 +169,14 @@ describe("runAnalyze (integration, real @ocpp-debugkit/toolkit)", () => {
           ],
         },
       }),
-      rec("CP001", {
+      recWithRaw("CP001", {
         timestamp: "2026-01-01T00:00:31.000Z",
         direction: "csms-to-cp",
         messageType: "CALLRESULT",
         messageId: "4",
         payload: {},
       }),
-      rec("CP001", {
+      recWithRaw("CP001", {
         timestamp: "2026-01-01T00:01:00.000Z",
         direction: "cp-to-csms",
         messageType: "CALL",
@@ -151,7 +190,7 @@ describe("runAnalyze (integration, real @ocpp-debugkit/toolkit)", () => {
           reason: "Local",
         },
       }),
-      rec("CP001", {
+      recWithRaw("CP001", {
         timestamp: "2026-01-01T00:01:01.000Z",
         direction: "csms-to-cp",
         messageType: "CALLRESULT",
@@ -348,5 +387,136 @@ describe("runAnalyze (integration, real @ocpp-debugkit/toolkit)", () => {
 
     expect(code).toBe(1);
     expect(stderr).toContain("Error: cannot read trace file:");
+  });
+
+  it("disambiguates two cpIds that sanitize to the same filename instead of overwriting", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "analyze-collide-"));
+    const tracePath = path.join(dir, "trace.jsonl");
+    const outPath = path.join(dir, "out.md");
+
+    // "CP/A" and "CP_A" both sanitize to "CP_A" -- distinct chargePointIds,
+    // colliding filenames.
+    const lines = [
+      rec("CP/A", {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "1",
+        action: "Authorize",
+        payload: { idTag: "TAG-SLASH" },
+      }),
+      rec("CP/A", {
+        timestamp: "2026-01-01T00:00:01.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "1",
+        payload: { idTagInfo: { status: "Accepted" } },
+      }),
+      rec("CP_A", {
+        timestamp: "2026-01-01T00:00:02.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "1",
+        action: "Authorize",
+        payload: { idTag: "TAG-UNDERSCORE" },
+      }),
+    ];
+    fs.writeFileSync(tracePath, lines.join("\n") + "\n");
+
+    const {
+      result: code,
+      stdout,
+      stderr,
+    } = await withCapturedIo(() =>
+      runAnalyze({ file: tracePath, output: outPath }),
+    );
+
+    expect(code).toBe(0);
+
+    const firstPath = path.join(dir, "out.CP_A.md");
+    const secondPath = path.join(dir, "out.CP_A.2.md");
+    expect(fs.existsSync(firstPath)).toBe(true);
+    expect(fs.existsSync(secondPath)).toBe(true);
+
+    const firstContent = fs.readFileSync(firstPath, "utf8");
+    const secondContent = fs.readFileSync(secondPath, "utf8");
+    // Group iteration order follows first-appearance in the trace file:
+    // "CP/A" (lines 1-2) claims the plain path; "CP_A" (line 3) collides
+    // and lands in the disambiguated one. Each report names only its own
+    // station.
+    expect(firstContent).toContain("CP/A");
+    expect(firstContent).not.toContain("CP_A");
+    expect(secondContent).toContain("CP_A");
+    expect(secondContent).not.toContain("CP/A");
+
+    // Both success lines point at the distinct, actually-written paths.
+    expect(stdout).toContain(`Wrote report: ${firstPath}`);
+    expect(stdout).toContain(`Wrote report: ${secondPath}`);
+
+    // The disambiguation itself is noted on stderr, naming the original cpId.
+    expect(stderr).toContain("CP_A");
+    expect(stderr).toContain(secondPath);
+  });
+
+  it("isolates a per-group write failure: other groups still write, error on stderr, disclaimer still printed, exit code 1", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "analyze-writefail-"));
+    const tracePath = path.join(dir, "trace.jsonl");
+    const outPath = path.join(dir, "out.md");
+
+    const lines = [
+      rec("CP-A", {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "1",
+        action: "Authorize",
+        payload: { idTag: "TAG-A" },
+      }),
+      rec("CP-A", {
+        timestamp: "2026-01-01T00:00:01.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "1",
+        payload: { idTagInfo: { status: "Accepted" } },
+      }),
+      rec("CP-B", {
+        timestamp: "2026-01-01T00:00:02.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "1",
+        action: "Authorize",
+        payload: { idTag: "TAG-B" },
+      }),
+      rec("CP-B", {
+        timestamp: "2026-01-01T00:00:03.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "1",
+        payload: { idTagInfo: { status: "Accepted" } },
+      }),
+    ];
+    fs.writeFileSync(tracePath, lines.join("\n") + "\n");
+
+    // Pre-create a DIRECTORY at CP-B's exact target path so writeFileSync
+    // throws EISDIR for that group only.
+    const cpBPath = path.join(dir, "out.CP-B.md");
+    fs.mkdirSync(cpBPath);
+
+    const { result: code, stderr } = await withCapturedIo(() =>
+      runAnalyze({ file: tracePath, output: outPath }),
+    );
+
+    expect(code).toBe(1);
+
+    const cpAPath = path.join(dir, "out.CP-A.md");
+    expect(fs.existsSync(cpAPath)).toBe(true);
+    expect(fs.readFileSync(cpAPath, "utf8")).toContain("CP-A");
+
+    expect(stderr).toContain("Error: cannot write report file:");
+    expect(stderr).toContain(cpBPath);
+    expect(stderr).toContain(ANALYZE_DISCLAIMER);
+    // Per-group summary lines still printed even though one group's write failed.
+    expect(stderr).toContain("CP-A:");
+    expect(stderr).toContain("CP-B:");
   });
 });

--- a/src/cli/analyze/__tests__/runAnalyze.toolkitFailure.test.ts
+++ b/src/cli/analyze/__tests__/runAnalyze.toolkitFailure.test.ts
@@ -1,0 +1,143 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// CodeRabbit finding (issue #188, Major): the per-group WRITE is isolated by
+// a try/catch (runAnalyze.test.ts's "isolates a per-group write failure"
+// case), but the per-group toolkit pipeline (parseOpenOcppTrace ->
+// buildSessionTimeline -> detectFailures -> summarizeSessions -> report
+// generation) had no equivalent guard: a throw for one charge point's data
+// escaped runAnalyze() entirely instead of being isolated the same way.
+//
+// This mock makes parseOpenOcppTrace throw only for the group whose jsonl
+// text contains "CP-BAD" (i.e. the CP-BAD group itself), delegating to the
+// real implementation otherwise -- vitest's vi.mock intercepts the dynamic
+// `await import("@ocpp-debugkit/toolkit/core")` in runAnalyze.ts just like a
+// static import.
+vi.mock("@ocpp-debugkit/toolkit/core", async () => {
+  const actual = await vi.importActual<
+    typeof import("@ocpp-debugkit/toolkit/core")
+  >("@ocpp-debugkit/toolkit/core");
+  return {
+    ...actual,
+    parseOpenOcppTrace: (jsonl: string) => {
+      if (jsonl.includes("CP-BAD")) {
+        throw new Error("simulated toolkit parse failure for CP-BAD");
+      }
+      return actual.parseOpenOcppTrace(jsonl);
+    },
+  };
+});
+
+import { ANALYZE_DISCLAIMER, runAnalyze } from "../runAnalyze";
+
+function rec(cpId: string, o: Record<string, unknown>): string {
+  return JSON.stringify({
+    schemaVersion: "1.1",
+    ocppVersion: "1.6",
+    transport: "json",
+    chargePointId: cpId,
+    ...o,
+  });
+}
+
+async function withCapturedIo<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; stdout: string; stderr: string }> {
+  const originalStdout = process.stdout.write.bind(process.stdout);
+  const originalStderr = process.stderr.write.bind(process.stderr);
+  let stdout = "";
+  let stderr = "";
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdout += chunk.toString();
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += chunk.toString();
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const result = await fn();
+    return { result, stdout, stderr };
+  } finally {
+    process.stdout.write = originalStdout;
+    process.stderr.write = originalStderr;
+  }
+}
+
+describe("runAnalyze (per-group toolkit analysis failure isolation)", () => {
+  let dir: string;
+
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("isolates a per-group toolkit analysis failure: the other group still analyzes and writes, an error is printed on stderr, the successful group's summary line and the disclaimer still print, exit code 1", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "analyze-toolkitfail-"));
+    const tracePath = path.join(dir, "trace.jsonl");
+    const outPath = path.join(dir, "out.md");
+
+    const lines = [
+      rec("CP-GOOD", {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "1",
+        action: "Authorize",
+        payload: { idTag: "TAG-GOOD" },
+      }),
+      rec("CP-GOOD", {
+        timestamp: "2026-01-01T00:00:01.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "1",
+        payload: { idTagInfo: { status: "Accepted" } },
+      }),
+      rec("CP-BAD", {
+        timestamp: "2026-01-01T00:00:02.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "1",
+        action: "Authorize",
+        payload: { idTag: "TAG-BAD" },
+      }),
+      rec("CP-BAD", {
+        timestamp: "2026-01-01T00:00:03.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "1",
+        payload: { idTagInfo: { status: "Accepted" } },
+      }),
+    ];
+    fs.writeFileSync(tracePath, lines.join("\n") + "\n");
+
+    const { result: code, stderr } = await withCapturedIo(() =>
+      runAnalyze({ file: tracePath, output: outPath }),
+    );
+
+    expect(code).toBe(1);
+
+    // CP-GOOD's report was still generated and written with real content.
+    const cpGoodPath = path.join(dir, "out.CP-GOOD.md");
+    expect(fs.existsSync(cpGoodPath)).toBe(true);
+    const cpGoodContent = fs.readFileSync(cpGoodPath, "utf8");
+    expect(cpGoodContent).toContain("CP-GOOD");
+    expect(cpGoodContent).toContain(ANALYZE_DISCLAIMER);
+
+    // CP-BAD's report was never written -- its analysis failed.
+    const cpBadPath = path.join(dir, "out.CP-BAD.md");
+    expect(fs.existsSync(cpBadPath)).toBe(false);
+
+    // The per-group toolkit failure is reported on stderr with the group id
+    // and the underlying message, using the same convention as the
+    // per-group write-failure path.
+    expect(stderr).toContain(
+      "Error: cannot analyze charge point CP-BAD: simulated toolkit parse failure for CP-BAD",
+    );
+    // CP-GOOD's summary line and the disclaimer still print even though
+    // CP-BAD's analysis failed.
+    expect(stderr).toContain("CP-GOOD:");
+    expect(stderr).toContain(ANALYZE_DISCLAIMER);
+  });
+});

--- a/src/cli/analyze/__tests__/splitTrace.test.ts
+++ b/src/cli/analyze/__tests__/splitTrace.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { splitTraceJsonl } from "../splitTrace";
+
+function line(rec: Record<string, unknown>): string {
+  return JSON.stringify(rec);
+}
+
+describe("splitTraceJsonl", () => {
+  it("groups records by chargePointId, preserving line order within a group", () => {
+    const a1 = line({
+      schemaVersion: "1.1",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      ocppVersion: "1.6",
+      transport: "json",
+      chargePointId: "CP-A",
+      direction: "cp-to-csms",
+      messageType: "CALL",
+      messageId: "1",
+      action: "BootNotification",
+    });
+    const b1 = line({
+      schemaVersion: "1.1",
+      timestamp: "2026-01-01T00:00:01.000Z",
+      ocppVersion: "1.6",
+      transport: "json",
+      chargePointId: "CP-B",
+      direction: "cp-to-csms",
+      messageType: "CALL",
+      messageId: "1",
+      action: "BootNotification",
+    });
+    const a2 = line({
+      schemaVersion: "1.1",
+      timestamp: "2026-01-01T00:00:02.000Z",
+      ocppVersion: "1.6",
+      transport: "json",
+      chargePointId: "CP-A",
+      direction: "csms-to-cp",
+      messageType: "CALLRESULT",
+      messageId: "1",
+    });
+
+    const split = splitTraceJsonl([a1, b1, a2].join("\n") + "\n");
+
+    expect(Array.from(split.byChargePoint.keys())).toEqual(["CP-A", "CP-B"]);
+    expect(split.byChargePoint.get("CP-A")).toBe(a1 + "\n" + a2 + "\n");
+    expect(split.byChargePoint.get("CP-B")).toBe(b1 + "\n");
+    expect(split.unattributed).toBe("");
+    expect(split.excluded).toEqual({
+      soap: 0,
+      unsupportedOcppVersion: 0,
+      unparseableLine: 0,
+    });
+    expect(split.total).toBe(3);
+  });
+
+  it("excludes soap-transport records and counts them", () => {
+    const kept = line({
+      ocppVersion: "1.6",
+      transport: "json",
+      chargePointId: "CP-A",
+      messageType: "CALL",
+      messageId: "1",
+      action: "Heartbeat",
+    });
+    const soap = line({
+      ocppVersion: "1.6",
+      transport: "soap",
+      chargePointId: "CP-A",
+      messageType: "CALL",
+      messageId: "2",
+      action: "Heartbeat",
+    });
+
+    const split = splitTraceJsonl([kept, soap].join("\n") + "\n");
+
+    expect(split.byChargePoint.get("CP-A")).toBe(kept + "\n");
+    expect(split.excluded.soap).toBe(1);
+    expect(split.total).toBe(2);
+  });
+
+  it("excludes records whose ocppVersion does not start with 1.6, but keeps records with no ocppVersion at all", () => {
+    const v16 = line({
+      ocppVersion: "1.6",
+      transport: "json",
+      chargePointId: "CP-A",
+      messageType: "CALL",
+      messageId: "1",
+      action: "Heartbeat",
+    });
+    const v201 = line({
+      ocppVersion: "2.0.1",
+      transport: "json",
+      chargePointId: "CP-A",
+      messageType: "CALL",
+      messageId: "2",
+      action: "Heartbeat",
+    });
+    const v21 = line({
+      ocppVersion: "2.1",
+      transport: "json",
+      chargePointId: "CP-A",
+      messageType: "CALL",
+      messageId: "3",
+      action: "Heartbeat",
+    });
+    const noVersion = line({
+      transport: "json",
+      chargePointId: "CP-A",
+      messageType: "CALL",
+      messageId: "4",
+      action: "Heartbeat",
+    });
+
+    const split = splitTraceJsonl(
+      [v16, v201, v21, noVersion].join("\n") + "\n",
+    );
+
+    expect(split.byChargePoint.get("CP-A")).toBe(v16 + "\n" + noVersion + "\n");
+    expect(split.excluded.unsupportedOcppVersion).toBe(2);
+    expect(split.total).toBe(4);
+  });
+
+  it("counts unparseable lines and skips them without throwing", () => {
+    const good = line({
+      ocppVersion: "1.6",
+      transport: "json",
+      chargePointId: "CP-A",
+      messageType: "CALL",
+      messageId: "1",
+      action: "Heartbeat",
+    });
+    const notJson = "this is not json";
+    const jsonArray = "[1,2,3]"; // valid JSON, but not an object -> unparseable
+
+    const split = splitTraceJsonl([good, notJson, jsonArray].join("\n") + "\n");
+
+    expect(split.byChargePoint.get("CP-A")).toBe(good + "\n");
+    expect(split.excluded.unparseableLine).toBe(2);
+    expect(split.total).toBe(3);
+  });
+
+  it("buckets records with no chargePointId into `unattributed`", () => {
+    const withCp = line({
+      ocppVersion: "1.6",
+      transport: "json",
+      chargePointId: "CP-A",
+      messageType: "CALL",
+      messageId: "1",
+      action: "Heartbeat",
+    });
+    const withoutCp = line({
+      ocppVersion: "1.6",
+      transport: "json",
+      messageType: "CALL",
+      messageId: "2",
+      action: "Heartbeat",
+    });
+
+    const split = splitTraceJsonl([withCp, withoutCp].join("\n") + "\n");
+
+    expect(split.byChargePoint.get("CP-A")).toBe(withCp + "\n");
+    expect(split.unattributed).toBe(withoutCp + "\n");
+    expect(split.total).toBe(2);
+  });
+
+  it("returns empty structures for empty input", () => {
+    const split = splitTraceJsonl("");
+
+    expect(split.byChargePoint.size).toBe(0);
+    expect(split.unattributed).toBe("");
+    expect(split.excluded).toEqual({
+      soap: 0,
+      unsupportedOcppVersion: 0,
+      unparseableLine: 0,
+    });
+    expect(split.total).toBe(0);
+  });
+
+  it("preserves the original raw line text verbatim (byte fidelity), not a re-stringified copy", () => {
+    // Deliberately odd formatting (extra whitespace, key order) that
+    // JSON.stringify would normalize away if we round-tripped through parse.
+    const raw =
+      '{"ocppVersion":  "1.6", "transport": "json", "chargePointId":"CP-A", "messageType":"CALL", "messageId":"1",   "action": "Heartbeat"}';
+
+    const split = splitTraceJsonl(raw + "\n");
+
+    expect(split.byChargePoint.get("CP-A")).toBe(raw + "\n");
+  });
+});

--- a/src/cli/analyze/parseAnalyzeArgs.ts
+++ b/src/cli/analyze/parseAnalyzeArgs.ts
@@ -1,0 +1,65 @@
+/**
+ * Argument parser for the `analyze` subcommand.
+ *
+ * Kept out of main.ts's `parseArgs()` switch and its own module (rather than
+ * inline in main.ts's early dispatch) so the flag/format edge cases are unit
+ * testable without spawning a `bun` subprocess for each one. It returns a
+ * result object instead of calling `process.exit()` itself for the same
+ * reason: a pure function is trivial to assert against in vitest.
+ */
+
+export interface AnalyzeCliArgs {
+  file: string;
+  output?: string;
+  format?: "html" | "markdown";
+}
+
+export type AnalyzeCliParseResult =
+  { ok: true; args: AnalyzeCliArgs } | { ok: false; message: string };
+
+export const ANALYZE_USAGE =
+  "Usage: ocpp-cp-sim analyze <trace.jsonl> [--output <file>] [--format html|markdown]";
+
+export function parseAnalyzeArgs(argv: string[]): AnalyzeCliParseResult {
+  let file: string | undefined;
+  let output: string | undefined;
+  let format: "html" | "markdown" | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--output" || arg === "-o") {
+      const next = argv[i + 1];
+      if (!next || next.startsWith("-")) {
+        return { ok: false, message: `Error: ${arg} requires a value` };
+      }
+      output = next;
+      i++;
+    } else if (arg === "--format") {
+      const next = argv[i + 1];
+      if (next !== "html" && next !== "markdown") {
+        return {
+          ok: false,
+          message: "Error: --format must be 'html' or 'markdown'",
+        };
+      }
+      format = next;
+      i++;
+    } else if (arg.startsWith("-")) {
+      return { ok: false, message: `Unknown option: ${arg}` };
+    } else if (file === undefined) {
+      file = arg;
+    } else {
+      // A second positional argument: analyze only takes one trace file.
+      return { ok: false, message: `Unknown option: ${arg}` };
+    }
+  }
+
+  if (!file) {
+    return {
+      ok: false,
+      message: `Error: analyze requires a trace file path\n${ANALYZE_USAGE}`,
+    };
+  }
+
+  return { ok: true, args: { file, output, format } };
+}

--- a/src/cli/analyze/runAnalyze.ts
+++ b/src/cli/analyze/runAnalyze.ts
@@ -1,0 +1,238 @@
+/**
+ * `analyze` subcommand orchestration (issue #188 Track 3): assembles the
+ * OCPP DebugKit toolkit's own building blocks into the one pipeline it
+ * doesn't ship as a single call, per charge point.
+ *
+ * The toolkit is imported dynamically, and ONLY its `/core` and `/reporter`
+ * subpaths -- never the package root, and never `/cli` (which runs
+ * `program.parse()` at module load, a real side effect on our own argv).
+ * A dynamic import also means a missing/broken install fails inside
+ * `runAnalyze()` with our own message instead of crashing every other CLI
+ * mode at startup.
+ *
+ * Only `import type` (fully erased at compile time, no runtime import) is
+ * used for the toolkit's types so the type-checker can see its shapes
+ * without that also constituting an eager load.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { splitTraceJsonl } from "./splitTrace";
+import type { AnalysisResult } from "@ocpp-debugkit/toolkit/reporter";
+
+export interface AnalyzeOptions {
+  file: string;
+  output?: string;
+  format?: "html" | "markdown";
+}
+
+/**
+ * Issue #188 PoC item 8: the detector only recognizes a fixed catalog of
+ * known failure shapes -- it is not a conformance checker. Printed
+ * unconditionally (stderr, every markdown report, every HTML report) so a
+ * clean run can never be read as "this station is OCPP compliant".
+ */
+export const ANALYZE_DISCLAIMER =
+  'Failure-pattern detection is not OCPP compliance certification: "no known failure detected" does not mean "OCPP compliant".';
+
+/** Label for the bucket of records with no `chargePointId` at all. */
+const UNATTRIBUTED_GROUP_LABEL = "(no chargePointId)";
+
+export function resolveReportFormat(
+  output: string | undefined,
+  format: "html" | "markdown" | undefined,
+): "html" | "markdown" {
+  if (format) return format;
+  if (output && output.toLowerCase().endsWith(".html")) return "html";
+  return "markdown";
+}
+
+/** Charge point ids are operator-controlled strings and land directly in a
+ *  filename (multi-CP `--output` splitting); neutralize path separators and
+ *  anything else a filesystem might treat specially. */
+export function sanitizeCpIdForFilename(cpId: string): string {
+  return cpId.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+/** `out.html` + `CP001` -> `out.CP001.html` (multi-CP `--output` splitting). */
+export function perGroupOutputPath(
+  outputPath: string,
+  chargePointId: string,
+): string {
+  const dir = path.dirname(outputPath);
+  const ext = path.extname(outputPath);
+  const base = path.basename(outputPath, ext);
+  const fileName = `${base}.${sanitizeCpIdForFilename(chargePointId)}${ext}`;
+  return dir === "." ? fileName : path.join(dir, fileName);
+}
+
+export function appendMarkdownDisclaimer(markdown: string): string {
+  const separator = markdown.endsWith("\n") ? "\n" : "\n\n";
+  return `${markdown}${separator}${ANALYZE_DISCLAIMER}\n`;
+}
+
+export function injectHtmlDisclaimer(html: string): string {
+  const marker = "</body>";
+  const fragment = `<p>${ANALYZE_DISCLAIMER}</p>`;
+  const idx = html.lastIndexOf(marker);
+  if (idx === -1) return `${html}${fragment}`;
+  return `${html.slice(0, idx)}${fragment}${html.slice(idx)}`;
+}
+
+/** `ocppVersion` for the group's metadata, only when every record that
+ *  states one agrees (records with no `ocppVersion` field don't count
+ *  against uniformity) -- otherwise the field is left undefined rather than
+ *  guessing. */
+function detectUniformOcppVersion(jsonlText: string): string | undefined {
+  let version: string | undefined;
+  for (const line of jsonlText.split("\n")) {
+    if (!line.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null) continue;
+    const value = (parsed as Record<string, unknown>).ocppVersion;
+    if (typeof value !== "string") continue;
+    if (version === undefined) {
+      version = value;
+    } else if (version !== value) {
+      return undefined;
+    }
+  }
+  return version;
+}
+
+interface Group {
+  id: string;
+  jsonl: string;
+}
+
+export async function runAnalyze(opts: AnalyzeOptions): Promise<number> {
+  let text: string;
+  try {
+    text = fs.readFileSync(opts.file, "utf8");
+  } catch (err) {
+    process.stderr.write(
+      `Error: cannot read trace file: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    );
+    return 1;
+  }
+
+  const split = splitTraceJsonl(text);
+
+  const groups: Group[] = [];
+  for (const [cpId, jsonl] of split.byChargePoint)
+    groups.push({ id: cpId, jsonl });
+  if (split.unattributed) {
+    groups.push({ id: UNATTRIBUTED_GROUP_LABEL, jsonl: split.unattributed });
+  }
+
+  if (groups.length === 0) {
+    process.stderr.write(
+      "Error: no analyzable records found in trace file " +
+        "(all records were excluded or unparseable)\n",
+    );
+    return 1;
+  }
+
+  // Toolkit facts (probed against the real 0.4.0 install, not inferred):
+  // no single analyze() call -- parseOpenOcppTrace -> buildSessionTimeline ->
+  // detectFailures -> summarizeSessions is the pipeline, assembled here.
+  let core: typeof import("@ocpp-debugkit/toolkit/core");
+  let reporter: typeof import("@ocpp-debugkit/toolkit/reporter");
+  try {
+    core = await import("@ocpp-debugkit/toolkit/core");
+    reporter = await import("@ocpp-debugkit/toolkit/reporter");
+  } catch {
+    process.stderr.write(
+      "Error: @ocpp-debugkit/toolkit is not installed (analyze requires it)\n",
+    );
+    return 1;
+  }
+  const {
+    parseOpenOcppTrace,
+    buildSessionTimeline,
+    detectFailures,
+    summarizeSessions,
+  } = core;
+  const { generateMarkdownReport, generateHtmlReport } = reporter;
+
+  const format = resolveReportFormat(opts.output, opts.format);
+
+  const stderrSummaryLines: string[] = [];
+  const stdoutSections: string[] = [];
+  const writtenPaths: string[] = [];
+
+  for (const group of groups) {
+    const { events, warnings } = parseOpenOcppTrace(group.jsonl);
+    const sessions = buildSessionTimeline(events);
+    const failures = detectFailures(events, sessions);
+    const summaries = summarizeSessions(sessions, failures);
+    const result: AnalysisResult = {
+      events,
+      sessions,
+      failures,
+      summaries,
+      warnings,
+      metadata: {
+        stationId: group.id,
+        source: opts.file,
+        ocppVersion: detectUniformOcppVersion(group.jsonl),
+      },
+    };
+
+    const content =
+      format === "html"
+        ? injectHtmlDisclaimer(generateHtmlReport(result))
+        : appendMarkdownDisclaimer(generateMarkdownReport(result));
+
+    stderrSummaryLines.push(
+      `${group.id}: ${events.length} events, ${failures.length} failures`,
+    );
+
+    if (opts.output) {
+      const outPath =
+        groups.length === 1
+          ? opts.output
+          : perGroupOutputPath(opts.output, group.id);
+      fs.writeFileSync(outPath, content);
+      writtenPaths.push(outPath);
+    } else {
+      // No --output: everything goes to stdout. The brief's default shape
+      // is markdown with a per-group heading; a self-contained HTML report
+      // has no sensible place for that heading, so an explicit `--format
+      // html` with no `--output` instead separates groups with an HTML
+      // comment marker (still one valid concatenated stream to redirect).
+      stdoutSections.push(
+        format === "html"
+          ? `<!-- Charge point ${group.id} -->\n${content}`
+          : `# Charge point ${group.id}\n\n${content}`,
+      );
+    }
+  }
+
+  for (const writtenPath of writtenPaths) {
+    process.stdout.write(`Wrote report: ${writtenPath}\n`);
+  }
+  if (stdoutSections.length > 0) {
+    process.stdout.write(stdoutSections.join("\n\n"));
+  }
+
+  for (const line of stderrSummaryLines) {
+    process.stderr.write(`${line}\n`);
+  }
+  const { soap, unsupportedOcppVersion, unparseableLine } = split.excluded;
+  if (soap > 0 || unsupportedOcppVersion > 0 || unparseableLine > 0) {
+    process.stderr.write(
+      `excluded: ${soap} soap record(s), ${unsupportedOcppVersion} non-1.6 record(s), ${unparseableLine} unparseable line(s)\n`,
+    );
+  }
+  process.stderr.write(`${ANALYZE_DISCLAIMER}\n`);
+
+  return 0;
+}

--- a/src/cli/analyze/runAnalyze.ts
+++ b/src/cli/analyze/runAnalyze.ts
@@ -66,6 +66,55 @@ export function perGroupOutputPath(
   return dir === "." ? fileName : path.join(dir, fileName);
 }
 
+/** Inserts a numeric suffix before `path`'s extension: `out.CP_A.html` ->
+ *  `out.CP_A.2.html`. Used to disambiguate a sanitized-filename collision
+ *  between two distinct chargePointIds (e.g. "CP/A" and "CP_A" both
+ *  sanitize to "CP_A"). */
+function withNumericSuffix(outPath: string, n: number): string {
+  const dir = path.dirname(outPath);
+  const ext = path.extname(outPath);
+  const base = path.basename(outPath, ext);
+  const fileName = `${base}.${n}${ext}`;
+  return dir === "." ? fileName : path.join(dir, fileName);
+}
+
+/** Computes each group's per-CP output path, in group iteration order,
+ *  disambiguating any sanitized-filename collision deterministically: the
+ *  first occupant of a filename keeps the plain path, later occupants get
+ *  `.2`, `.3`, ... suffixes inserted before the extension. Returns the
+ *  resolved path for each group plus a stderr note for any group that had
+ *  to be disambiguated (see Fix 1, issue #188 review). */
+function resolveGroupOutputPaths(
+  outputPath: string,
+  groups: Group[],
+): { path: string; note?: string }[] {
+  const used = new Set<string>();
+  const resolved: { path: string; note?: string }[] = [];
+  for (const group of groups) {
+    const candidate = perGroupOutputPath(outputPath, group.id);
+    if (!used.has(candidate)) {
+      used.add(candidate);
+      resolved.push({ path: candidate });
+      continue;
+    }
+    let n = 2;
+    let disambiguated = withNumericSuffix(candidate, n);
+    while (used.has(disambiguated)) {
+      n++;
+      disambiguated = withNumericSuffix(candidate, n);
+    }
+    used.add(disambiguated);
+    resolved.push({
+      path: disambiguated,
+      note:
+        `Note: charge point "${group.id}" sanitizes to the same report ` +
+        `filename as another charge point; writing its report to ` +
+        `${disambiguated} instead of ${candidate}`,
+    });
+  }
+  return resolved;
+}
+
 export function appendMarkdownDisclaimer(markdown: string): string {
   const separator = markdown.endsWith("\n") ? "\n" : "\n\n";
   return `${markdown}${separator}${ANALYZE_DISCLAIMER}\n`;
@@ -164,11 +213,24 @@ export async function runAnalyze(opts: AnalyzeOptions): Promise<number> {
 
   const format = resolveReportFormat(opts.output, opts.format);
 
+  // Per-group output paths are computed up front, in group iteration order,
+  // so a sanitized-filename collision between two distinct chargePointIds
+  // (Fix 1, issue #188 review) is resolved deterministically before any
+  // file is written, rather than the second write silently clobbering the
+  // first.
+  const outputPaths: { path: string; note?: string }[] | undefined = opts.output
+    ? groups.length === 1
+      ? [{ path: opts.output }]
+      : resolveGroupOutputPaths(opts.output, groups)
+    : undefined;
+
   const stderrSummaryLines: string[] = [];
   const stdoutSections: string[] = [];
   const writtenPaths: string[] = [];
+  let hadWriteError = false;
 
-  for (const group of groups) {
+  for (let i = 0; i < groups.length; i++) {
+    const group = groups[i];
     const { events, warnings } = parseOpenOcppTrace(group.jsonl);
     const sessions = buildSessionTimeline(events);
     const failures = detectFailures(events, sessions);
@@ -195,13 +257,24 @@ export async function runAnalyze(opts: AnalyzeOptions): Promise<number> {
       `${group.id}: ${events.length} events, ${failures.length} failures`,
     );
 
-    if (opts.output) {
-      const outPath =
-        groups.length === 1
-          ? opts.output
-          : perGroupOutputPath(opts.output, group.id);
-      fs.writeFileSync(outPath, content);
-      writtenPaths.push(outPath);
+    if (outputPaths) {
+      const { path: outPath, note } = outputPaths[i];
+      if (note) process.stderr.write(`${note}\n`);
+      // A write failure (Fix 2, issue #188 review) must not abort the run:
+      // other groups still get their reports, and the per-group summaries,
+      // exclusion counts, and disclaimer below are still printed. The run
+      // is still flagged as an operational error via the exit code.
+      try {
+        fs.writeFileSync(outPath, content);
+        writtenPaths.push(outPath);
+      } catch (err) {
+        hadWriteError = true;
+        process.stderr.write(
+          `Error: cannot write report file: ${outPath}: ${
+            err instanceof Error ? err.message : String(err)
+          }\n`,
+        );
+      }
     } else {
       // No --output: everything goes to stdout. The brief's default shape
       // is markdown with a per-group heading; a self-contained HTML report
@@ -234,5 +307,5 @@ export async function runAnalyze(opts: AnalyzeOptions): Promise<number> {
   }
   process.stderr.write(`${ANALYZE_DISCLAIMER}\n`);
 
-  return 0;
+  return hadWriteError ? 1 : 0;
 }

--- a/src/cli/analyze/runAnalyze.ts
+++ b/src/cli/analyze/runAnalyze.ts
@@ -227,48 +227,66 @@ export async function runAnalyze(opts: AnalyzeOptions): Promise<number> {
   const stderrSummaryLines: string[] = [];
   const stdoutSections: string[] = [];
   const writtenPaths: string[] = [];
-  let hadWriteError = false;
+  let hadError = false;
 
   for (let i = 0; i < groups.length; i++) {
     const group = groups[i];
-    const { events, warnings } = parseOpenOcppTrace(group.jsonl);
-    const sessions = buildSessionTimeline(events);
-    const failures = detectFailures(events, sessions);
-    const summaries = summarizeSessions(sessions, failures);
-    const result: AnalysisResult = {
-      events,
-      sessions,
-      failures,
-      summaries,
-      warnings,
-      metadata: {
-        stationId: group.id,
-        source: opts.file,
-        ocppVersion: detectUniformOcppVersion(group.jsonl),
-      },
-    };
 
-    const content =
-      format === "html"
-        ? injectHtmlDisclaimer(generateHtmlReport(result))
-        : appendMarkdownDisclaimer(generateMarkdownReport(result));
+    // The toolkit pipeline (parseOpenOcppTrace -> buildSessionTimeline ->
+    // detectFailures -> summarizeSessions -> report generation) is not
+    // guaranteed to succeed for every charge point's data -- one CP's
+    // malformed session must not abort the whole run any more than a write
+    // failure does: other groups still get analyzed and reported, and the
+    // per-group summaries, exclusion counts, and disclaimer below are still
+    // printed. The run is still flagged as an operational error via the
+    // shared exit-code flag.
+    let content: string;
+    try {
+      const { events, warnings } = parseOpenOcppTrace(group.jsonl);
+      const sessions = buildSessionTimeline(events);
+      const failures = detectFailures(events, sessions);
+      const summaries = summarizeSessions(sessions, failures);
+      const result: AnalysisResult = {
+        events,
+        sessions,
+        failures,
+        summaries,
+        warnings,
+        metadata: {
+          stationId: group.id,
+          source: opts.file,
+          ocppVersion: detectUniformOcppVersion(group.jsonl),
+        },
+      };
 
-    stderrSummaryLines.push(
-      `${group.id}: ${events.length} events, ${failures.length} failures`,
-    );
+      content =
+        format === "html"
+          ? injectHtmlDisclaimer(generateHtmlReport(result))
+          : appendMarkdownDisclaimer(generateMarkdownReport(result));
+
+      stderrSummaryLines.push(
+        `${group.id}: ${events.length} events, ${failures.length} failures`,
+      );
+    } catch (err) {
+      hadError = true;
+      process.stderr.write(
+        `Error: cannot analyze charge point ${group.id}: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+      continue;
+    }
 
     if (outputPaths) {
       const { path: outPath, note } = outputPaths[i];
       if (note) process.stderr.write(`${note}\n`);
-      // A write failure (Fix 2, issue #188 review) must not abort the run:
-      // other groups still get their reports, and the per-group summaries,
-      // exclusion counts, and disclaimer below are still printed. The run
-      // is still flagged as an operational error via the exit code.
+      // A write failure (Fix 2, issue #188 review) must not abort the run,
+      // for the same reason as the analysis failure above.
       try {
         fs.writeFileSync(outPath, content);
         writtenPaths.push(outPath);
       } catch (err) {
-        hadWriteError = true;
+        hadError = true;
         process.stderr.write(
           `Error: cannot write report file: ${outPath}: ${
             err instanceof Error ? err.message : String(err)
@@ -307,5 +325,5 @@ export async function runAnalyze(opts: AnalyzeOptions): Promise<number> {
   }
   process.stderr.write(`${ANALYZE_DISCLAIMER}\n`);
 
-  return hadWriteError ? 1 : 0;
+  return hadError ? 1 : 0;
 }

--- a/src/cli/analyze/splitTrace.ts
+++ b/src/cli/analyze/splitTrace.ts
@@ -1,0 +1,109 @@
+/**
+ * Pre-processing layer for `analyze` (issue #188 Track 3): splits a v1.1
+ * trace JSONL file into one JSONL blob per charge point.
+ *
+ * Exists to compensate for a real limitation of the OCPP DebugKit toolkit
+ * (probed against the real 0.4.0 install, not inferred): its analysis
+ * pipeline has no concept of `chargePointId` at all — every record in a
+ * trace is folded into one implicit station, so two charge points that
+ * happen to reuse the same OCPP messageId (routine, since messageIds are
+ * only unique per connection) get their CALLs/CALLRESULTs correlated
+ * against each other. A CSMS that answers CP-A's `Authorize` but ignores
+ * CP-B's same-id `Authorize` reads, to the toolkit, as one fully-answered
+ * exchange — CP-B's real failure disappears. Splitting by chargePointId
+ * BEFORE handing anything to the toolkit is the only fix; it cannot be
+ * patched after the fact once messageIds have collided.
+ *
+ * It also only understands OCPP 1.6J: SOAP transport and non-1.6 versions
+ * (2.0.1, 2.1) are accepted silently and analyzed as if they were 1.6J
+ * frames, producing meaningless results. We filter those out ourselves and
+ * surface the counts so the operator knows what was skipped.
+ *
+ * Deliberately has no dependency on the toolkit (or anything else) so it is
+ * cheap to unit test in isolation and cannot be affected by how the toolkit
+ * is imported/loaded elsewhere in the analyze code path.
+ */
+
+export interface TraceSplit {
+  /** chargePointId -> that CP's records re-serialized as JSONL text. */
+  byChargePoint: Map<string, string>;
+  /** Records with no chargePointId, as JSONL text ("" if none). */
+  unattributed: string;
+  excluded: {
+    soap: number;
+    unsupportedOcppVersion: number;
+    unparseableLine: number;
+  };
+  /** Count of non-blank lines examined (kept + excluded); blank lines are
+   *  not records and are silently ignored, matching JSONL convention for a
+   *  trailing newline at end of file. */
+  total: number;
+}
+
+export function splitTraceJsonl(jsonlText: string): TraceSplit {
+  const byChargePointLines = new Map<string, string[]>();
+  const unattributedLines: string[] = [];
+  const excluded = { soap: 0, unsupportedOcppVersion: 0, unparseableLine: 0 };
+  let total = 0;
+
+  for (const line of jsonlText.split("\n")) {
+    if (line.trim() === "") continue;
+    total++;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      excluded.unparseableLine++;
+      continue;
+    }
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      excluded.unparseableLine++;
+      continue;
+    }
+    const record = parsed as Record<string, unknown>;
+
+    if (record.transport === "soap") {
+      excluded.soap++;
+      continue;
+    }
+    if (
+      typeof record.ocppVersion === "string" &&
+      !record.ocppVersion.startsWith("1.6")
+    ) {
+      excluded.unsupportedOcppVersion++;
+      continue;
+    }
+
+    const cpId =
+      typeof record.chargePointId === "string" && record.chargePointId
+        ? record.chargePointId
+        : undefined;
+    if (cpId === undefined) {
+      unattributedLines.push(line);
+      continue;
+    }
+    const bucket = byChargePointLines.get(cpId);
+    if (bucket) {
+      bucket.push(line);
+    } else {
+      byChargePointLines.set(cpId, [line]);
+    }
+  }
+
+  const byChargePoint = new Map<string, string>();
+  for (const [cpId, lines] of byChargePointLines) {
+    byChargePoint.set(cpId, lines.map((l) => l + "\n").join(""));
+  }
+
+  return {
+    byChargePoint,
+    unattributed: unattributedLines.map((l) => l + "\n").join(""),
+    excluded,
+    total,
+  };
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -781,7 +781,9 @@ Options:
   --trace-output <path>    Append every OCPP wire message as a JSONL trace
                            record (docs/trace-format.md) — works in REPL,
                            JSON, and daemon modes.
-  analyze <trace.jsonl> [--output <file>] [--format html|markdown]  Analyze a trace with OCPP DebugKit and write a report
+  analyze <trace.jsonl> [--output <file>] [--format html|markdown]
+                           Analyze a trace with OCPP DebugKit and write a
+                           report.
   --health-path <path>     Absolute path the health-check JSON is served on
                            (default: /v1/healthz). Change this when running
                            behind a proxy that reserves the default path

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -12,6 +12,8 @@ import type { Database } from "../cp/domain/persistence/Database";
 import { SqliteScenarioRepository } from "../cp/domain/persistence/SqliteScenarioRepository";
 import { setGlobalLogFormat } from "../cp/shared/Logger";
 import { TraceWriter, setGlobalTraceWriter } from "./trace/TraceWriter";
+import { parseAnalyzeArgs } from "./analyze/parseAnalyzeArgs";
+import { runAnalyze } from "./analyze/runAnalyze";
 import {
   startServer,
   DEFAULT_HTTP_PORT,
@@ -779,6 +781,7 @@ Options:
   --trace-output <path>    Append every OCPP wire message as a JSONL trace
                            record (docs/trace-format.md) — works in REPL,
                            JSON, and daemon modes.
+  analyze <trace.jsonl> [--output <file>] [--format html|markdown]  Analyze a trace with OCPP DebugKit and write a report
   --health-path <path>     Absolute path the health-check JSON is served on
                            (default: /v1/healthz). Change this when running
                            behind a proxy that reserves the default path
@@ -916,6 +919,21 @@ function createStandaloneChargePointRuntime(
 }
 
 async function main(): Promise<void> {
+  // `analyze` is a subcommand, not a flag combination: it never bootstraps a
+  // charge point, so it is dispatched before parseArgs() (which requires
+  // --cp-id/--ws-url or a server mode) even sees argv. Its own small parser
+  // lives in ./analyze/parseAnalyzeArgs so the flag edge cases are unit
+  // testable without spawning a subprocess per case.
+  if (process.argv[2] === "analyze") {
+    const parsed = parseAnalyzeArgs(process.argv.slice(3));
+    if (!parsed.ok) {
+      process.stderr.write(`${parsed.message}\n`);
+      process.exit(1);
+    }
+    const code = await runAnalyze(parsed.args);
+    process.exit(code);
+  }
+
   const options = parseArgs(process.argv);
   // Apply log format BEFORE constructing any service / charge point so
   // every line that follows respects it — including "[server] xxx" setup


### PR DESCRIPTION
Third producer/consumer step for [#188](https://github.com/shiv3/ocpp-cp-simulator/issues/188): an `analyze` subcommand that runs [OCPP DebugKit](https://github.com/ocpp-debugkit/toolkit)'s failure detection over a v1.1 trace file and emits a report.

```bash
ocpp-cp-sim --cp-id CP001 --ws-url ws://... --trace-output trace.jsonl   # produce
ocpp-cp-sim analyze trace.jsonl --output report.html                     # analyze
```

## What this adds

- **`analyze <trace.jsonl> [--output <file>] [--format html|markdown]`** — parse → session timeline → failure detection (16 rules: FAILED_AUTHORIZATION, CONNECTOR_FAULT, UNRESPONSIVE_CSMS, …) → report. Markdown to stdout by default; `--output` writes a file with the format inferred from its extension; the HTML report is fully self-contained (no external references).
- **Pre-processing layer the toolkit needs** (`src/cli/analyze/splitTrace.ts`): the toolkit's model is single-station OCPP 1.6J — it ignores `chargePointId` entirely (cross-CP messageId collisions mis-correlate responses) and silently accepts SOAP/2.x records as if they were 1.6J. So the wrapper splits records by `chargePointId` first (one report per charge point, colliding sanitized filenames disambiguated with numeric suffixes), excludes `transport: "soap"` and non-1.6 records with counts on stderr, and skips unparseable lines with a count. A multi-CP fixture with a deliberate cross-CP messageId collision pins the split guarantee.
- **Dependency**: `@ocpp-debugkit/toolkit` pinned **exact `0.4.0`** (coordinated updates rather than chasing minors, as agreed on #188). Loaded only via dynamic import inside the analyze path — the simulator core stays structurally independent; adds only `commander@13` + `zod@4.4.3` (identical to our existing zod, deduped), no install scripts, Apache-2.0.
- **Disclaimer** (issue #188 PoC item 8) on stderr for every run and embedded in every report: failure-pattern detection is not OCPP compliance certification.
- Detected failures do not change the exit code (informational; a CI strict mode is a documented follow-up). Operational errors — unreadable file, empty trace, report-write failures — exit 1, and a mid-run write failure still prints the remaining per-CP summaries and disclaimer.
- Docs: `docs/cli.md` section covering usage, multi-CP behavior, exclusions, the dependency-pin policy, and that the report timeline is transaction-focused (toolkit behavior).

## Verification

- `vitest` — 1377/1377 green (new: splitTrace units, arg parsing, format resolution, and integration tests against the real toolkit: clean session → 0 findings, invalid-idTag trace → FAILED_AUTHORIZATION, cross-CP collision → correctly attributed per-CP reports, exclusion counts, filename-collision disambiguation, EISDIR write-failure isolation).
- `bun test bun.test` — 224/224 green (spawn e2e: HTML report written, disclaimer present, usage/exit-code checks).
- `tsc -b --noEmit` — baseline unchanged (0 new); eslint clean; `bun.lock` delta is registry.npmjs.org-only; `package-lock.json` untouched (bun.lock is the source of truth).
- Live smoke: real `--trace-output` capture analyzed end-to-end; self-contained HTML confirmed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `analyze` CLI subcommand for offline failure-pattern detection from OCPP DebugKit v1.1 trace JSONL, producing per-charge-point reports (plus an unattributed bucket) with safe, collision-resistant filenames.
  * Supports Markdown to stdout or self-contained HTML output to a file (including `--format` precedence), with a mandatory disclaimer injected into reports and diagnostics.
  * Skips unsupported/unparseable records while counting exclusions and returns a non-zero exit code on failures.
* **Documentation**
  * Documented `analyze` behavior and output/format options, including multi–charge-point handling.
* **Tests**
  * Added end-to-end and unit/integration tests for argument parsing, trace splitting, formatting, and failure/exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->