### PR TITLE
feat(console): Session Analysis tab — in-browser DebugKit analysis (#188)

### DIFF
--- a/src/cli/analyze/runAnalyze.ts
+++ b/src/cli/analyze/runAnalyze.ts
@@ -20,20 +20,18 @@ import * as path from "path";
 import { splitTraceJsonl } from "./splitTrace";
 import type { AnalysisResult } from "@ocpp-debugkit/toolkit/reporter";
 
+// Shared with the web console's Session Analysis tab (issue #188 PoC item
+// 8) -- moved to a browser-safe module (no node imports) so both surfaces
+// use the same verbatim text; re-exported here so existing imports of
+// `ANALYZE_DISCLAIMER` from this module keep working unchanged.
+import { ANALYZE_DISCLAIMER } from "../../trace/analysisDisclaimer";
+export { ANALYZE_DISCLAIMER };
+
 export interface AnalyzeOptions {
   file: string;
   output?: string;
   format?: "html" | "markdown";
 }
-
-/**
- * Issue #188 PoC item 8: the detector only recognizes a fixed catalog of
- * known failure shapes -- it is not a conformance checker. Printed
- * unconditionally (stderr, every markdown report, every HTML report) so a
- * clean run can never be read as "this station is OCPP compliant".
- */
-export const ANALYZE_DISCLAIMER =
-  'Failure-pattern detection is not OCPP compliance certification: "no known failure detected" does not mean "OCPP compliant".';
 
 /** Label for the bucket of records with no `chargePointId` at all. */
 const UNATTRIBUTED_GROUP_LABEL = "(no chargePointId)";

--- a/src/console/pages/CpDetailPage.tsx
+++ b/src/console/pages/CpDetailPage.tsx
@@ -37,8 +37,9 @@ import { useCpConfigActions } from "./dashboard/useCpConfigActions";
 const StateTransitionViewer = lazy(
   () => import("@/components/state-transition/StateTransitionViewer"),
 );
+const SessionAnalysisPanel = lazy(() => import("./cp/SessionAnalysisPanel"));
 
-type TabValue = "transactions" | "logs" | "config" | "diagnostics";
+type TabValue = "transactions" | "logs" | "config" | "diagnostics" | "analysis";
 
 /**
  * Builds the `ChargePointConfig` shape `ChargePointConfigModal` expects,
@@ -319,6 +320,20 @@ const CpDetailPage: React.FC = () => {
         </TabsContent>
         <TabsContent value="logs">
           <LogViewer logs={view.logs} onClear={view.clearLogs} />
+        </TabsContent>
+        <TabsContent value="analysis">
+          <Suspense
+            fallback={
+              <div className="p-6 text-sm text-gray-500 dark:text-gray-400">
+                Loading session analysis…
+              </div>
+            }
+          >
+            <SessionAnalysisPanel
+              cpId={cpId}
+              ocppVersion={resolvedOcppVersion}
+            />
+          </Suspense>
         </TabsContent>
         <TabsContent value="config">
           <ConfigTab

--- a/src/console/pages/cp/CpTabs.tsx
+++ b/src/console/pages/cp/CpTabs.tsx
@@ -5,6 +5,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 const TAB_ITEMS: ReadonlyArray<{ value: string; label: string }> = [
   { value: "transactions", label: "Transactions" },
   { value: "logs", label: "Message Log" },
+  { value: "analysis", label: "Session Analysis" },
   { value: "config", label: "Configuration" },
   { value: "diagnostics", label: "Diagnostics" },
 ];

--- a/src/console/pages/cp/SessionAnalysisPanel.dom.test.tsx
+++ b/src/console/pages/cp/SessionAnalysisPanel.dom.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { act } from "react";
+import { cleanup as rtlCleanup, render } from "@testing-library/react";
 import type { Root } from "react-dom/client";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -8,6 +9,7 @@ import {
   renderConsole,
   type FakeChargePointService,
 } from "../../test/harness";
+import { DataContext } from "../../../data/providers/DataProvider";
 import { OCPPStatus } from "../../../cp/domain/types/OcppTypes";
 import type {
   ChargePointService,
@@ -15,6 +17,7 @@ import type {
   StoredLogEntry,
 } from "../../../data/interfaces/ChargePointService";
 import { ANALYZE_DISCLAIMER } from "../../../trace/analysisDisclaimer";
+import SessionAnalysisPanel from "./SessionAnalysisPanel";
 
 /** `CpDetailPage` always renders `TransactionsTab` (the default active tab),
  *  whose `useStateHistory` crashes on the harness's auto-stubbed
@@ -104,18 +107,11 @@ function findButton(
   ) as HTMLButtonElement | undefined;
 }
 
-/** Clicks "Analyze" and waits for the click handler's own dynamic
- *  `import("@ocpp-debugkit/toolkit/core")` to settle (button label reverts
- *  from "Analyzing..." once the analyzing/empty/results/error state
- *  transition lands). Same cold-import caveat as `openAnalysisTab`: real
- *  `setTimeout` polling, not a microtask-only flush. */
-async function clickAnalyzeAndWait(container: HTMLElement): Promise<void> {
-  const button = findButton(container, "Analyze");
-  expect(button, "expected an Analyze button").toBeTruthy();
-  await act(async () => {
-    button!.click();
-    await Promise.resolve();
-  });
+/** Waits for the "Analyzing…" button label to revert (to "Analyze") once
+ *  whatever async work is in flight settles into empty/results/error. Same
+ *  cold-import caveat as `openAnalysisTab`: real `setTimeout` polling, not a
+ *  microtask-only flush. */
+async function waitForAnalyzeSettle(container: HTMLElement): Promise<void> {
   for (let i = 0; i < 200; i++) {
     if (!findButton(container, "Analyzing…")) return;
     await act(async () => {
@@ -123,6 +119,60 @@ async function clickAnalyzeAndWait(container: HTMLElement): Promise<void> {
     });
   }
   throw new Error("timed out waiting for Analyze to settle");
+}
+
+/** Clicks "Analyze" and waits for the click handler's own dynamic
+ *  `import("@ocpp-debugkit/toolkit/core")` to settle (button label reverts
+ *  from "Analyzing..." once the analyzing/empty/results/error state
+ *  transition lands). */
+async function clickAnalyzeAndWait(container: HTMLElement): Promise<void> {
+  const button = findButton(container, "Analyze");
+  expect(button, "expected an Analyze button").toBeTruthy();
+  await act(async () => {
+    button!.click();
+    await Promise.resolve();
+  });
+  await waitForAnalyzeSettle(container);
+}
+
+/** A promise plus its externally-callable `resolve`, for tests that need to
+ *  hold an in-flight `listStoredLogs()` call open deterministically (rather
+ *  than racing against real timers) while they assert on the transient
+ *  "analyzing" state or exercise a stale-prop scenario. */
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+/** Renders `SessionAnalysisPanel` directly (not through the full console /
+ *  lazy tab machinery) wrapped in just the `DataContext` it needs. Used by
+ *  tests that need to change the `cpId` prop via `rerender` -- navigating
+ *  `renderConsole` to a different CP route wouldn't remount or re-prop this
+ *  lazy-loaded panel any differently than a plain prop change would, and
+ *  this way avoids the lazy-chunk-load and tab-click choreography entirely. */
+function renderPanel(
+  props: { cpId: string; ocppVersion?: string },
+  service: FakeChargePointService,
+) {
+  return render(
+    <DataContext.Provider
+      value={{
+        mode: "remote",
+        serverUrl: "http://test",
+        defaultEvSettings: null,
+        setDefaultEvSettings: () => {},
+        chargePointService: service,
+      }}
+    >
+      <SessionAnalysisPanel {...props} />
+    </DataContext.Provider>,
+  );
 }
 
 /** A wire-frame `Sent:`/`Received:` log row -- the shape `listStoredLogs`
@@ -214,8 +264,9 @@ describe("SessionAnalysisPanel", () => {
     expect(analyzeButton!.disabled).toBe(false);
   });
 
-  it("analyzes a clean session: timeline events render, FailureSummary says no failures, disclaimer stays visible", async () => {
-    const listStoredLogs = vi.fn(async () => CLEAN_SESSION_ROWS);
+  it("analyzes a clean session: shows the transient analyzing state, then timeline events render, FailureSummary says no failures, disclaimer stays visible", async () => {
+    const logs = deferred<StoredLogEntry[]>();
+    const listStoredLogs = vi.fn(() => logs.promise);
     const service = makeService({
       snapshots: [snapshot("CP-1")],
       listStoredLogs,
@@ -225,7 +276,26 @@ describe("SessionAnalysisPanel", () => {
     await flush();
     await openAnalysisTab(container);
 
-    await clickAnalyzeAndWait(container);
+    const analyzeButton = findButton(container, "Analyze");
+    expect(analyzeButton, "expected an Analyze button").toBeTruthy();
+    await act(async () => {
+      analyzeButton!.click();
+      await Promise.resolve();
+    });
+
+    // Transient state: immediately after clicking, before `listStoredLogs`
+    // (held open by the deferred promise) resolves.
+    const analyzingButton = findButton(container, "Analyzing…");
+    expect(
+      analyzingButton,
+      'expected the button to read "Analyzing…" while in flight',
+    ).toBeTruthy();
+    expect(analyzingButton!.disabled).toBe(true);
+
+    await act(async () => {
+      logs.resolve(CLEAN_SESSION_ROWS);
+    });
+    await waitForAnalyzeSettle(container);
 
     expect(listStoredLogs).toHaveBeenCalledWith("CP-1");
     expect(container.textContent).toContain("BootNotification");
@@ -293,6 +363,7 @@ describe("SessionAnalysisPanel", () => {
     expect(container.textContent).toContain(
       "Session analysis is not available in this runtime",
     );
+    expect(container.textContent).toContain(ANALYZE_DISCLAIMER);
     expect(findButton(container, "Analyze")).toBeUndefined();
   });
 
@@ -326,5 +397,79 @@ describe("SessionAnalysisPanel", () => {
     expect(container.textContent).toContain(
       "No logged traffic to analyze yet.",
     );
+  });
+
+  it("guards against a stale cpId: an analyze started for the old CP does not render its results once the panel has moved on to a new CP", async () => {
+    // `handleAnalyze` closes over `cpId`; nothing remounts the panel on a
+    // `cpId` prop change alone (CpDetailPage keeps one lazy-loaded panel
+    // instance across route param changes), so this renders the panel
+    // directly (not through the full console) to change `cpId` via
+    // `rerender` without unmounting -- exactly the scenario a stale async
+    // result would otherwise leak into.
+    const logsA = deferred<StoredLogEntry[]>();
+    const listStoredLogsA = vi.fn(() => logsA.promise);
+    const serviceA = makeService({
+      snapshots: [snapshot("CP-A")],
+      listStoredLogs: listStoredLogsA,
+    });
+
+    const { container, rerender } = renderPanel({ cpId: "CP-A" }, serviceA);
+    cleanup = async () => rtlCleanup();
+
+    const findAnalyze = () =>
+      Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Analyze",
+      ) as HTMLButtonElement | undefined;
+
+    expect(findAnalyze(), "expected an Analyze button for CP-A").toBeTruthy();
+    await act(async () => {
+      findAnalyze()!.click();
+      await Promise.resolve();
+    });
+    expect(listStoredLogsA).toHaveBeenCalledWith("CP-A");
+
+    // CP-A's analyze is still in flight (listStoredLogsA's promise hasn't
+    // resolved yet) when the panel is handed a different cpId -- e.g. the
+    // user navigated to another charge point's detail page.
+    const serviceB = makeService({ snapshots: [snapshot("CP-B")] });
+    await act(async () => {
+      rerender(
+        <DataContext.Provider
+          value={{
+            mode: "remote",
+            serverUrl: "http://test",
+            defaultEvSettings: null,
+            setDefaultEvSettings: () => {},
+            chargePointService: serviceB,
+          }}
+        >
+          <SessionAnalysisPanel cpId="CP-B" />
+        </DataContext.Provider>,
+      );
+    });
+
+    // The panel resets to idle for CP-B as soon as the prop changes --
+    // it doesn't wait for CP-A's in-flight analyze to settle first.
+    expect(
+      findAnalyze(),
+      "expected the panel to already be idle (Analyze button) for CP-B",
+    ).toBeTruthy();
+    expect(findAnalyze()!.disabled).toBe(false);
+
+    // Now release CP-A's stale analyze. Its results must not leak onto
+    // CP-B's now-rendered page.
+    await act(async () => {
+      logsA.resolve(CLEAN_SESSION_ROWS);
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(container.textContent).not.toContain("BootNotification");
+    expect(container.textContent).not.toContain("No failures detected");
+    expect(
+      findAnalyze(),
+      "expected the panel to remain idle for CP-B",
+    ).toBeTruthy();
+    expect(findAnalyze()!.disabled).toBe(false);
   });
 });

--- a/src/console/pages/cp/SessionAnalysisPanel.dom.test.tsx
+++ b/src/console/pages/cp/SessionAnalysisPanel.dom.test.tsx
@@ -303,6 +303,31 @@ describe("SessionAnalysisPanel", () => {
     expect(container.textContent).toContain(ANALYZE_DISCLAIMER);
   });
 
+  it("calls listStoredLogs as a method of the service (real implementations read `this`)", async () => {
+    // Every real ChargePointService implementation reads `this` inside
+    // listStoredLogs; a detached call would pass with the arrow-fn fakes
+    // above, so this fake explicitly rejects an unbound invocation.
+    const service = makeService({
+      snapshots: [snapshot("CP-1")],
+      listStoredLogs: function (this: unknown) {
+        if (this == null) {
+          throw new Error("listStoredLogs called without its service binding");
+        }
+        return Promise.resolve(CLEAN_SESSION_ROWS);
+      } as never,
+    });
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+    await openAnalysisTab(container);
+    await clickAnalyzeAndWait(container);
+
+    expect(container.textContent).toContain("No failures detected");
+    expect(container.textContent).not.toContain(
+      "listStoredLogs called without its service binding",
+    );
+  });
+
   it("analyzes a failed-auth trace: FAILED_AUTHORIZATION is visible", async () => {
     const service = makeService({
       snapshots: [snapshot("CP-1")],

--- a/src/console/pages/cp/SessionAnalysisPanel.dom.test.tsx
+++ b/src/console/pages/cp/SessionAnalysisPanel.dom.test.tsx
@@ -1,0 +1,330 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  createFakeChargePointService,
+  renderConsole,
+  type FakeChargePointService,
+} from "../../test/harness";
+import { OCPPStatus } from "../../../cp/domain/types/OcppTypes";
+import type {
+  ChargePointService,
+  ChargePointSnapshot,
+  StoredLogEntry,
+} from "../../../data/interfaces/ChargePointService";
+import { ANALYZE_DISCLAIMER } from "../../../trace/analysisDisclaimer";
+
+/** `CpDetailPage` always renders `TransactionsTab` (the default active tab),
+ *  whose `useStateHistory` crashes on the harness's auto-stubbed
+ *  `getStateHistory` (resolves `undefined`, not `[]`) -- unrelated to this
+ *  panel, so every test here supplies a real empty-array stub. */
+function makeService(
+  overrides: Partial<ChargePointService> & {
+    snapshots?: ChargePointSnapshot[];
+  },
+): FakeChargePointService {
+  return createFakeChargePointService({
+    getStateHistory: vi.fn(async () => []),
+    ...overrides,
+  });
+}
+
+async function unmount(root: Root): Promise<void> {
+  await act(async () => {
+    root.unmount();
+  });
+  document.body.innerHTML = "";
+}
+
+/** Flushes pending microtasks across a couple of ticks -- the lazy panel
+ *  chunk's dynamic import, `listStoredLogs()`, and the toolkit's own
+ *  dynamic `/core` import each add at least one hop. */
+async function flush(times = 6): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+function snapshot(id: string): ChargePointSnapshot {
+  return { id, status: OCPPStatus.Available, error: "", connectors: [] };
+}
+
+function tabTrigger(
+  container: HTMLElement,
+  label: string,
+): HTMLElement | undefined {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>('[role="tab"]'),
+  ).find((el) => el.textContent?.trim() === label);
+}
+
+async function openAnalysisTab(container: HTMLElement): Promise<void> {
+  const trigger = tabTrigger(container, "Session Analysis");
+  expect(trigger, "expected a Session Analysis tab").toBeTruthy();
+  // Radix's TabsTrigger switches on `onMouseDown`, not `onClick` -- plain
+  // `.click()` only dispatches a "click" event, so it never activates it
+  // (mirrors the dropdown-trigger workaround in CpDetailPage.dom.test.tsx).
+  await act(async () => {
+    trigger!.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      }),
+    );
+    await Promise.resolve();
+  });
+  // The panel is a lazy chunk (`import("./cp/SessionAnalysisPanel")`) that
+  // itself statically pulls in the real `@ocpp-debugkit/toolkit/react`
+  // package. The FIRST such import in a run does real (macrotask-bound)
+  // module transform I/O, not just microtask hops, so a microtask-only
+  // flush loop can spin forever without ever observing it resolve; poll
+  // with a real `setTimeout` between checks instead of guessing a tick
+  // count. Later tests in this file hit the same import already cached
+  // and resolve on the first check.
+  for (let i = 0; i < 100; i++) {
+    if (!container.textContent?.includes("Loading session analysis")) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+  throw new Error("timed out waiting for SessionAnalysisPanel to load");
+}
+
+function findButton(
+  container: HTMLElement,
+  label: string,
+): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  ) as HTMLButtonElement | undefined;
+}
+
+/** Clicks "Analyze" and waits for the click handler's own dynamic
+ *  `import("@ocpp-debugkit/toolkit/core")` to settle (button label reverts
+ *  from "Analyzing..." once the analyzing/empty/results/error state
+ *  transition lands). Same cold-import caveat as `openAnalysisTab`: real
+ *  `setTimeout` polling, not a microtask-only flush. */
+async function clickAnalyzeAndWait(container: HTMLElement): Promise<void> {
+  const button = findButton(container, "Analyze");
+  expect(button, "expected an Analyze button").toBeTruthy();
+  await act(async () => {
+    button!.click();
+    await Promise.resolve();
+  });
+  for (let i = 0; i < 200; i++) {
+    if (!findButton(container, "Analyzing…")) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+  throw new Error("timed out waiting for Analyze to settle");
+}
+
+/** A wire-frame `Sent:`/`Received:` log row -- the shape `listStoredLogs`
+ *  returns and `logLinesToTrace` (src/trace/logEntryToTrace.ts) parses. */
+function logRow(timestamp: string, message: string): StoredLogEntry {
+  return { timestamp, level: "INFO", type: "WebSocket", cpId: "CP-1", message };
+}
+
+const CLEAN_SESSION_ROWS = [
+  logRow(
+    "2026-01-01T00:00:00.000Z",
+    'Sent: [2,"1","BootNotification",{"chargePointVendor":"V","chargePointModel":"M"}]',
+  ),
+  logRow(
+    "2026-01-01T00:00:01.000Z",
+    'Received: [3,"1",{"status":"Accepted","currentTime":"2026-01-01T00:00:01.000Z","interval":300}]',
+  ),
+  logRow("2026-01-01T00:00:02.000Z", 'Sent: [2,"2","Heartbeat",{}]'),
+  logRow(
+    "2026-01-01T00:00:03.000Z",
+    'Received: [3,"2",{"currentTime":"2026-01-01T00:00:03.000Z"}]',
+  ),
+];
+
+const FAILED_AUTH_ROWS = [
+  logRow(
+    "2026-01-01T00:00:00.000Z",
+    'Sent: [2,"1","BootNotification",{"chargePointVendor":"V","chargePointModel":"M"}]',
+  ),
+  logRow(
+    "2026-01-01T00:00:01.000Z",
+    'Received: [3,"1",{"status":"Accepted","currentTime":"2026-01-01T00:00:01.000Z","interval":300}]',
+  ),
+  logRow(
+    "2026-01-01T00:00:02.000Z",
+    'Sent: [2,"2","Authorize",{"idTag":"TAG1"}]',
+  ),
+  logRow(
+    "2026-01-01T00:00:03.000Z",
+    'Received: [3,"2",{"idTagInfo":{"status":"Invalid"}}]',
+  ),
+];
+
+const NON_WIRE_ROWS = [
+  logRow("2026-01-01T00:00:00.000Z", "Scenario started: default-scenario"),
+];
+
+describe("SessionAnalysisPanel", () => {
+  let cleanup: (() => Promise<void>) | null = null;
+
+  beforeAll(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = null;
+    }
+  });
+
+  it("shows the Session Analysis tab (alongside the existing tabs) in idle state with the disclaimer and an Analyze button", async () => {
+    const service = makeService({
+      snapshots: [snapshot("CP-1")],
+      listStoredLogs: vi.fn(async () => []),
+    });
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+
+    const labels = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="tab"]'),
+    ).map((el) => el.textContent?.trim());
+    expect(labels).toEqual([
+      "Transactions",
+      "Message Log",
+      "Session Analysis",
+      "Configuration",
+      "Diagnostics",
+    ]);
+
+    await openAnalysisTab(container);
+
+    expect(container.textContent).toContain(ANALYZE_DISCLAIMER);
+    const analyzeButton = findButton(container, "Analyze");
+    expect(analyzeButton, "expected an Analyze button").toBeTruthy();
+    expect(analyzeButton!.disabled).toBe(false);
+  });
+
+  it("analyzes a clean session: timeline events render, FailureSummary says no failures, disclaimer stays visible", async () => {
+    const listStoredLogs = vi.fn(async () => CLEAN_SESSION_ROWS);
+    const service = makeService({
+      snapshots: [snapshot("CP-1")],
+      listStoredLogs,
+    });
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+    await openAnalysisTab(container);
+
+    await clickAnalyzeAndWait(container);
+
+    expect(listStoredLogs).toHaveBeenCalledWith("CP-1");
+    expect(container.textContent).toContain("BootNotification");
+    expect(container.textContent).toContain("No failures detected");
+    expect(container.textContent).toContain(ANALYZE_DISCLAIMER);
+  });
+
+  it("analyzes a failed-auth trace: FAILED_AUTHORIZATION is visible", async () => {
+    const service = makeService({
+      snapshots: [snapshot("CP-1")],
+      listStoredLogs: vi.fn(async () => FAILED_AUTH_ROWS),
+    });
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+    await openAnalysisTab(container);
+    await clickAnalyzeAndWait(container);
+
+    expect(container.textContent).toContain("FAILED_AUTHORIZATION");
+  });
+
+  it("clicking a timeline event shows it in the MessageInspector", async () => {
+    const service = makeService({
+      snapshots: [snapshot("CP-1")],
+      listStoredLogs: vi.fn(async () => CLEAN_SESSION_ROWS),
+    });
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+    await openAnalysisTab(container);
+    await clickAnalyzeAndWait(container);
+
+    expect(container.textContent).toContain("Select an event to inspect");
+
+    const timelineItem = Array.from(container.querySelectorAll("li")).find(
+      (el) => el.textContent?.includes("BootNotification"),
+    );
+    expect(
+      timelineItem,
+      "expected a BootNotification timeline row",
+    ).toBeTruthy();
+
+    await act(async () => {
+      timelineItem!.click();
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(container.textContent).not.toContain("Select an event to inspect");
+    expect(container.textContent).toContain("Message Inspector");
+    // MessageInspector renders the action inline ("Action: BootNotification").
+    expect(container.textContent).toContain("BootNotification");
+  });
+
+  it("shows the unavailable EmptyState (no Analyze button) when listStoredLogs is undefined", async () => {
+    const service = makeService({
+      snapshots: [snapshot("CP-1")],
+      listStoredLogs: undefined,
+    });
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+    await openAnalysisTab(container);
+
+    expect(container.textContent).toContain(
+      "Session analysis is not available in this runtime",
+    );
+    expect(findButton(container, "Analyze")).toBeUndefined();
+  });
+
+  it("shows 'No logged traffic to analyze yet' after clicking Analyze when listStoredLogs resolves []", async () => {
+    const service = makeService({
+      snapshots: [snapshot("CP-1")],
+      listStoredLogs: vi.fn(async () => []),
+    });
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+    await openAnalysisTab(container);
+    await clickAnalyzeAndWait(container);
+
+    expect(container.textContent).toContain(
+      "No logged traffic to analyze yet.",
+    );
+  });
+
+  it("shows 'No logged traffic to analyze yet' when the stored rows are all non-wire log lines", async () => {
+    const service = makeService({
+      snapshots: [snapshot("CP-1")],
+      listStoredLogs: vi.fn(async () => NON_WIRE_ROWS),
+    });
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+    await openAnalysisTab(container);
+    await clickAnalyzeAndWait(container);
+
+    expect(container.textContent).toContain(
+      "No logged traffic to analyze yet.",
+    );
+  });
+});

