### PR TITLE
fix(docker): ship schema/, src/scenario and src/trace in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,12 @@ COPY src ./src
 # build time, so the vendor tree must be present or `bun run build` fails
 # with "Could not resolve ../../../vendor/ocpp-schemas/...".
 COPY vendor ./vendor
+# src/scenario/scenarioSchemaValidator.ts imports the scenario JSON Schema
+# (../../schema/scenario.schema.json, #214) and reaches the browser bundle via
+# src/utils/scenarioFile.ts -> ScenarioLibraryPage. Vite resolves that JSON
+# import at build time, so schema/ must be present or `bun run build` fails
+# with "[UNRESOLVED_IMPORT] Could not resolve ../../schema/scenario.schema.json".
+COPY schema ./schema
 
 # VITE_HEALTH_PATH is read by src/data/healthPath.ts at build time and
 # inlined into the bundle so the static UI knows which path to probe for
@@ -103,6 +109,18 @@ COPY src/data ./src/data
 # scenarioTemplates.ts left the daemon crashing on boot with
 # "Cannot find module './scenarios/essential-cp-behavior.json'".
 COPY src/utils ./src/utils
+# src/cli/server/{socketServer,startServer,RegistryChargePointService}.ts all
+# statically import ../../scenario/scenarioSchemaValidator (#214), which in turn
+# imports ../../schema/scenario.schema.json. Both must ship or the daemon
+# crashes on boot with "Cannot find module '../../scenario/
+# scenarioSchemaValidator'" — the same class of miss as src/protocol and
+# src/utils above. package.json's `files` already lists them for the npm
+# package; this keeps the image in step.
+COPY src/scenario ./src/scenario
+COPY schema ./schema
+# src/cli/analyze/runAnalyze.ts imports ../../trace/analysisDisclaimer (#188),
+# so the `analyze` subcommand's module graph is pulled in on CLI startup.
+COPY src/trace ./src/trace
 
 # Built-in scenario examples — kept handy under /app/docs.
 COPY docs/examples/scenarios ./docs/examples/scenarios


### PR DESCRIPTION
## Problem

The **Build & publish Docker image** workflow has been failing since #214 — on `main` and on the `v0.7.1` tag, so the v0.7.1 image never published.

The `ui` stage copies `index.html`, the configs, `public/`, `src/` and `vendor/` — but not `schema/`:

```
[UNRESOLVED_IMPORT] Could not resolve '../../schema/scenario.schema.json'
  in src/scenario/scenarioSchemaValidator.ts
  imported by src/utils/scenarioFile.ts -> ScenarioLibraryPage -> ... -> index.html
```

No PR job runs `vite build`, so this can only surface in the Docker build (Pages does its own checkout from the repo root, where `schema/` exists).

The runtime stage was missing more. It enumerates the subtrees the daemon needs, and two never got added:

| missing | why it's needed |
|---|---|
| `src/scenario` + `schema/` | `socketServer.ts`, `startServer.ts`, `RegistryChargePointService.ts` all statically import `../../scenario/scenarioSchemaValidator` (#214) |
| `src/trace` | `src/cli/analyze/runAnalyze.ts` imports `../../trace/analysisDisclaimer` (#188) |

With only the `ui` stage fixed the daemon still died on boot with `Cannot find module '../../trace/analysisDisclaimer'`.

`package.json`'s `files` already lists `src/scenario` and `schema` for the npm package — the image had just fallen out of step.

## Approach

Rather than fixing one boot crash at a time, I walked the static import graph from `src/cli/main.ts` (993 files) to get the full set. It reaches `schema/`, `vendor/` and `src/{cli,cp,data,ocpp,protocol,scenario,store,trace,utils}`.

`src/store` is reached **only** through `import type { Config }` (4 call sites, all type-only), so it's erased at runtime and deliberately stays out of the image.

## Verification

Real Docker builds, not just inspection:

- `docker build --target ui` — succeeds (previously the failing step)
- full image builds, container reaches `Up (healthy)`
- `GET /v1/healthz` → 200, console served with the right `<title>`
- inside the container, `scenarioSchemaValidator` imports **and** validates a document against the shipped schema — proving `schema/scenario.schema.json` actually landed, not just that the module resolved
- `src/trace/analysisDisclaimer` imports cleanly

## Follow-up worth considering

This is the fourth time this class of bug has shipped (`src/protocol`, `src/utils`, and now `src/scenario`/`src/trace` — each documented in a Dockerfile comment). A CI job that builds the image and boots it would catch it at PR time instead of at release. Happy to open a separate issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application build reliability by ensuring required scenario validation resources are included.
  * Fixed runtime packaging issues that could prevent the CLI and daemon from starting correctly.
  * Preserved access to scenario validation and trace-related functionality in deployed builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->