### PR TITLE
ci(codecov): upload Bun test coverage alongside Vitest (#215)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Coverage (non-blocking)
         run: bun run test:coverage
         continue-on-error: true
+        if: ${{ !cancelled() }}
+
+      - name: Coverage (non-blocking, bun)
+        run: bun run test:coverage:bun
+        continue-on-error: true
+        if: ${{ !cancelled() }}
 
       # Coverage + test-results reporting (issue #131). Both are non-blocking
       # (fail_ci_if_error: false) and run even when a test step failed, so a
@@ -49,7 +55,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info
+          files: ./coverage/lcov.info,./coverage/bun/lcov.info
           fail_ci_if_error: false
 
       - name: Upload test results to Codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,8 +3,12 @@
 # Coverage is uploaded from both vitest's lcov (`bun run test:coverage`, at
 # ./coverage/lcov.info) and Bun's lcov (`bun run test:coverage:bun`, at
 # ./coverage/bun/lcov.info) — Codecov merges the two reports for the same
-# commit, so the daemon/runtime code exercised only by Bun tests
-# (`*.bun.test.ts`, run via `bun test bun.test`) is now reflected too.
+# commit, so the line coverage of daemon/runtime code exercised only by Bun
+# tests (`*.bun.test.ts`, run via `bun test bun.test`) is now reflected too.
+# Two caveats: Bun's lcov carries line coverage only (no branch/function
+# data), and a few Bun tests spawn subprocesses whose lines can't be
+# attributed to the parent — so the merged number is a floor, not a
+# fully-representative figure, for Bun-only-covered code.
 #
 # Keep the status checks informational for now: the true combined % hasn't
 # been observed yet, and codecov here is for visibility, not a merge gate.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,16 +1,15 @@
-# Codecov configuration (issue #131).
+# Codecov configuration (issue #131, #215).
 #
-# Coverage is uploaded from vitest's lcov only (`bun run test:coverage`).
-# A large share of the daemon/runtime code is exercised by Bun tests
-# (`*.bun.test.ts`, run via `bun test bun.test`), whose coverage is NOT yet
-# part of the upload. Codecov therefore under-reports, and its default
-# project/patch status gates fail on Bun-tested changes even when the change is
-# well covered — which is not the intent (codecov here is for visibility, not a
-# merge gate).
+# Coverage is uploaded from both vitest's lcov (`bun run test:coverage`, at
+# ./coverage/lcov.info) and Bun's lcov (`bun run test:coverage:bun`, at
+# ./coverage/bun/lcov.info) — Codecov merges the two reports for the same
+# commit, so the daemon/runtime code exercised only by Bun tests
+# (`*.bun.test.ts`, run via `bun test bun.test`) is now reflected too.
 #
-# Keep the status checks informational so they still report the numbers on each
-# PR/commit but never fail. Follow-up: merge Bun coverage into the upload, then
-# these can become real gates.
+# Keep the status checks informational for now: the true combined % hasn't
+# been observed yet, and codecov here is for visibility, not a merge gate.
+# Follow-up (separate change): once the combined number is known, revisit
+# whether project/patch gates should become real (non-informational).
 coverage:
   status:
     project:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,15 @@
+# Testing strategy
+
+## Vitest vs. Bun test
+
+- **Vitest** (`bun run test:vitest`, `*.test.ts(x)`) is the default: jsdom
+  UI/DOM tests, plain unit tests, and anything that runs fine in a
+  browser-safe environment.
+- **Bun test** (`bun run test:bun`, `*.bun.test.ts`) is for behavior that
+  needs the real Bun runtime: the CLI entry point, the Bun HTTP/socket
+  server, `bun:sqlite`, and subprocess-spawning integration tests.
+
+Coverage (`bun run test:coverage` / `test:coverage:bun`, uploaded to Codecov
+in CI) merges both reports — `coverage/lcov.info` (Vitest) and
+`coverage/bun/lcov.info` (Bun) — so code exercised only by Bun tests no
+longer shows as uncovered.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -11,5 +11,10 @@
 
 Coverage (`bun run test:coverage` / `test:coverage:bun`, uploaded to Codecov
 in CI) merges both reports — `coverage/lcov.info` (Vitest) and
-`coverage/bun/lcov.info` (Bun) — so code exercised only by Bun tests no
-longer shows as uncovered.
+`coverage/bun/lcov.info` (Bun) — so the **line** coverage of code exercised
+only by Bun tests no longer shows as uncovered. Two limitations to keep in
+mind: Bun's lcov reports line coverage only (no branch or per-function data,
+unlike Vitest's v8 report), and Bun tests that spawn a subprocess (e.g. the
+CLI-entry integration tests) only cover the parent process, so the child's
+lines are not attributed. The merged figure is therefore a floor for
+Bun-only-covered code, not a fully-representative number.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:bun": "bun test bun.test",
     "test:e2e": "bun run e2e/support/buildCsms.ts && bun test --timeout 60000 ./e2e/ocpp16.gocpp.e2e.ts ./e2e/ocpp201.gocpp.e2e.ts ./e2e/ocpp21.gocpp.e2e.ts ./e2e/scenario.gocpp.e2e.ts ./e2e/comprehensive.gocpp.e2e.ts",
     "test:coverage": "vitest run --coverage",