--- a/src/console/pages/cp/SessionAnalysisPanel.errorStates.dom.test.tsx
+++ b/src/console/pages/cp/SessionAnalysisPanel.errorStates.dom.test.tsx
@@ -1,0 +1,259 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+// CodeRabbit finding (issue #188, Minor): the panel's two error branches --
+// (a) a successfully-loaded toolkit whose pipeline (parseOpenOcppTrace ->
+// buildSessionTimeline -> detectFailures -> summarizeSessions) throws, and
+// (b) the toolkit's own dynamic `import("@ocpp-debugkit/toolkit/core")`
+// itself failing to load -- had no test coverage. Both need
+// `@ocpp-debugkit/toolkit/core` to misbehave, which vi.mock's hoisting
+// handles for a dynamic `import()` exactly like a static one (same
+// technique as
+// src/cli/analyze/__tests__/runAnalyze.toolkitFailure.test.ts). Kept out of
+// SessionAnalysisPanel.dom.test.tsx so that file's tests keep exercising the
+// real toolkit.
+//
+// (a) is a single hoisted vi.mock, delegating to the real implementation
+// unless the trace text carries the "CP-PIPELINE-FAIL" marker (mirrors the
+// CLI precedent's per-group "CP-BAD" marker) -- a call-time check, so it
+// coexists with every other test in this file that wants the real
+// implementation. (b) needs the dynamic `import()` itself to reject, which
+// -- once a module has resolved for a given specifier -- can't be flipped
+// per-test without resetting the module registry; it uses `vi.doMock` +
+// `vi.resetModules()` and re-imports the harness fresh, isolated to that one
+// test (last in the file, so nothing after it depends on the pre-reset
+// module graph).
+vi.mock("@ocpp-debugkit/toolkit/core", async () => {
+  const actual = await vi.importActual<
+    typeof import("@ocpp-debugkit/toolkit/core")
+  >("@ocpp-debugkit/toolkit/core");
+  return {
+    ...actual,
+    parseOpenOcppTrace: (jsonl: string) => {
+      if (jsonl.includes("CP-PIPELINE-FAIL")) {
+        throw new Error("simulated toolkit pipeline failure");
+      }
+      return actual.parseOpenOcppTrace(jsonl);
+    },
+  };
+});
+
+import {
+  createFakeChargePointService,
+  renderConsole,
+  type FakeChargePointService,
+} from "../../test/harness";
+import { OCPPStatus } from "../../../cp/domain/types/OcppTypes";
+import type {
+  ChargePointService,
+  ChargePointSnapshot,
+  StoredLogEntry,
+} from "../../../data/interfaces/ChargePointService";
+
+/** See SessionAnalysisPanel.dom.test.tsx for why `getStateHistory` is
+ *  stubbed on every service built here. */
+function makeService(
+  overrides: Partial<ChargePointService> & {
+    snapshots?: ChargePointSnapshot[];
+  },
+): FakeChargePointService {
+  return createFakeChargePointService({
+    getStateHistory: vi.fn(async () => []),
+    ...overrides,
+  });
+}
+
+async function unmount(root: Root): Promise<void> {
+  await act(async () => {
+    root.unmount();
+  });
+  document.body.innerHTML = "";
+}
+
+async function flush(times = 6): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+function snapshot(id: string): ChargePointSnapshot {
+  return { id, status: OCPPStatus.Available, error: "", connectors: [] };
+}
+
+function tabTrigger(
+  container: HTMLElement,
+  label: string,
+): HTMLElement | undefined {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>('[role="tab"]'),
+  ).find((el) => el.textContent?.trim() === label);
+}
+
+async function openAnalysisTab(container: HTMLElement): Promise<void> {
+  const trigger = tabTrigger(container, "Session Analysis");
+  expect(trigger, "expected a Session Analysis tab").toBeTruthy();
+  await act(async () => {
+    trigger!.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      }),
+    );
+    await Promise.resolve();
+  });
+  for (let i = 0; i < 100; i++) {
+    if (!container.textContent?.includes("Loading session analysis")) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+  throw new Error("timed out waiting for SessionAnalysisPanel to load");
+}
+
+function findButton(
+  container: HTMLElement,
+  label: string,
+): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  ) as HTMLButtonElement | undefined;
+}
+
+async function clickAnalyzeAndWait(container: HTMLElement): Promise<void> {
+  const button = findButton(container, "Analyze");
+  expect(button, "expected an Analyze button").toBeTruthy();
+  await act(async () => {
+    button!.click();
+    await Promise.resolve();
+  });
+  for (let i = 0; i < 200; i++) {
+    if (!findButton(container, "Analyzing…")) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+  throw new Error("timed out waiting for Analyze to settle");
+}
+
+function logRow(timestamp: string, message: string): StoredLogEntry {
+  return { timestamp, level: "INFO", type: "WebSocket", cpId: "CP-1", message };
+}
+
+// `logLinesToTrace` stamps this trace's derived records with the "CP-1"
+// chargePointId (from the `chargePointId` option passed by the panel), not
+// the marker string -- so the marker has to live in the wire payload itself
+// (an idTag) to land in the jsonl text the mocked `parseOpenOcppTrace` sees.
+const PIPELINE_FAIL_ROWS = [
+  logRow(
+    "2026-01-01T00:00:00.000Z",
+    'Sent: [2,"1","BootNotification",{"chargePointVendor":"V","chargePointModel":"M"}]',
+  ),
+  logRow(
+    "2026-01-01T00:00:01.000Z",
+    'Received: [3,"1",{"status":"Accepted","currentTime":"2026-01-01T00:00:01.000Z","interval":300}]',
+  ),
+  logRow(
+    "2026-01-01T00:00:02.000Z",
+    'Sent: [2,"2","Authorize",{"idTag":"CP-PIPELINE-FAIL"}]',
+  ),
+  logRow(
+    "2026-01-01T00:00:03.000Z",
+    'Received: [3,"2",{"idTagInfo":{"status":"Accepted"}}]',
+  ),
+];
+
+describe("SessionAnalysisPanel (pipeline failure after a successful toolkit load)", () => {
+  let cleanup: (() => Promise<void>) | null = null;
+
+  beforeAll(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = null;
+    }
+  });
+
+  it("shows 'Analysis failed: <msg>' and keeps the Analyze button as a retry affordance", async () => {
+    const service = makeService({
+      snapshots: [snapshot("CP-1")],
+      listStoredLogs: vi.fn(async () => PIPELINE_FAIL_ROWS),
+    });
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+    await openAnalysisTab(container);
+    await clickAnalyzeAndWait(container);
+
+    expect(container.textContent).toContain(
+      "Analysis failed: simulated toolkit pipeline failure",
+    );
+
+    // Retry affordance: the Analyze button is still present and enabled
+    // (not stuck disabled/"Analyzing…") so the user can just click again.
+    const retryButton = findButton(container, "Analyze");
+    expect(retryButton, "expected the Analyze button to remain").toBeTruthy();
+    expect(retryButton!.disabled).toBe(false);
+  });
+});
+
+describe("SessionAnalysisPanel (toolkit-load failure)", () => {
+  let cleanup: (() => Promise<void>) | null = null;
+
+  beforeAll(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = null;
+    }
+  });
+
+  it("shows 'Failed to load analysis toolkit' when the dynamic import itself rejects", async () => {
+    // Once `import("@ocpp-debugkit/toolkit/core")` has resolved for a given
+    // specifier, later `import()` calls of it in this file get the same
+    // cached (fulfilled) module -- so making it reject here (while the
+    // sibling describe block above needs it to resolve) requires swapping
+    // the registered factory and clearing the module registry, then
+    // re-importing the harness (and, transitively, the panel) fresh so the
+    // new dynamic import call actually observes the swapped factory. This
+    // is isolated to this one test (the last in the file).
+    vi.resetModules();
+    vi.doMock("@ocpp-debugkit/toolkit/core", () => {
+      throw new Error("simulated toolkit load failure");
+    });
+
+    const harness = await import("../../test/harness");
+    const service = harness.createFakeChargePointService({
+      getStateHistory: vi.fn(async () => []),
+      snapshots: [snapshot("CP-1")],
+      listStoredLogs: vi.fn(async () => PIPELINE_FAIL_ROWS),
+    });
+    const { container, root } = await harness.renderConsole("/cp/CP-1", {
+      service,
+    });
+    cleanup = () => unmount(root);
+    await flush();
+    await openAnalysisTab(container);
+    await clickAnalyzeAndWait(container);
+
+    expect(container.textContent).toContain("Failed to load analysis toolkit");
+
+    const retryButton = findButton(container, "Analyze");
+    expect(retryButton, "expected the Analyze button to remain").toBeTruthy();
+    expect(retryButton!.disabled).toBe(false);
+  });
+});

