### PR TITLE
feat(scenario): versioned JSON Schema for scenario definitions (#214)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -89,6 +89,20 @@ jobs:
             | grep -q 'package/src/protocol/' \
             || { echo "::error::src/protocol missing from the CLI tarball"; exit 1; }
 
+      - name: Verify the tarball ships the scenario schema (issue #214)
+        run: |
+          # The daemon (src/cli/server/startServer.ts, socketServer.ts,
+          # RegistryChargePointService.ts) imports src/scenario for advisory
+          # scenario-schema validation, which itself imports
+          # schema/scenario.schema.json; if either is missing from the npm
+          # `files` list the published CLI crashes on boot.
+          tar -tf "${{ steps.pack.outputs.tarball }}" \
+            | grep -q 'package/src/scenario/scenarioSchemaValidator.ts' \
+            || { echo "::error::src/scenario missing from the CLI tarball"; exit 1; }
+          tar -tf "${{ steps.pack.outputs.tarball }}" \
+            | grep -q 'package/schema/scenario.schema.json' \
+            || { echo "::error::schema/scenario.schema.json missing from the CLI tarball"; exit 1; }
+
       - name: Create / update release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -282,11 +282,15 @@ ocpp-cp-sim --daemon ... --scenario-template-file /path/to/template.json \
 ```
 
 `--scenario-template-file` reads a JSON file shaped like a
-`ScenarioDefinition` (the format the browser Scenario Editor exports), then
-clones it per connector — rewriting `targetType`, `targetId`, `id`, and
-`name` — so each connector runs an independent state machine from the same
-file. `--scenario` and `--scenario-template` fan out the same way when
-`--scenario-connector` resolves to more than one id.
+`ScenarioDefinition` (the format the browser Scenario Editor exports — see
+[docs/scenario-format.md](scenario-format.md) for the field reference and
+published [JSON Schema](../schema/scenario.schema.json)), then clones it per
+connector — rewriting `targetType`, `targetId`, `id`, and `name` — so each
+connector runs an independent state machine from the same file. `--scenario`
+and `--scenario-template` fan out the same way when `--scenario-connector`
+resolves to more than one id. Both `--scenario` and `--scenario-template-file`
+validate the file against that schema at load time and warn (never reject)
+on a mismatch.
 
 > **Breaking change (vs. earlier versions):** REST control endpoints, native
 > WebSocket event streams, and the Unix-domain control socket have been

--- a/docs/scenario-format.md
+++ b/docs/scenario-format.md
@@ -1,0 +1,163 @@
+# Scenario File Format (v1.0)
+
+A **node-graph JSON file** describing a scripted charge-point behavior: a
+directed graph of typed nodes (status changes, transactions, meter values,
+CSMS-call waits, ...) connected by edges, executed by the scenario engine.
+This is the format the browser Scenario Editor exports/imports, the shape
+`--scenario` / `--scenario-template-file` expect on the CLI, and what
+`load_scenario` / `run_scenario_file` accept over the Socket.IO control API
+— see [issue #214](https://github.com/shiv3/ocpp-cp-simulator/issues/214).
+
+A published **JSON Schema** (Draft 2020-12) lives at
+[`schema/scenario.schema.json`](../schema/scenario.schema.json) and is the
+source of truth for field names, types, and the closed vocabularies (node
+`type`, `OCPPStatus`, etc.). This document is a human-readable overview of
+that schema, not a replacement for it.
+
+## Status & scope
+
+- **Version `1.0`** (`schemaVersion`).
+- Covers the full 20-node discriminated union the scenario engine supports
+  (see [Node types](#node-types) below).
+- **Validation against this schema is advisory in this version**: the
+  simulator warns (`console.warn` in the browser, stderr / server log on the
+  CLI and daemon) on a mismatch but **never refuses to load a file**. This
+  keeps every scenario file written before this schema existed — none of
+  which carry `schemaVersion` or `createdAt`/`updatedAt` — working exactly
+  as before.
+
+## Versioning
+
+Mirrors the [OCPP trace format](./trace-format.md#versioning)'s rules:
+
+- Additive optional fields bump the **minor** version.
+- Consumers **MUST ignore unknown fields** — real editor exports carry
+  [xyflow](https://reactflow.dev/) UI fields (`width`, `height`, `selected`,
+  `style`, ...) that this schema deliberately does not reject
+  (`additionalProperties: true` at every object level: root, node, node
+  `data`, and edge).
+- Changing the meaning of an existing field, or removing one, is a new
+  **major** version.
+- A published version is immutable: any change that alters what a
+  conformant file must look like is a new version, not an edit.
+
+## Top-level fields
+
+| Field                   | Type                                                                            | Required | Notes                                                                               |
+| ----------------------- | ------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------- |
+| `schemaVersion`         | string                                                                          | No       | e.g. `"1.0"`. Absent on files predating issue #214 — still valid.                   |
+| `id`                    | string                                                                          | Yes      | Stable scenario identifier.                                                         |
+| `name`                  | string                                                                          | Yes      |                                                                                     |
+| `description`           | string                                                                          | No       |                                                                                     |
+| `targetType`            | `"chargePoint"` \| `"connector"`                                                | Yes      |                                                                                     |
+| `targetId`              | number                                                                          | No       | Connector id if `targetType` is `"connector"`.                                      |
+| `nodes`                 | [Node](#node-shape)`[]`                                                         | Yes      |                                                                                     |
+| `edges`                 | [Edge](#edge-shape)`[]`                                                         | Yes      |                                                                                     |
+| `createdAt`/`updatedAt` | string (ISO-8601)                                                               | No       | Most shipped templates omit these — kept optional so they still validate.           |
+| `trigger`               | `{ type: "manual" \| "statusChange", conditions?: { fromStatus?, toStatus? } }` | No       | Auto-execution trigger (default: manual).                                           |
+| `defaultExecutionMode`  | `"oneshot"` \| `"step"`                                                         | No       | Default: `oneshot`.                                                                 |
+| `enabled`               | boolean                                                                         | No       | Default: `true`.                                                                    |
+| `evSettings`            | `Partial<EVSettings>`                                                           | No       | `modelName`, `batteryCapacityKwh`, `maxChargingPowerKw`, `initialSoc`, `targetSoc`. |
+| `assertions`            | [Assertion](#assertions)`[]`                                                    | No       | Declarative pass/fail checks against the run's OCPP transcript.                     |
+
+## Node shape
+
+```json
+{
+  "id": "start-tx",
+  "type": "transaction",
+  "position": { "x": 400, "y": 1080 },
+  "data": { "label": "StartTransaction", "action": "start", "tagId": "TAG-1" }
+}
+```
+
+Every node has `id` (string), `type` (the discriminator — a closed
+enum of the 20 values below), `position` (`{ x: number, y: number }`), and
+`data` (an object requiring at least `label: string`; the rest of `data`'s
+shape depends on `type`).
+
+## Node types
+
+| `type`               | Required `data` fields (beyond `label`)                          | Notable optional fields                                                                                                                                                    |
+| -------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `statusChange`       | `status`                                                         |                                                                                                                                                                            |
+| `transaction`        | `action` (`"start"` \| `"stop"`)                                 | `tagId`, `batteryCapacityKwh`, `initialSoc`, `stopReason`                                                                                                                  |
+| `meterValue`         | `value`, `sendMessage`                                           | `autoIncrement`, `outputKw`, `maxChargeKwh`, `incrementInterval`, `incrementAmount`, `stopMode`, `maxTime`, `maxValue`, `useCurve`, `curvePoints`, `autoCalculateInterval` |
+| `delay`              | `delaySeconds`                                                   |                                                                                                                                                                            |
+| `notification`       | `messageType`, `payload`                                         |                                                                                                                                                                            |
+| `connectorPlug`      | `action` (`"plugin"` \| `"plugout"`)                             |                                                                                                                                                                            |
+| `remoteStartTrigger` | —                                                                | `timeout`                                                                                                                                                                  |
+| `remoteStopTrigger`  | —                                                                | `timeout`                                                                                                                                                                  |
+| `statusTrigger`      | `targetStatus`                                                   | `timeout`                                                                                                                                                                  |
+| `reserveNow`         | `expiryMinutes`, `idTag`                                         | `parentIdTag`, `reservationId`                                                                                                                                             |
+| `cancelReservation`  | `reservationId`                                                  |                                                                                                                                                                            |
+| `reservationTrigger` | —                                                                | `timeout`                                                                                                                                                                  |
+| `start`              | —                                                                | `triggerOn` (`"connect"` \| `"status"`), `targetStatus`                                                                                                                    |
+| `end`                | —                                                                |                                                                                                                                                                            |
+| `statusNotification` | `status`                                                         | `errorCode`, `info`, `vendorErrorCode`, `vendorId`, `connectorId`                                                                                                          |
+| `unlockOutcome`      | `outcome` (`"Unlocked"` \| `"UnlockFailed"` \| `"NotSupported"`) |                                                                                                                                                                            |
+| `configSet`          | `key`, `value`                                                   |                                                                                                                                                                            |
+| `dataTransfer`       | `vendorId`                                                       | `messageId`, `data`                                                                                                                                                        |
+| `csmsCallTrigger`    | `action`                                                         | `timeout`                                                                                                                                                                  |
+| `responseOverride`   | `action`, `status`                                               | See [note](#responseoverride-notes) below.                                                                                                                                 |
+
+`status` / `targetStatus` fields use the `OCPPStatus` enum: `Available`,
+`Preparing`, `Charging`, `SuspendedEVSE`, `SuspendedEV`, `Finishing`,
+`Reserved`, `Unavailable`, `Faulted`.
+
+### `responseOverride` notes
+
+Which `status` values are valid depends on `action` (e.g. `action:
+"RemoteStartTransaction"` only accepts `status: "Accepted" | "Rejected"`; see
+`RESPONSE_OVERRIDE_STATUSES` in
+[`ScenarioTypes.ts`](../src/cp/application/scenario/ScenarioTypes.ts)). The
+schema types both fields as plain strings and does **not** enforce this
+action → status constraint — encoding the full per-action status matrix
+into JSON Schema would make the schema harder to read for little benefit
+over the existing editor-side check. This is called out as a `$comment` in
+the schema itself.
+
+## Edge shape
+
+```json
+{ "id": "e1", "source": "start", "target": "boot-delay" }
+```
+
+`id`, `source`, `target` are required strings. xyflow adds further UI fields
+(`sourceHandle`, `targetHandle`, `type`, `animated`, ...) which the schema
+allows but does not require.
+
+## Assertions
+
+An optional array of declarative pass/fail checks evaluated against the
+run's captured OCPP transcript once a scenario finishes (see
+`evaluateAssertions` in
+[`ScenarioAssertions.ts`](../src/cp/application/verification/ScenarioAssertions.ts)).
+Each entry has `id` and `type` (one of `ocpp_sent`, `ocpp_received`,
+`ocpp_absent`, `response_status`, `idtag_info_status`, `payload_match`,
+`message_order`, `message_after`, `state_transition`, `no_unexpected`), plus
+type-dependent fields (`action`, `direction`, `status`, `occurrence`,
+`payload`, `targetStatus`, `actions`, `before`, `after`). A scenario with no
+`assertions` produces a `SKIPPED` verdict and runs exactly as before.
+
+## Validating a scenario file
+
+```ts
+import { validateScenarioSchema } from "../src/scenario/scenarioSchemaValidator";
+
+const result = validateScenarioSchema(JSON.parse(fileContents));
+if (!result.valid) {
+  console.warn(result.errors); // advisory — do not reject on this
+}
+```
+
+The simulator itself calls this at every import point (browser upload,
+`--scenario` / `--scenario-template-file`, and the `load_scenario` /
+`run_scenario_file` Socket.IO methods) and only ever warns — see [Status &
+scope](#status--scope).
+
+## Changelog
+
+- **v1.0**: Initial published schema (issue #214). Adds the optional
+  `schemaVersion` field; documents the existing on-file shape used since the
+  scenario editor's introduction.

--- a/docs/server.md
+++ b/docs/server.md
@@ -140,6 +140,12 @@ Runtime packages for this control plane are `socket.io`,
 | `stop_all_scenarios`              | `{ "connector": number }`                                              | Stop every scenario on a connector.                      |
 | `remove_scenario`                 | `{ "connector": number, "scenarioId": string }`                        | Remove a loaded scenario.                                |
 
+> Scenario definitions (the `scenario` param above, and the file read by
+> `load_scenario`'s `file` param / `run_scenario_file`) follow
+> [docs/scenario-format.md](scenario-format.md) and its published
+> [JSON Schema](../schema/scenario.schema.json). Validation against that
+> schema is advisory — a mismatch is logged, not rejected.
+
 ### Daemon methods
 
 | Method               | Params                                                                                                                                                                                                | Result / purpose                                                                      |

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "src/cli",
     "src/cp",
     "src/protocol",
+    "src/scenario",
     "src/utils/scenarioTemplates.ts",
     "src/utils/scenarios",
+    "schema",
     "dist"
   ],
   "scripts": {

--- a/schema/scenario.schema.json
+++ b/schema/scenario.schema.json
@@ -471,7 +471,7 @@
           "then": {
             "properties": {
               "data": {
-                "$comment": "Valid `status` values depend on `action` (see RESPONSE_OVERRIDE_STATUSES, ScenarioTypes.ts:855). Not schema-enforced here — advisory only.",
+                "$comment": "Valid `status` values depend on `action` (see RESPONSE_OVERRIDE_STATUSES in ScenarioTypes.ts). Not schema-enforced here — advisory only.",
                 "required": ["action", "status"],
                 "properties": {
                   "action": { "type": "string" },

--- a/schema/scenario.schema.json
+++ b/schema/scenario.schema.json
@@ -1,0 +1,487 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/shiv3/ocpp-cp-simulator/schema/scenario.schema.json",
+  "title": "ScenarioDefinition (scenario schema v1.0)",
+  "$comment": "Scenario file format v1.0 (issue #214). Mirrors src/cp/application/scenario/ScenarioTypes.ts. See docs/scenario-format.md for the field overview and versioning rules. This is a first published contract: it is STRICT on known fields (types, required-ness, closed-vocabulary enums) but PERMISSIVE on unknown keys at every object level (additionalProperties: true) — real editor exports carry xyflow UI fields (width/height/selected/style/...) that this schema deliberately does not reject. Validation against this schema is advisory only in this version: the simulator warns on a mismatch but never refuses to load a file.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["id", "name", "targetType", "nodes", "edges"],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "description": "Scenario schema version, e.g. \"1.0\". Optional: absent on files predating issue #214."
+    },
+    "id": { "type": "string" },
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "targetType": { "type": "string", "enum": ["chargePoint", "connector"] },
+    "targetId": {
+      "type": "number",
+      "description": "Connector id if targetType is \"connector\"."
+    },
+    "nodes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/node" }
+    },
+    "edges": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/edge" }
+    },
+    "createdAt": {
+      "type": "string",
+      "description": "ISO-8601 timestamp. Optional: most shipped templates omit it."
+    },
+    "updatedAt": {
+      "type": "string",
+      "description": "ISO-8601 timestamp. Optional: most shipped templates omit it."
+    },
+    "trigger": { "$ref": "#/$defs/trigger" },
+    "defaultExecutionMode": { "type": "string", "enum": ["oneshot", "step"] },
+    "enabled": { "type": "boolean" },
+    "evSettings": { "$ref": "#/$defs/evSettings" },
+    "assertions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/assertion" }
+    }
+  },
+  "$defs": {
+    "ocppStatus": {
+      "type": "string",
+      "enum": [
+        "Available",
+        "Preparing",
+        "Charging",
+        "SuspendedEVSE",
+        "SuspendedEV",
+        "Finishing",
+        "Reserved",
+        "Unavailable",
+        "Faulted"
+      ]
+    },
+    "position": {
+      "type": "object",
+      "required": ["x", "y"],
+      "additionalProperties": true,
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" }
+      }
+    },
+    "curvePoint": {
+      "type": "object",
+      "required": ["time", "value"],
+      "additionalProperties": true,
+      "properties": {
+        "time": { "type": "number" },
+        "value": { "type": "number" }
+      }
+    },
+    "trigger": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "enum": ["manual", "statusChange"] },
+        "conditions": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "fromStatus": { "$ref": "#/$defs/ocppStatus" },
+            "toStatus": { "$ref": "#/$defs/ocppStatus" }
+          }
+        }
+      }
+    },
+    "evSettings": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Partial<EVSettings> — every field optional in a scenario file.",
+      "properties": {
+        "modelName": { "type": "string" },
+        "batteryCapacityKwh": { "type": "number" },
+        "maxChargingPowerKw": { "type": "number" },
+        "initialSoc": { "type": "number" },
+        "targetSoc": { "type": "number" }
+      }
+    },
+    "assertion": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["id", "type"],
+      "properties": {
+        "id": { "type": "string" },
+        "description": { "type": "string" },
+        "type": {
+          "type": "string",
+          "enum": [
+            "ocpp_sent",
+            "ocpp_received",
+            "ocpp_absent",
+            "response_status",
+            "idtag_info_status",
+            "payload_match",
+            "message_order",
+            "message_after",
+            "state_transition",
+            "no_unexpected"
+          ]
+        },
+        "action": { "type": "string" },
+        "direction": { "type": "string", "enum": ["sent", "received"] },
+        "status": { "type": "string" },
+        "occurrence": { "type": "number" },
+        "payload": { "type": "object" },
+        "targetStatus": { "type": "string" },
+        "actions": { "type": "array", "items": { "type": "string" } },
+        "before": { "$ref": "#/$defs/assertionFrameRef" },
+        "after": { "$ref": "#/$defs/assertionFrameRef" }
+      }
+    },
+    "assertionFrameRef": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["action"],
+      "properties": {
+        "action": { "type": "string" },
+        "direction": { "type": "string", "enum": ["sent", "received"] }
+      }
+    },
+    "edge": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["id", "source", "target"],
+      "properties": {
+        "id": { "type": "string" },
+        "source": { "type": "string" },
+        "target": { "type": "string" },
+        "sourceHandle": { "type": ["string", "null"] },
+        "targetHandle": { "type": ["string", "null"] },
+        "type": { "type": "string" },
+        "animated": { "type": "boolean" }
+      }
+    },
+    "baseNodeData": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["label"],
+      "properties": {
+        "label": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "node": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["id", "type", "position", "data"],
+      "properties": {
+        "id": { "type": "string" },
+        "type": {
+          "type": "string",
+          "enum": [
+            "statusChange",
+            "transaction",
+            "meterValue",
+            "delay",
+            "notification",
+            "connectorPlug",
+            "remoteStartTrigger",
+            "remoteStopTrigger",
+            "statusTrigger",
+            "reserveNow",
+            "cancelReservation",
+            "reservationTrigger",
+            "start",
+            "end",
+            "statusNotification",
+            "unlockOutcome",
+            "configSet",
+            "dataTransfer",
+            "csmsCallTrigger",
+            "responseOverride"
+          ]
+        },
+        "position": { "$ref": "#/$defs/position" },
+        "data": { "$ref": "#/$defs/baseNodeData" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "statusChange" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["status"],
+                "properties": {
+                  "status": { "$ref": "#/$defs/ocppStatus" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "transaction" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["action"],
+                "properties": {
+                  "action": { "type": "string", "enum": ["start", "stop"] },
+                  "tagId": { "type": "string" },
+                  "batteryCapacityKwh": { "type": "number" },
+                  "initialSoc": { "type": "number" },
+                  "stopReason": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "meterValue" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["value", "sendMessage"],
+                "properties": {
+                  "value": { "type": "number" },
+                  "sendMessage": { "type": "boolean" },
+                  "autoIncrement": { "type": "boolean" },
+                  "outputKw": { "type": "number" },
+                  "maxChargeKwh": { "type": "number" },
+                  "incrementInterval": { "type": "number" },
+                  "incrementAmount": { "type": "number" },
+                  "stopMode": {
+                    "type": "string",
+                    "enum": ["manual", "evSettings"]
+                  },
+                  "maxTime": { "type": "number" },
+                  "maxValue": { "type": "number" },
+                  "useCurve": { "type": "boolean" },
+                  "curvePoints": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/curvePoint" }
+                  },
+                  "autoCalculateInterval": { "type": "boolean" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "delay" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["delaySeconds"],
+                "properties": {
+                  "delaySeconds": { "type": "number" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "notification" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["messageType", "payload"],
+                "properties": {
+                  "messageType": { "type": "string" },
+                  "payload": { "type": "object" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "connectorPlug" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["action"],
+                "properties": {
+                  "action": { "type": "string", "enum": ["plugin", "plugout"] }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "remoteStartTrigger",
+                  "remoteStopTrigger",
+                  "reservationTrigger"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "data": {
+                "properties": {
+                  "timeout": { "type": "number" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "csmsCallTrigger" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["action"],
+                "properties": {
+                  "action": { "type": "string" },
+                  "timeout": { "type": "number" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "statusTrigger" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["targetStatus"],
+                "properties": {
+                  "targetStatus": { "$ref": "#/$defs/ocppStatus" },
+                  "timeout": { "type": "number" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "reserveNow" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["expiryMinutes", "idTag"],
+                "properties": {
+                  "expiryMinutes": { "type": "number" },
+                  "idTag": { "type": "string" },
+                  "parentIdTag": { "type": "string" },
+                  "reservationId": { "type": "number" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "cancelReservation" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["reservationId"],
+                "properties": {
+                  "reservationId": { "type": "number" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "start" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "properties": {
+                  "triggerOn": {
+                    "type": "string",
+                    "enum": ["connect", "status"]
+                  },
+                  "targetStatus": { "$ref": "#/$defs/ocppStatus" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "const": "statusNotification" } }
+          },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["status"],
+                "properties": {
+                  "status": { "$ref": "#/$defs/ocppStatus" },
+                  "errorCode": { "type": "string" },
+                  "info": { "type": "string" },
+                  "vendorErrorCode": { "type": "string" },
+                  "vendorId": { "type": "string" },
+                  "connectorId": { "type": "number" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "unlockOutcome" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["outcome"],
+                "properties": {
+                  "outcome": {
+                    "type": "string",
+                    "enum": ["Unlocked", "UnlockFailed", "NotSupported"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "configSet" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["key", "value"],
+                "properties": {
+                  "key": { "type": "string" },
+                  "value": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "dataTransfer" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["vendorId"],
+                "properties": {
+                  "vendorId": { "type": "string" },
+                  "messageId": { "type": "string" },
+                  "data": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "responseOverride" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "$comment": "Valid `status` values depend on `action` (see RESPONSE_OVERRIDE_STATUSES, ScenarioTypes.ts:855). Not schema-enforced here — advisory only.",
+                "required": ["action", "status"],
+                "properties": {
+                  "action": { "type": "string" },
+                  "status": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/cli/server/RegistryChargePointService.ts
+++ b/src/cli/server/RegistryChargePointService.ts
@@ -9,6 +9,7 @@ import {
   type ScenarioExecutionContext,
   type ScenarioMode,
 } from "../../cp/application/scenario/ScenarioTypes";
+import { validateScenarioSchema } from "../../scenario/scenarioSchemaValidator";
 import type { ScenarioRunResult } from "../../cp/application/verification/ScenarioAssertions";
 import type {
   HistoryOptions,
@@ -532,6 +533,13 @@ export class RegistryChargePointService implements ChargePointService {
     const parsed: unknown = JSON.parse(fs.readFileSync(path, "utf-8"));
     if (!isScenarioDefinitionShape(parsed)) {
       throw new Error(`file does not contain a scenario definition: ${path}`);
+    }
+    // Issue #214: advisory (warning-only) schema check — never blocks loading.
+    const schemaResult = validateScenarioSchema(parsed);
+    if (!schemaResult.valid) {
+      console.warn(
+        `[RegistryChargePointService] "${path}" does not match schema/scenario.schema.json (loading anyway): ${schemaResult.errors.slice(0, 5).join("; ")}`,
+      );
     }
     const scenarioId = service.loadScenario(connectorId, parsed);
     service.runScenario(connectorId, scenarioId);

--- a/src/cli/server/__tests__/socketServer.rpc.test.ts
+++ b/src/cli/server/__tests__/socketServer.rpc.test.ts
@@ -832,6 +832,89 @@ describe("socket.io rpc dispatch", () => {
       rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("issue #214: warns but still loads a schema-invalid (yet structurally valid) scenario file via load_scenario/run_scenario_file", async () => {
+    const bus = new EventBus();
+    const service = {
+      loadScenario: vi.fn().mockReturnValue("schema-warn-scenario"),
+      runScenario: vi.fn(),
+    };
+    const registry = {
+      get: vi.fn((cpId: string) => (cpId === "cp-alpha" ? service : undefined)),
+    };
+    const io = new FakeIo();
+    const socket = new FakeSocket();
+    const tmpDir = mkdtempSync(
+      join(tmpdir(), "ocpp-rpc-scenario-schema-warn-"),
+    );
+    // Structurally valid per isScenarioDefinitionShape (id/name/targetType/
+    // nodes[]/edges[]) but schema-invalid: delaySeconds must be a number.
+    const invalidSchemaFile = join(tmpDir, "invalid-schema.json");
+    writeFileSync(
+      invalidSchemaFile,
+      JSON.stringify({
+        id: "schema-invalid",
+        name: "Schema invalid",
+        targetType: "connector",
+        targetId: 1,
+        nodes: [
+          {
+            id: "wait",
+            type: "delay",
+            position: { x: 0, y: 0 },
+            data: { label: "Wait", delaySeconds: "not-a-number" },
+          },
+        ],
+        edges: [],
+      }),
+    );
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      registerSocketHandlers(io as never, {
+        registry: registry as never,
+        bus,
+        database: null,
+      });
+      io.connect(socket);
+
+      const loadAck = await socket.emitRpc({
+        cpId: "cp-alpha",
+        method: "load_scenario",
+        params: { connector: 1, file: invalidSchemaFile },
+      });
+      expect(loadAck).toMatchObject({ ok: true });
+      expect(service.loadScenario).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ id: "schema-invalid" }),
+      );
+
+      const runAck = await socket.emitRpc({
+        cpId: "cp-alpha",
+        method: "run_scenario_file",
+        params: { connector: 1, file: invalidSchemaFile },
+      });
+      expect(runAck).toMatchObject({
+        ok: true,
+        result: { scenarioId: "schema-warn-scenario" },
+      });
+      expect(service.runScenario).toHaveBeenCalledWith(
+        1,
+        "schema-warn-scenario",
+      );
+
+      expect(warnSpy).toHaveBeenCalled();
+      expect(
+        warnSpy.mock.calls.some((call) =>
+          String(call[0]).includes("schema/scenario.schema.json"),
+        ),
+      ).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 function simulatorConfig(

--- a/src/cli/server/__tests__/startupScenarioSchemaWarning.bun.test.ts
+++ b/src/cli/server/__tests__/startupScenarioSchemaWarning.bun.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startMockCsms } from "../../../cp/infrastructure/transport/__tests__/mockCsms";
+import { CLIChargePointService } from "../../service";
+import { runStartupScenario } from "../startServer";
+
+/**
+ * Issue #214: import-time schema validation is advisory (WARNING-ONLY) —
+ * a scenario file that fails `schema/scenario.schema.json` must still load
+ * and run exactly as before, just with a stderr warning. This exercises the
+ * real `runStartupScenario` entry point (the `--scenario-template-file`
+ * path, `src/cli/server/startServer.ts`) against a real mock CSMS, mirroring
+ * `startupScenarioBootGate.bun.test.ts`'s harness.
+ *
+ * The fixture's schema violation is `targetId` being a string instead of a
+ * number at the template root — deliberately chosen because
+ * `instantiateTemplate` overwrites `targetId` with the real connector id
+ * before the scenario is ever loaded/run, so the violation cannot affect
+ * runtime behavior; only the RAW template (as read from disk) is what gets
+ * schema-checked and warned about.
+ */
+describe("CLI startup-scenario schema warning (issue #214, advisory only)", () => {
+  it("warns to stderr but still loads and runs a schema-invalid --scenario-template-file", async () => {
+    const csms = startMockCsms();
+    const svc = new CLIChargePointService({
+      cpId: "cp214",
+      wsUrl: csms.url,
+      connectors: 1,
+      vendor: "Vendor",
+      model: "Model",
+      basicAuth: null,
+    });
+
+    const tmpDir = mkdtempSync(join(tmpdir(), "ocpp-scenario-schema-warn-"));
+    const templateFile = join(tmpDir, "invalid-schema-template.json");
+    writeFileSync(
+      templateFile,
+      JSON.stringify({
+        id: "schema-invalid-template",
+        name: "Schema invalid template",
+        targetType: "connector",
+        // Schema requires targetId: number — a string is a schema
+        // violation, but instantiateTemplate overwrites it per-connector
+        // before this ever reaches loadScenario/runScenario.
+        targetId: "not-a-number",
+        trigger: { type: "manual" },
+        nodes: [
+          {
+            id: "start",
+            type: "start",
+            position: { x: 0, y: 0 },
+            data: { label: "Start" },
+          },
+          {
+            id: "end",
+            type: "end",
+            position: { x: 0, y: 100 },
+            data: { label: "End" },
+          },
+        ],
+        edges: [{ id: "e1", source: "start", target: "end" }],
+      }),
+    );
+
+    const stderrLines: string[] = [];
+    const realWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      stderrLines.push(chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      await svc.connect();
+      const boot = await csms.waitForCall("BootNotification");
+
+      const runPromise = runStartupScenario(
+        svc,
+        {
+          scenario: null,
+          scenarioTemplate: null,
+          scenarioTemplateFile: templateFile,
+          scenarioConnector: "1",
+        },
+        1,
+      );
+
+      csms.replyCallResult(boot.messageId, {
+        currentTime: new Date().toISOString(),
+        interval: 300,
+        status: "Accepted",
+      });
+
+      await runPromise;
+
+      const warning = stderrLines.find((line) =>
+        line.includes("schema/scenario.schema.json"),
+      );
+      expect(warning).toBeDefined();
+      expect(warning).toContain(templateFile);
+      expect(warning).toContain("targetId");
+
+      // Still loaded and started despite the warning — advisory, never a gate.
+      const applied = stderrLines.find(
+        (line) =>
+          line.includes("Scenario template file") && line.includes("applied"),
+      );
+      expect(applied).toBeDefined();
+
+      const scenarios = svc.listScenarios(1);
+      expect(
+        scenarios.some((s) => s.name?.includes("Schema invalid template")),
+      ).toBe(true);
+    } finally {
+      process.stderr.write = realWrite;
+      svc.disconnect();
+      await csms.stop();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/server/socketServer.ts
+++ b/src/cli/server/socketServer.ts
@@ -52,6 +52,7 @@ import {
   type ScenarioDefinition,
   type ScenarioMode,
 } from "../../cp/application/scenario/ScenarioTypes";
+import { validateScenarioSchema } from "../../scenario/scenarioSchemaValidator";
 import type { AutoMeterValueConfig } from "../../cp/domain/connector/MeterValueCurve";
 import type { EVSettings } from "../../cp/domain/connector/EVSettings";
 import type { HistoryOptions } from "../../cp/application/services/types/StateSnapshot";
@@ -796,6 +797,21 @@ export function createSocketConfigRepository(
   return repository;
 }
 
+/**
+ * Issue #214: advisory (warning-only) schema check for a scenario value
+ * received over the `load_scenario` RPC. Never throws and never blocks
+ * loading — a schema mismatch is logged and the caller proceeds exactly as
+ * it would have before this check existed.
+ */
+function warnOnScenarioSchemaMismatch(source: string, value: unknown): void {
+  const result = validateScenarioSchema(value);
+  if (!result.valid) {
+    console.warn(
+      `[socketServer] "${source}" does not match schema/scenario.schema.json (loading anyway): ${result.errors.slice(0, 5).join("; ")}`,
+    );
+  }
+}
+
 async function dispatchFacadeCpCommand(
   chargePointService: RegistryChargePointService,
   method: RpcMethod,
@@ -1130,6 +1146,7 @@ async function dispatchFacadeCpCommand(
         if (!isScenarioDefinitionShape(parsed)) {
           throw new RpcFailure("invalid_params", "");
         }
+        warnOnScenarioSchemaMismatch(params.file, parsed);
         return handled(
           await runFacadeOperation(() =>
             chargePointService.loadScenario(id, connectorId, parsed),
@@ -1137,6 +1154,10 @@ async function dispatchFacadeCpCommand(
         );
       }
       if (params.scenario) {
+        warnOnScenarioSchemaMismatch(
+          "load_scenario params.scenario",
+          params.scenario,
+        );
         return handled(
           await runFacadeOperation(() =>
             chargePointService.loadScenario(

--- a/src/cli/server/startServer.ts
+++ b/src/cli/server/startServer.ts
@@ -5,6 +5,7 @@ import { CLIChargePointService } from "../service";
 type AnyServer = Server<unknown>;
 import type { ChargePointInitOptions } from "../types";
 import type { ScenarioDefinition } from "../../cp/application/scenario/ScenarioTypes";
+import { validateScenarioSchema } from "../../scenario/scenarioSchemaValidator";
 import { CPRegistry } from "./CPRegistry";
 import { EventBus } from "./eventBus";
 import { createLifecycle } from "./lifecycle";
@@ -300,6 +301,21 @@ function resolveConnectorIds(raw: string, connectorCount: number): number[] {
 }
 
 /**
+ * Issue #214: advisory (warning-only) schema check for a scenario file read
+ * from disk at startup. Never throws and never blocks loading — a schema
+ * mismatch is logged to stderr and the caller proceeds exactly as it would
+ * have before this check existed.
+ */
+function warnOnScenarioSchemaMismatch(source: string, value: unknown): void {
+  const result = validateScenarioSchema(value);
+  if (!result.valid) {
+    process.stderr.write(
+      `[server] Warning: "${source}" does not match schema/scenario.schema.json (loading anyway): ${result.errors.slice(0, 5).join("; ")}\n`,
+    );
+  }
+}
+
+/**
  * Start `scenarioId` unless it's already running. Loading a scenario
  * (loadScenario/loadScenarioTemplate) while the CP is already Available
  * synchronously triggers CLIChargePointService's own "connect"-trigger
@@ -399,6 +415,7 @@ export async function runStartupScenario(
       );
       return;
     }
+    warnOnScenarioSchemaMismatch(opt.scenarioTemplateFile, template);
     for (const connectorId of connectors) {
       try {
         const instance = instantiateTemplate(template, connectorId);
@@ -434,6 +451,7 @@ export async function runStartupScenario(
       );
       return;
     }
+    warnOnScenarioSchemaMismatch(opt.scenario, definition);
     for (const connectorId of connectors) {
       try {
         const instance =

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -368,9 +368,24 @@ export interface ScenarioTrigger {
 }
 
 /**
+ * Scenario file schema version (issue #214), mirroring the `"major.minor"`
+ * string convention and versioning rules of {@link
+ * ../../../trace/OcppTraceRecord.ts | OCPP_TRACE_SCHEMA_VERSION}: additive
+ * optional fields bump the minor version, consumers MUST ignore unknown
+ * fields, and a semantic change to an existing field is a new major version.
+ * See `schema/scenario.schema.json` (Draft 2020-12) and
+ * `docs/scenario-format.md`.
+ */
+export const SCENARIO_SCHEMA_VERSION = "1.0";
+
+/**
  * Scenario definition
  */
 export interface ScenarioDefinition {
+  /** Scenario schema version, e.g. {@link SCENARIO_SCHEMA_VERSION}. Optional:
+   *  absent on files exported before issue #214 (they remain valid — schema
+   *  conformance is advisory, never a hard gate). */
+  schemaVersion?: string;
   id: string;
   name: string;
   description?: string;

--- a/src/scenario/__tests__/scenarioSchema.conformance.test.ts
+++ b/src/scenario/__tests__/scenarioSchema.conformance.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { validateScenarioSchema } from "../scenarioSchemaValidator";
+
+/**
+ * Issue #214 — conformance test proving `schema/scenario.schema.json`
+ * accepts every scenario file this repo actually ships. This is the key
+ * test: it guards against schema drift (a field the schema doesn't know
+ * about, a required field the shipped templates don't carry, etc.) by
+ * running the real fixtures through the real validator, not hand-picked
+ * samples.
+ */
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+
+function jsonFilesIn(dir: string): string[] {
+  return readdirSync(dir)
+    .filter((name) => name.endsWith(".json"))
+    .map((name) => join(dir, name));
+}
+
+const fixturePaths = [
+  ...jsonFilesIn(join(repoRoot, "src/utils/scenarios")),
+  ...jsonFilesIn(join(repoRoot, "docs/examples/scenarios")),
+];
+
+describe("scenario schema conformance", () => {
+  it("finds a non-trivial number of shipped scenario fixtures", () => {
+    // Sanity guard: if this drops to 0 the test below would vacuously pass.
+    expect(fixturePaths.length).toBeGreaterThan(30);
+  });
+
+  it.each(fixturePaths.map((p) => [p] as const))(
+    "%s validates against schema/scenario.schema.json",
+    (path) => {
+      const data: unknown = JSON.parse(readFileSync(path, "utf-8"));
+      const result = validateScenarioSchema(data);
+      expect(result.errors).toEqual([]);
+      expect(result.valid).toBe(true);
+    },
+  );
+
+  it("validates every shipped fixture (aggregate count)", () => {
+    const results = fixturePaths.map((path) => ({
+      path,
+      ...validateScenarioSchema(
+        JSON.parse(readFileSync(path, "utf-8")) as unknown,
+      ),
+    }));
+    const failures = results.filter((r) => !r.valid);
+    expect(failures).toEqual([]);
+    // Prove the count, not just "no failures" (a moved/renamed fixtures dir
+    // would otherwise silently validate zero files).
+    expect(results.length).toBe(fixturePaths.length);
+  });
+});

--- a/src/scenario/__tests__/scenarioSchemaValidator.test.ts
+++ b/src/scenario/__tests__/scenarioSchemaValidator.test.ts
@@ -66,4 +66,59 @@ describe("validateScenarioSchema", () => {
     expect(result.valid).toBe(false);
     expect(result.errors.length).toBeGreaterThan(0);
   });
+
+  it("accepts a well-formed assertions array", () => {
+    const scenario = {
+      ...minimalScenario(),
+      assertions: [
+        {
+          id: "a1",
+          type: "ocpp_sent",
+          action: "BootNotification",
+          direction: "sent",
+          occurrence: 1,
+        },
+        {
+          id: "a2",
+          type: "message_after",
+          before: { action: "Authorize", direction: "sent" },
+          after: { action: "StartTransaction" },
+        },
+      ],
+    };
+    const result = validateScenarioSchema(scenario);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("rejects an assertion with an unknown type and a wrong-typed field", () => {
+    const scenario = {
+      ...minimalScenario(),
+      assertions: [
+        { id: "a1", type: "not_a_real_assertion", occurrence: "many" },
+      ],
+    };
+    const result = validateScenarioSchema(scenario);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it("is permissive about unknown fields on nodes, node data, and edges", () => {
+    // Real editor exports carry xyflow UI fields (width/selected/style/…) and
+    // sometimes un-stripped runtime keys on data — none must trip validation.
+    const scenario = minimalScenario();
+    const nodes = scenario.nodes as Array<Record<string, unknown>>;
+    nodes[0] = {
+      ...nodes[0],
+      width: 160,
+      selected: true,
+      data: { label: "Start", progress: 0.5, style: { color: "red" } },
+    };
+    const edges = scenario.edges as Array<Record<string, unknown>>;
+    edges[0] = { ...edges[0], selected: false, animated: true };
+
+    const result = validateScenarioSchema(scenario);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
 });

--- a/src/scenario/__tests__/scenarioSchemaValidator.test.ts
+++ b/src/scenario/__tests__/scenarioSchemaValidator.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { validateScenarioSchema } from "../scenarioSchemaValidator";
+
+function minimalScenario(): Record<string, unknown> {
+  return {
+    id: "s1",
+    name: "Minimal",
+    targetType: "connector",
+    nodes: [
+      {
+        id: "start",
+        type: "start",
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "end",
+        type: "end",
+        position: { x: 0, y: 100 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [{ id: "e1", source: "start", target: "end" }],
+  };
+}
+
+describe("validateScenarioSchema", () => {
+  it("accepts a known-good minimal scenario", () => {
+    const result = validateScenarioSchema(minimalScenario());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("rejects a wrong-typed node data field with an informative error", () => {
+    const scenario = minimalScenario();
+    (scenario.nodes as Array<{ type: string; data: unknown }>).push({
+      type: "delay",
+      data: { label: "Wait", delaySeconds: "x" },
+    });
+    // Give the pushed node the required id/position too.
+    const nodes = scenario.nodes as Array<Record<string, unknown>>;
+    nodes[2] = {
+      id: "wait",
+      type: "delay",
+      position: { x: 0, y: 200 },
+      data: { label: "Wait", delaySeconds: "x" },
+    };
+
+    const result = validateScenarioSchema(scenario);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors.some((e) => e.includes("delaySeconds"))).toBe(true);
+  });
+
+  it("accepts an unknown top-level field (additionalProperties: true)", () => {
+    const scenario = { ...minimalScenario(), someEditorOnlyField: "xyflow" };
+    const result = validateScenarioSchema(scenario);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("rejects a scenario missing id", () => {
+    const scenario = minimalScenario();
+    delete scenario.id;
+    const result = validateScenarioSchema(scenario);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/scenario/scenarioSchemaValidator.ts
+++ b/src/scenario/scenarioSchemaValidator.ts
@@ -1,0 +1,58 @@
+/**
+ * Advisory JSON Schema validation for scenario files (issue #214).
+ *
+ * Validates a parsed scenario value against `schema/scenario.schema.json`
+ * (Draft 2020-12). This is intentionally WARNING-ONLY: every call site that
+ * uses {@link validateScenarioSchema} logs the result and keeps loading the
+ * scenario regardless of `valid`. No existing scenario file — including
+ * ones authored before this schema existed — should ever fail to load
+ * because of a schema mismatch.
+ *
+ * Uses the same Ajv Draft 2020-12 build (`ajv/dist/2020`) already vendored
+ * for this project's generated OCPP payload schemas, with the same
+ * permissive compiler options as `src/ocpp/validate.ts` (allErrors so a
+ * single warning can list every problem, strict/strictSchema/validateFormats
+ * off to match the hand-authored, non-formats-heavy schema here).
+ */
+import Ajv2020 from "ajv/dist/2020";
+import type { ValidateFunction } from "ajv";
+import scenarioSchema from "../../schema/scenario.schema.json";
+
+export interface ScenarioSchemaValidationResult {
+  valid: boolean;
+  /** Short, human-readable messages, one per Ajv error (empty when valid). */
+  errors: string[];
+}
+
+const ajv = new Ajv2020({
+  allErrors: true,
+  strict: false,
+  strictSchema: false,
+  validateFormats: false,
+});
+
+let compiled: ValidateFunction | null = null;
+
+function getValidator(): ValidateFunction {
+  if (!compiled) {
+    compiled = ajv.compile(scenarioSchema);
+  }
+  return compiled;
+}
+
+/** Validate a parsed scenario value against the published scenario schema.
+ *  Never throws; a non-object/invalid value simply comes back `valid: false`
+ *  with Ajv's error list. Callers use this for advisory warnings only. */
+export function validateScenarioSchema(
+  value: unknown,
+): ScenarioSchemaValidationResult {
+  const validate = getValidator();
+  const valid = validate(value) === true;
+  if (valid) {
+    return { valid: true, errors: [] };
+  }
+  const errors = (validate.errors ?? []).map((error) =>
+    `${error.instancePath || "/"} ${error.message ?? ""}`.trim(),
+  );
+  return { valid: false, errors };
+}

--- a/src/utils/__tests__/scenarioFile.test.ts
+++ b/src/utils/__tests__/scenarioFile.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { parseScenarioJSON } from "../scenarioFile";
-import type { ScenarioDefinition } from "../../cp/application/scenario/ScenarioTypes";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { parseScenarioJSON, withScenarioSchemaVersion } from "../scenarioFile";
+import {
+  SCENARIO_SCHEMA_VERSION,
+  type ScenarioDefinition,
+} from "../../cp/application/scenario/ScenarioTypes";
+import { validateScenarioSchema } from "../../scenario/scenarioSchemaValidator";
 
 describe("parseScenarioJSON", () => {
   const createValidScenario = (
@@ -120,5 +124,84 @@ describe("parseScenarioJSON", () => {
     expect(() => parseScenarioJSON("42")).toThrow(
       "Invalid scenario file format",
     );
+  });
+
+  describe("schema validation (issue #214, advisory only)", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("warns via console.warn on a schema mismatch but still returns the scenario", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      // delaySeconds must be a number per schema/scenario.schema.json; this
+      // scenario is structurally valid (passes the existing guard above) but
+      // schema-invalid.
+      const scenario = createValidScenario({
+        nodes: [
+          {
+            id: "wait",
+            type: "delay",
+            position: { x: 0, y: 0 },
+            data: { label: "Wait", delaySeconds: "not-a-number" as never },
+          },
+        ],
+      });
+
+      const result = parseScenarioJSON(JSON.stringify(scenario));
+
+      expect(result.id).toBe("test-scenario");
+      expect(result.nodes).toHaveLength(1);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("schema/scenario.schema.json");
+    });
+
+    it("does not warn for a schema-valid scenario", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      parseScenarioJSON(JSON.stringify(createValidScenario()));
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("withScenarioSchemaVersion", () => {
+  const createValidScenario = (
+    overrides: Partial<ScenarioDefinition> = {},
+  ): ScenarioDefinition => ({
+    id: "test-scenario",
+    name: "Test Scenario",
+    targetType: "connector" as const,
+    nodes: [
+      {
+        id: "start",
+        type: "start",
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "end",
+        type: "end",
+        position: { x: 0, y: 100 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [{ id: "e-start-end", source: "start", target: "end" }],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  });
+
+  it("stamps SCENARIO_SCHEMA_VERSION without mutating the input", () => {
+    const scenario = createValidScenario();
+    const stamped = withScenarioSchemaVersion(scenario);
+
+    expect(stamped.schemaVersion).toBe(SCENARIO_SCHEMA_VERSION);
+    expect(scenario.schemaVersion).toBeUndefined();
+  });
+
+  it("produces a scenario that still validates against schema/scenario.schema.json", () => {
+    const stamped = withScenarioSchemaVersion(createValidScenario());
+    const result = validateScenarioSchema(stamped);
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
   });
 });

--- a/src/utils/scenarioFile.ts
+++ b/src/utils/scenarioFile.ts
@@ -1,4 +1,8 @@
-import type { ScenarioDefinition } from "../cp/application/scenario/ScenarioTypes";
+import {
+  SCENARIO_SCHEMA_VERSION,
+  type ScenarioDefinition,
+} from "../cp/application/scenario/ScenarioTypes";
+import { validateScenarioSchema } from "../scenario/scenarioSchemaValidator";
 
 /**
  * Browser-only file I/O helpers for scenario JSON files. Lifted out of
@@ -7,10 +11,24 @@ import type { ScenarioDefinition } from "../cp/application/scenario/ScenarioType
  * to/from a `<a download>` Blob and a user-picked `File`.
  */
 
+/** Stamp the current {@link SCENARIO_SCHEMA_VERSION} onto a scenario without
+ *  mutating the input (issue #214). Exported separately from
+ *  {@link exportScenarioToJSON} so the stamping behavior is unit-testable
+ *  without a DOM (Blob/download) environment. */
+export function withScenarioSchemaVersion(
+  scenario: ScenarioDefinition,
+): ScenarioDefinition {
+  return { ...scenario, schemaVersion: SCENARIO_SCHEMA_VERSION };
+}
+
 /** Trigger a file download for the given scenario. The filename is
- *  `scenario_<name>_<timestamp>.json` so multiple exports don't collide. */
+ *  `scenario_<name>_<timestamp>.json` so multiple exports don't collide.
+ *  Stamps the current {@link SCENARIO_SCHEMA_VERSION} onto the exported
+ *  file (issue #214) so newly-exported scenarios declare their format
+ *  version; the in-memory `scenario` object passed in is not mutated. */
 export function exportScenarioToJSON(scenario: ScenarioDefinition): void {
-  const json = JSON.stringify(scenario, null, 2);
+  const withSchemaVersion = withScenarioSchemaVersion(scenario);
+  const json = JSON.stringify(withSchemaVersion, null, 2);
   const blob = new Blob([json], { type: "application/json" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
@@ -24,7 +42,13 @@ export function exportScenarioToJSON(scenario: ScenarioDefinition): void {
 
 /** Parse and validate a scenario from JSON text. Throws on invalid structure —
  *  rejects non-objects, requires a non-empty string `id`, and requires `nodes`
- *  and `edges` to be arrays (truthiness alone would accept `nodes: {}` etc.). */
+ *  and `edges` to be arrays (truthiness alone would accept `nodes: {}` etc.).
+ *
+ *  Issue #214: additionally runs the imported value through the published
+ *  `schema/scenario.schema.json` and, on a mismatch, logs a `console.warn`
+ *  listing the first few errors. This is ADVISORY ONLY — unlike the
+ *  structural checks above, a schema mismatch never throws; the scenario is
+ *  still returned and loads exactly as before. */
 export function parseScenarioJSON(text: string): ScenarioDefinition {
   const parsed: unknown = JSON.parse(text);
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
@@ -38,6 +62,12 @@ export function parseScenarioJSON(text: string): ScenarioDefinition {
     !Array.isArray(scenario.edges)
   ) {
     throw new Error("Invalid scenario file format");
+  }
+  const schemaResult = validateScenarioSchema(parsed);
+  if (!schemaResult.valid) {
+    console.warn(
+      `[scenarioFile] Imported scenario "${scenario.id}" does not match schema/scenario.schema.json (loading anyway): ${schemaResult.errors.slice(0, 5).join("; ")}`,
+    );
   }
   return scenario as ScenarioDefinition;
 }

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -41,6 +41,7 @@
     "src/data/sqlite/SqliteConnectorSettingsRepository.ts",
     "src/ocpp",
     "src/protocol",
+    "src/scenario",
     "src/store/store.ts",
     "src/trace",
     "src/utils/scenarioTemplates.ts"


### PR DESCRIPTION
Closes #214.

Publishes a versioned JSON Schema for the scenario file format, so it becomes a stable, implementation-independent contract (validation, IDE autocompletion, external authoring/tooling, DSLs) instead of being described only by the TypeScript `ScenarioDefinition` interface.

Scope is deliberately **contract + advisory validation**: the schema is published and wired at import points as a **warning**, never a hard gate — no existing scenario file changes how it loads. Turning the warnings into a rejecting gate, and unifying the runtime guards onto a single zod-derived source of truth, are natural follow-ups.

## What this adds

- **`schema/scenario.schema.json`** — Draft 2020-12, hand-authored (following the `docs/trace-format.md` precedent). Covers the full node graph: all 20 node types as a `type`-discriminated union (`if/then` per type), the `OCPPStatus`/action/outcome/trigger enums, edges, `evSettings`, `trigger`, and `assertions`. **Strict on known fields and enums, permissive on unknowns** (`additionalProperties: true` at root/node/data/edge) so real editor exports carrying xyflow UI fields (`width`, `selected`, `style`, …) still validate. `createdAt`/`updatedAt` are optional in the schema (most shipped templates omit them).
- **`schemaVersion`** — a new optional top-level field (`SCENARIO_SCHEMA_VERSION = "1.0"`, string "major.minor", same versioning rules as the trace format). Optional so every existing file stays valid; `exportScenarioToJSON` now stamps it on newly exported scenarios.
- **`src/scenario/scenarioSchemaValidator.ts`** — compiles the schema once (lazy singleton) with the same ajv setup as `src/ocpp/validate.ts` (Draft 2020-12 via `ajv/dist/2020`; no new dependency), returning `{ valid, errors }`. Browser-safe (no node-only imports).
- **Advisory wiring** — import points now validate and **warn** (then load unchanged): the browser upload path (`parseScenarioJSON`), `--scenario-template-file` / `--scenario` (CLI, to stderr), and the `load_scenario` / `run_scenario_file` socket RPCs (server log). Existing structural guards are untouched; the schema check is additive.
- **`docs/scenario-format.md`** — documents the format, `schemaVersion` + versioning rules, a node-type table, and that import validation is advisory in this version.
- **Packaging** — the schema and `src/scenario` are added to `package.json` `files` and guarded in `cli-release.yml`, so external tools can depend on the versioned schema shipped with releases.

## Tests

- **Conformance test** — validates **all 55 shipped scenario fixtures** (`src/utils/scenarios/*.json` + `docs/examples/scenarios/*.json`, which between them exercise all 20 node types) against the schema, proving it accepts real data and guarding against drift.
- Validator unit tests: known-good minimal scenario; wrong-typed field (`delaySeconds: "x"`) rejected with an informative error; unknown top-level field accepted; missing `id` rejected; well-formed `assertions` accepted; bad assertion (unknown type + wrong-typed field) rejected; node/data/edge-level unknown fields accepted.
- Advisory-wiring test (bun): a startup scenario that fails schema validation warns but still loads.
- Export stamping tested via a pure `withScenarioSchemaVersion` helper.

## Verification

- `vitest` 1456/1456 green (incl. the 55-fixture conformance test); `bun test bun.test` 225/225 green; `tsc -b` baseline unchanged (0 new); eslint/prettier clean.
- `vite build` succeeds; browser main chunk grows **+7.1 KB gzip** (~1.3%) — ajv's base build was already bundled via `src/ocpp/validate.ts`; this adds the `ajv/dist/2020` build + the schema JSON. (The ajv/schema code currently lands in the main chunk rather than the lazy editor chunk — noted as a possible later optimization.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scenario File Format v1.0 with a published JSON Schema.
  * Added advisory scenario validation across imports, startup, and server RPCs.
  * Scenario schema mismatches now produce warnings without blocking execution.
  * Exported scenarios now include the schema version.

* **Documentation**
  * Documented scenario structure, validation behavior, versioning, and supported fields.
  * Clarified scenario template and RPC parameter requirements.

* **Bug Fixes**
  * Improved CLI packaging checks to ensure scenario validation resources are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->