+    "test:coverage:bun": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=./coverage/bun bun.test",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "format": "prettier --write .",


### PR DESCRIPTION
Closes #215.

CI coverage was Vitest-only (`test:coverage` = `vitest run --coverage`), so code exercised only by `*.bun.test.ts` showed as uncovered — which is why #213 had to make the Codecov checks informational. This uploads a Bun LCOV report alongside Vitest's; Codecov merges the two for the same commit (issue #215, Option 1).

## Changes

- **`package.json`**: new `test:coverage:bun` = `bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=./coverage/bun bun.test`. Bun writes to `./coverage/bun/` so it never collides with Vitest's `./coverage/lcov.info`; the `text` reporter is kept alongside `lcov` so the console table still prints.
- **`.github/workflows/ci.yml`**: a "Coverage (non-blocking, bun)" step, and the Codecov upload's `files:` now lists both `./coverage/lcov.info,./coverage/bun/lcov.info`. Also added `if: ${{ !cancelled() }}` to the **existing** vitest coverage step — it had only `continue-on-error`, which (contrary to its comment) does not make a step run after an earlier step fails; both coverage steps now genuinely run on red builds.
- **`codecov.yml`**: comment updated to reflect that Bun coverage is now uploaded. Left the checks informational deliberately — the true combined % hasn't been observed yet; flipping the project/patch gates to real is a sensible follow-up once the merged number is known (a separate change).
- **`docs/testing.md`** (new): documents when to write a Vitest vs. a Bun test, per the issue's success criterion.

## Notes / honest limitations

- Bun's LCOV carries line coverage (`DA:`) but **no branch data and no per-function hit counts** — the merged project % will be a floor for Bun-only-covered files, not branch-coverage parity with Vitest. Two `*.bun.test.ts` files (`analyze.bun.test.ts`, `browserBundleNoDaemonXml.bun.test.ts`) spawn subprocesses, whose lines Bun coverage can't attribute to the parent — a small, understood under-report.
- Step order matters: Vitest's v8 provider directory-cleans `./coverage` before writing, so the vitest step must stay **before** the bun step (as committed) or it would wipe `coverage/bun/`.

## Verification

- `bun run test:coverage:bun` → writes `./coverage/bun/lcov.info` (repo-relative `SF:` paths), console table retained; `bun run test:coverage` still writes `./coverage/lcov.info` — both coexist, no collision. YAML sanity-checked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bun-based test coverage reporting alongside existing Vitest coverage.
  * Coverage now supports publishing/uploading both Bun and Vitest LCOV artifacts and merging them for the same commit.

* **Documentation**
  * Added/updated testing guidance to clarify when to use Vitest vs Bun tests.
  * Documented how combined coverage works in CI, including Bun coverage/reporting limitations.

* **Chores**
  * Updated CI coverage execution and Codecov configuration to upload both LCOV outputs, with the coverage step set to be non-blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->