### PR TITLE
fix(footer): stamp the short SHA on Pages builds so the version isn't blank (#93)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,8 +43,13 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: bun install --frozen-lockfile
+      # Pages builds from `main`, not a tag, so package.json stays 0.0.0 and the
+      # footer would render no build identifier. Stamp the short SHA instead —
+      # it's what actually identifies a rolling deploy (issue #93).
       - name: Build
         run: VITE_BASE_URL="/ocpp-cp-simulator" bun run build
+        env:
+          APP_COMMIT: ${{ github.sha }}
       - name: Copy index.html to 404.html for SPA routing
         run: cp dist/index.html dist/404.html
       - name: Upload Pages artifact

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -24,12 +24,21 @@ const GithubMark: React.FC<{ className?: string }> = ({ className }) => (
  * The version is injected at build time (`__APP_VERSION__`, see vite.config).
  * It's hidden for the unstamped dev default ("0.0.0") so we never show a
  * meaningless "v0.0.0".
+ *
+ * Only tag-triggered builds (Docker / Tauri / CLI release) carry a semver. The
+ * GitHub Pages deploy builds from `main`, so it stamps `__APP_COMMIT__` with
+ * the short SHA instead and we fall back to that — otherwise Pages would show
+ * no build identifier at all.
  */
 const Footer: React.FC = () => {
+  const commit =
+    typeof __APP_COMMIT__ !== "undefined" && __APP_COMMIT__ !== ""
+      ? __APP_COMMIT__
+      : null;
   const version =
     typeof __APP_VERSION__ !== "undefined" && __APP_VERSION__ !== "0.0.0"
       ? `v${__APP_VERSION__}`
-      : null;
+      : commit;
 
   return (
     <footer className="mt-auto border-t border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-800/60 px-4 py-2">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,3 +2,9 @@
 
 /** App version injected at build time from package.json (see vite.config.ts). */
 declare const __APP_VERSION__: string;
+
+/**
+ * Short commit SHA injected at build time from $APP_COMMIT (see vite.config.ts).
+ * Empty unless the build sets it — only the GitHub Pages deploy does.
+ */
+declare const __APP_COMMIT__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,12 +10,20 @@ const pkgVersion = JSON.parse(
   readFileSync(new URL("./package.json", import.meta.url), "utf-8"),
 ).version as string;
 
+// The GitHub Pages deploy builds from `main`, not a tag, so there is no semver
+// to stamp into package.json (`npm version` only takes semver anyway). It sets
+// APP_COMMIT instead and the footer falls back to the short SHA, which is what
+// actually identifies a rolling deploy. Truncated here rather than in the
+// workflow because GitHub expressions can't substring `github.sha`.
+const appCommit = (process.env.APP_COMMIT ?? "").slice(0, 7);
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   base: process.env.VITE_BASE_URL || "./",
   define: {
     __APP_VERSION__: JSON.stringify(pkgVersion),
+    __APP_COMMIT__: JSON.stringify(appCommit),
   },
   // The Tauri dev shell pins its devUrl to this port; if some unrelated
   // Vite server already holds 5173 we don't want to silently float to


### PR DESCRIPTION
## Problem

The GitHub Pages deployment renders `ocpp-cp-simulator · GitHub` with no build identifier between the name and the link.

`Footer.tsx` hides the version when `__APP_VERSION__` is the unstamped `"0.0.0"` default, so a build identifier only appears when something stamps `package.json`. Only the tag-triggered workflows do that:

| workflow | stamps version | trigger |
|---|---|---|
| `release.yml` | yes | `refs/tags/*` |
| `docker-publish.yml` | yes | `refs/tags/*` |
| `cli-release.yml` | yes | tag |
| **`deploy.yml` (Pages)** | **no** | `push: main` |

Pages builds from a push to `main`, where there is no tag to derive a semver from — so it has always shipped unstamped.

## Fix

`npm version` only accepts semver, so a commit SHA can't reuse that path. Instead:

- `vite.config.ts` — new `__APP_COMMIT__` define fed by `$APP_COMMIT`, truncated to 7 chars (GitHub expressions can't substring `github.sha`, so it's done here rather than in the workflow)
- `deploy.yml` — passes `APP_COMMIT: ${{ github.sha }}` to the build step
- `Footer.tsx` — falls back to the SHA when the semver is unstamped
- `vite-env.d.ts` — type declaration

Tag-triggered builds are unaffected: they carry a real semver, which still wins. Local dev sets neither, so the footer stays version-less as before.

## Verification

Checked against the actual build output rather than a unit test, since `__APP_COMMIT__` is a build-time define that `vi.stubGlobal` can't reach (it's already replaced by a literal at transform time):

- with `APP_COMMIT` → footer emits `jsx("span",{children:"534228f"})`, truncated to 7 chars as intended
- without `APP_COMMIT` → the span is `null`, preserving current dev behavior

Gates: eslint clean · vitest 117 files / 1216 pass · `bun test bun.test` 221 pass, 0 fail.

The `tsc -b` error on `vite.config.ts` (`TS2769` on `plugins: [react()]`) is pre-existing — confirmed it reproduces on `main` at the same line, it's the vite/vitest duplicate-vite type conflict and unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added build identification using a short commit identifier.
  * The footer now displays the commit identifier when a release version is unavailable or defaults to `0.0.0`.

* **Bug Fixes**
  * Improved build and deployment labeling for GitHub Pages deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->