--- a/src/console/pages/cp/SessionAnalysisPanel.tsx
+++ b/src/console/pages/cp/SessionAnalysisPanel.tsx
@@ -1,0 +1,196 @@
+import React, { useCallback, useMemo, useState } from "react";
+import type {
+  Event,
+  Failure,
+  ParseWarning,
+  Session,
+  SessionSummary,
+} from "@ocpp-debugkit/toolkit/core";
+import {
+  FailureSummary,
+  MessageInspector,
+  SessionTimeline,
+} from "@ocpp-debugkit/toolkit/react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { useDataContext } from "@/data/providers/DataProvider";
+import {
+  logLinesToTrace,
+  type SerializedLogLine,
+} from "@/trace/logEntryToTrace";
+import { ANALYZE_DISCLAIMER } from "@/trace/analysisDisclaimer";
+
+import EmptyState from "../../components/EmptyState";
+
+export interface SessionAnalysisPanelProps {
+  cpId: string;
+  ocppVersion?: string;
+}
+
+interface AnalysisData {
+  events: Event[];
+  sessions: Session[];
+  failures: Failure[];
+  summaries: SessionSummary[];
+  warnings: ParseWarning[];
+}
+
+type PanelState =
+  | { kind: "idle" }
+  | { kind: "analyzing" }
+  | { kind: "empty"; message: string }
+  | { kind: "results"; data: AnalysisData }
+  | { kind: "error"; message: string };
+
+const NO_LOGGED_TRAFFIC_MESSAGE = "No logged traffic to analyze yet.";
+
+/**
+ * Snapshot-on-click DebugKit analysis (issue #188 PoC items 6-7): clicking
+ * "Analyze" snapshots the CP's persisted logs and runs the toolkit pipeline
+ * once. There is no live/continuous analysis -- re-clicking re-snapshots and
+ * re-runs (deliberate; see issue #188).
+ *
+ * @ocpp-debugkit/toolkit is imported ONLY via its `/core` and `/react`
+ * subpaths -- never the package root, never `/cli` (a module-load side
+ * effect). `/react` has no runtime dependency on `/core` and is small
+ * (~9 KB), so it's imported at this module's top level; this whole module is
+ * itself only reachable through the lazy `import("./cp/SessionAnalysisPanel")`
+ * in CpDetailPage.tsx, so it never lands in the main entry chunk. `/core` is
+ * imported dynamically inside the click handler so a missing/broken install
+ * fails there with our own message instead of on tab open.
+ */
+const SessionAnalysisPanel: React.FC<SessionAnalysisPanelProps> = ({
+  cpId,
+  ocppVersion,
+}) => {
+  const { chargePointService } = useDataContext();
+  const [state, setState] = useState<PanelState>({ kind: "idle" });
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+
+  const listStoredLogs = chargePointService.listStoredLogs;
+  const canAnalyze = typeof listStoredLogs === "function";
+
+  const handleAnalyze = useCallback(async () => {
+    if (!listStoredLogs) return;
+    setSelectedEventId(null);
+    setState({ kind: "analyzing" });
+
+    try {
+      const rows = await listStoredLogs(cpId);
+      if (rows.length === 0) {
+        setState({ kind: "empty", message: NO_LOGGED_TRAFFIC_MESSAGE });
+        return;
+      }
+
+      const records = logLinesToTrace(rows as SerializedLogLine[], {
+        ocppVersion,
+        chargePointId: cpId,
+      });
+      if (records.length === 0) {
+        setState({ kind: "empty", message: NO_LOGGED_TRAFFIC_MESSAGE });
+        return;
+      }
+      const jsonl = records.map((record) => JSON.stringify(record)).join("\n");
+
+      let core: typeof import("@ocpp-debugkit/toolkit/core");
+      try {
+        core = await import("@ocpp-debugkit/toolkit/core");
+      } catch {
+        setState({
+          kind: "error",
+          message: "Failed to load analysis toolkit",
+        });
+        return;
+      }
+
+      try {
+        const { events, warnings } = core.parseOpenOcppTrace(jsonl);
+        const sessions = core.buildSessionTimeline(events);
+        const failures = core.detectFailures(events, sessions);
+        const summaries = core.summarizeSessions(sessions, failures);
+        setState({
+          kind: "results",
+          data: { events, sessions, failures, summaries, warnings },
+        });
+      } catch (err) {
+        setState({
+          kind: "error",
+          message: `Analysis failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    } catch (err) {
+      setState({
+        kind: "error",
+        message: `Analysis failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }, [listStoredLogs, cpId, ocppVersion]);
+
+  const selectedEvent = useMemo(() => {
+    if (state.kind !== "results") return null;
+    return state.data.events.find((e) => e.id === selectedEventId) ?? null;
+  }, [state, selectedEventId]);
+
+  if (!canAnalyze) {
+    return (
+      <EmptyState title="Session analysis is not available in this runtime" />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardContent className="space-y-3 p-4">
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Snapshot this charge point&apos;s stored logs and run OCPP
+            DebugKit&apos;s failure-pattern analysis in your browser.
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {ANALYZE_DISCLAIMER}
+          </p>
+          <Button
+            type="button"
+            size="sm"
+            disabled={state.kind === "analyzing"}
+            onClick={() => void handleAnalyze()}
+          >
+            {state.kind === "analyzing" ? "Analyzing…" : "Analyze"}
+          </Button>
+          {state.kind === "error" && (
+            <div className="rounded-md border border-rose-300 bg-rose-50 px-3 py-2 text-sm text-rose-800 dark:border-rose-800 dark:bg-rose-950 dark:text-rose-200">
+              {state.message}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {state.kind === "empty" && <EmptyState title={state.message} />}
+
+      {state.kind === "results" && (
+        <div className="space-y-4">
+          <div className="text-sm text-gray-600 dark:text-gray-300">
+            {state.data.events.length} events · {state.data.sessions.length}{" "}
+            sessions · {state.data.failures.length} failures
+            {state.data.warnings.length > 0
+              ? ` · ${state.data.warnings.length} parse warnings`
+              : ""}
+          </div>
+
+          <FailureSummary failures={state.data.failures} />
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <SessionTimeline
+              events={state.data.events}
+              selectedEventId={selectedEventId}
+              onSelectEvent={setSelectedEventId}
+            />
+            <MessageInspector event={selectedEvent} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SessionAnalysisPanel;

--- a/src/console/pages/cp/SessionAnalysisPanel.tsx
+++ b/src/console/pages/cp/SessionAnalysisPanel.tsx
@@ -89,11 +89,12 @@ const SessionAnalysisPanel: React.FC<SessionAnalysisPanelProps> = ({
     setSelectedEventId(null);
   }, [cpId]);
 
-  const listStoredLogs = chargePointService.listStoredLogs;
-  const canAnalyze = typeof listStoredLogs === "function";
+  const canAnalyze = typeof chargePointService.listStoredLogs === "function";
 
   const handleAnalyze = useCallback(async () => {
-    if (!listStoredLogs) return;
+    // Called as a method — every real implementation reads `this` inside
+    // listStoredLogs, so a detached reference breaks at runtime.
+    if (!chargePointService.listStoredLogs) return;
     const requestCpId = cpId;
     setSelectedEventId(null);
     setState({ kind: "analyzing" });
@@ -107,7 +108,7 @@ const SessionAnalysisPanel: React.FC<SessionAnalysisPanelProps> = ({
     };
 
     try {
-      const rows = await listStoredLogs(requestCpId);
+      const rows = await chargePointService.listStoredLogs(requestCpId);
       if (rows.length === 0) {
         commit({ kind: "empty", message: NO_LOGGED_TRAFFIC_MESSAGE });
         return;
@@ -155,7 +156,7 @@ const SessionAnalysisPanel: React.FC<SessionAnalysisPanelProps> = ({
         message: `Analysis failed: ${err instanceof Error ? err.message : String(err)}`,
       });
     }
-  }, [listStoredLogs, cpId, ocppVersion]);
+  }, [chargePointService, cpId, ocppVersion]);
 
   const selectedEvent = useMemo(() => {
     if (state.kind !== "results") return null;

--- a/src/console/pages/cp/SessionAnalysisPanel.tsx
+++ b/src/console/pages/cp/SessionAnalysisPanel.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type {
   Event,
   Failure,
@@ -68,27 +74,51 @@ const SessionAnalysisPanel: React.FC<SessionAnalysisPanelProps> = ({
   const [state, setState] = useState<PanelState>({ kind: "idle" });
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
 
+  // Nothing remounts this panel when `cpId` changes (CpDetailPage keeps one
+  // lazy-loaded instance across route param changes), so `handleAnalyze`'s
+  // in-flight `listStoredLogs`/dynamic-import/pipeline work for the OLD cpId
+  // could otherwise land after the prop has already moved on to a new CP,
+  // rendering the wrong CP's results/error under the new CP's page. This ref
+  // tracks the current cpId for `handleAnalyze`'s staleness guard below, and
+  // the effect resets the panel back to idle the moment cpId changes so the
+  // new CP never shows a stale "analyzing"/results/error state either.
+  const cpIdRef = useRef(cpId);
+  useEffect(() => {
+    cpIdRef.current = cpId;
+    setState({ kind: "idle" });
+    setSelectedEventId(null);
+  }, [cpId]);
+
   const listStoredLogs = chargePointService.listStoredLogs;
   const canAnalyze = typeof listStoredLogs === "function";
 
   const handleAnalyze = useCallback(async () => {
     if (!listStoredLogs) return;
+    const requestCpId = cpId;
     setSelectedEventId(null);
     setState({ kind: "analyzing" });
 
+    // Only commits when the panel is still showing the CP this analyze was
+    // started for -- guards every post-await setState against a stale
+    // result from a cpId the panel has since moved away from.
+    const commit = (next: PanelState) => {
+      if (cpIdRef.current !== requestCpId) return;
+      setState(next);
+    };
+
     try {
-      const rows = await listStoredLogs(cpId);
+      const rows = await listStoredLogs(requestCpId);
       if (rows.length === 0) {
-        setState({ kind: "empty", message: NO_LOGGED_TRAFFIC_MESSAGE });
+        commit({ kind: "empty", message: NO_LOGGED_TRAFFIC_MESSAGE });
         return;
       }
 
       const records = logLinesToTrace(rows as SerializedLogLine[], {
         ocppVersion,
-        chargePointId: cpId,
+        chargePointId: requestCpId,
       });
       if (records.length === 0) {
-        setState({ kind: "empty", message: NO_LOGGED_TRAFFIC_MESSAGE });
+        commit({ kind: "empty", message: NO_LOGGED_TRAFFIC_MESSAGE });
         return;
       }
       const jsonl = records.map((record) => JSON.stringify(record)).join("\n");
@@ -97,7 +127,7 @@ const SessionAnalysisPanel: React.FC<SessionAnalysisPanelProps> = ({
       try {
         core = await import("@ocpp-debugkit/toolkit/core");
       } catch {
-        setState({
+        commit({
           kind: "error",
           message: "Failed to load analysis toolkit",
         });
@@ -109,18 +139,18 @@ const SessionAnalysisPanel: React.FC<SessionAnalysisPanelProps> = ({
         const sessions = core.buildSessionTimeline(events);
         const failures = core.detectFailures(events, sessions);
         const summaries = core.summarizeSessions(sessions, failures);
-        setState({
+        commit({
           kind: "results",
           data: { events, sessions, failures, summaries, warnings },
         });
       } catch (err) {
-        setState({
+        commit({
           kind: "error",
           message: `Analysis failed: ${err instanceof Error ? err.message : String(err)}`,
         });
       }
     } catch (err) {
-      setState({
+      commit({
         kind: "error",
         message: `Analysis failed: ${err instanceof Error ? err.message : String(err)}`,
       });
@@ -134,7 +164,10 @@ const SessionAnalysisPanel: React.FC<SessionAnalysisPanelProps> = ({
 
   if (!canAnalyze) {
     return (
-      <EmptyState title="Session analysis is not available in this runtime" />
+      <EmptyState
+        title="Session analysis is not available in this runtime"
+        hint={ANALYZE_DISCLAIMER}
+      />
     );
   }
 

--- a/src/trace/__tests__/analysisDisclaimer.test.ts
+++ b/src/trace/__tests__/analysisDisclaimer.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { ANALYZE_DISCLAIMER } from "../analysisDisclaimer";
+
+describe("ANALYZE_DISCLAIMER", () => {
+  it("is the issue #188 PoC item 8 compliance disclaimer text", () => {
+    expect(ANALYZE_DISCLAIMER).toBe(
+      'Failure-pattern detection is not OCPP compliance certification: "no known failure detected" does not mean "OCPP compliant".',
+    );
+  });
+});

--- a/src/trace/analysisDisclaimer.ts
+++ b/src/trace/analysisDisclaimer.ts
@@ -1,0 +1,10 @@
+/**
+ * Issue #188 PoC item 8: the detector only recognizes a fixed catalog of
+ * known failure shapes -- it is not a conformance checker. Required on every
+ * analysis surface (the CLI `analyze` command, the web console's Session
+ * Analysis tab) so a clean run can never be read as "this station is OCPP
+ * compliant". Browser-safe (no node imports) so both surfaces can share it;
+ * `src/cli/analyze/runAnalyze.ts` re-exports this unchanged.
+ */
+export const ANALYZE_DISCLAIMER =
+  'Failure-pattern detection is not OCPP compliance certification: "no known failure detected" does not mean "OCPP compliant".';


### PR DESCRIPTION
Completes [#188](https://github.com/shiv3/ocpp-cp-simulator/issues/188)'s PoC items 6-7: a **Session Analysis** tab on the `/v3` charge-point page that runs [OCPP DebugKit](https://github.com/ocpp-debugkit/toolkit)'s failure detection in the browser and renders its React components.

## What this adds

- **New "Session Analysis" tab** on the CP detail page (next to Message Log). Snapshot-on-click by design (the issue's own recommendation — no continuous live analysis): "Analyze" fetches the CP's **full persisted log history** via `listStoredLogs` (both local and remote modes — deliberately not the page's live log tail, which only starts at tab-open), adapts it with the existing `logLinesToTrace`, and runs the DebugKit pipeline in the browser.
- **Rendered with DebugKit's own components**: `FailureSummary` + `SessionTimeline` + `MessageInspector` (timeline selection wired to the inspector; components are fully controlled, selection state lives in the panel). `ReplayControls`/`ReportViewer` left for a follow-up.
- **Bundle isolation**: the panel is a `React.lazy` chunk, and `@ocpp-debugkit/toolkit` (`/core` dynamically at click time, `/react` inside the lazy chunk) never enters the main entry bundle — verified both by local `vite build` and **`docker build --target ui`** (the release-image path; PR CI does not run vite build), with a grep check that the main chunk contains no toolkit code.
- **Disclaimer everywhere** (PoC item 8): the shared `ANALYZE_DISCLAIMER` moved to a browser-safe module (`src/trace/analysisDisclaimer.ts`, re-exported by the CLI so nothing changes there) and is visible in every panel state, including the runtime-unavailable branch.
- **Robustness**: switching CPs mid-analysis can't render a stale CP's results (request-time cpId capture + staleness guard + reset-on-change effect, regression-tested with a deferred-promise test); toolkit-load failure and pipeline failure surface as distinct, retryable error states.

## Tests

12 new dom tests (jsdom + Testing Library harness, **real toolkit — no mocks** for the analysis paths): idle/disclaimer, clean session → timeline + "No failures detected", invalid-idTag → `FAILED_AUTHORIZATION`, timeline→inspector selection, unavailable/empty/non-wire branches, transient analyzing state, stale-cpId guard; plus a separate mocked pair for the two error states (following the CLI's dynamic-import mock precedent).

## Verification

- `vitest` 1389/1389 green; `bun test bun.test` 224/224 green; `tsc -b` baseline unchanged; eslint clean.
- `vite build` + `docker build --target ui .` both succeed; panel/toolkit chunks separate from the main entry (checked in both build outputs).
- No new dependencies (uses the `@ocpp-debugkit/toolkit@0.4.0` exact pin from #221).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Session Analysis** tab to review stored OCPP traffic for a charge point.
  * Users can run analysis, view a session timeline, inspect individual messages, and see detected failures and warnings.
  * Added clear UI states for runtime-unavailable services, empty results, loading, and error cases (with retry support).
  * Included an on-screen **analysis disclaimer** clarifying results are not OCPP compliance certification.
* **Bug Fixes**
  * Prevented stale analysis results from showing after switching to a different charge point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->