### PR TITLE
fix(release): attach desktop binaries to the published release, not a new draft

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -69,7 +69,7 @@ template: |
 
   - **macOS (Apple Silicon)**: `OCPP.CP.Simulator_*_aarch64.dmg`
   - **macOS (Intel)**: `OCPP.CP.Simulator_*_x64.dmg`
-  - **Windows**: `OCPP.CP.Simulator_*_x64-setup.exe` or `.msi`
+  - **Windows**: `OCPP.CP.Simulator_*_x64-setup.exe` or `OCPP.CP.Simulator_*_x64_en-US.msi`
   - **Linux (Debian/Ubuntu)**: `OCPP.CP.Simulator_*_amd64.deb`
   - **Linux (Fedora/RHEL)**: `OCPP.CP.Simulator-*.x86_64.rpm`
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -61,5 +61,21 @@ template: |
 
   **Full Changelog**: https://github.com/$OWNER/$REPO/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 
+  ### Desktop App Downloads
+
+  Attached by release.yml a few minutes after this release is published — the
+  tag created on publish is what starts the desktop builds, so the assets show
+  up shortly after, not instantly.
+
+  - **macOS (Apple Silicon)**: `OCPP.CP.Simulator_*_aarch64.dmg`
+  - **macOS (Intel)**: `OCPP.CP.Simulator_*_x64.dmg`
+  - **Windows**: `OCPP.CP.Simulator_*_x64-setup.exe` or `.msi`
+  - **Linux (Debian/Ubuntu)**: `OCPP.CP.Simulator_*_amd64.deb`
+  - **Linux (Fedora/RHEL)**: `OCPP.CP.Simulator-*.x86_64.rpm`
+
+  ### Web Version
+
+  https://shiv3.github.io/ocpp-cp-simulator/
+
   ---
   Container image: `ghcr.io/$OWNER/$REPO:$RESOLVED_VERSION` (published when this release is tagged).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,63 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Resolve which release the binaries belong to, ONCE, before the matrix fans
+  # out. tauri-action is then handed a `releaseId` and acts as a pure asset
+  # uploader — see the comment on its step below for why it must not be allowed
+  # to resolve the release itself.
+  resolve-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      release_id: ${{ steps.find.outputs.release_id }}
+    steps:
+      - name: Find (or create) the release for this tag
+        id: find
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // workflow_dispatch runs off a branch, not a tag. Leave the id
+            // empty: tauri-action then has neither releaseId nor tagName and
+            // logs "skipping all uploads", so a manual run still smoke-builds
+            // the desktop app without inventing a release for a branch ref.
+            if (!context.ref.startsWith('refs/tags/')) {
+              core.notice(`${context.ref} is not a tag; building without uploading.`);
+              return;
+            }
+
+            const tag = context.ref.replace('refs/tags/', '');
+
+            // Normally release-drafter's draft was just published — that is
+            // what created this tag — so the release already exists.
+            // listReleases rather than getReleaseByTag so a draft is still
+            // found if a tag somehow exists without a published release.
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            let release = releases.find((r) => r.tag_name === tag);
+
+            // Fallback: the tag was pushed directly instead of by publishing a
+            // drafter release. Create one so the binaries have somewhere to go
+            // rather than failing the build.
+            if (!release) {
+              core.warning(`No release for ${tag}; creating one.`);
+              const created = await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                name: tag,
+                generate_release_notes: true,
+              });
+              release = created.data;
+            }
+
+            core.setOutput('release_id', String(release.id));
+
   release:
+    needs: resolve-release
     permissions:
       contents: write
     strategy:
@@ -120,27 +176,29 @@ jobs:
           # for the cross-compiled x86_64 macOS build).
           TAURI_TARGET: ${{ matrix.target }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: "OCPP CP Simulator ${{ github.ref_name }}"
-          # `releaseDraft: false` is load-bearing. By the time this workflow
-          # runs, the release for this tag is ALREADY PUBLISHED — publishing
-          # release-drafter's rolling draft is what creates the tag that
-          # triggers us. With `true`, tauri-action ignored that published
-          # release and parked the binaries in a NEW draft instead. Release
-          # Drafter then adopted that leftover draft on the next merge to main
-          # (it updates the newest existing draft rather than making its own),
-          # renamed it to the next version, and the operator published it — so
-          # every release shipped the PREVIOUS version's binaries: v0.7.2 got
-          # 0.7.1's, v0.7.1 got 0.7.0's, and v0.7.0 got none at all. Same class
-          # of bug as #121, where two mechanisms both drove Pages deploys.
-          releaseDraft: false
-          # No `releaseBody`: release-drafter owns the notes (its template
-          # already emits "## What's Changed", which update-release-notes below
-          # keys off to inject the commit list). Passing a body here would
-          # clobber those categorized notes with a static blurb. The download
-          # table that used to live here now lives in the drafter template, so
-          # it lands on every release regardless of who created it.
-          prerelease: false
+          # Pass `releaseId` and NOT `tagName`. In tauri-action's index.ts the
+          # release-resolving branch is `if (tagName && !releaseId)`, so an id
+          # skips it entirely and the action only uploads assets. That matters
+          # for two reasons:
+          #
+          # 1. With `tagName` + `releaseDraft: true` (the old config) it ignored
+          #    the already-published release for this tag and parked the
+          #    binaries in a NEW draft. Release Drafter then adopted that
+          #    leftover draft on the next merge to main, renamed it to the next
+          #    version, and the operator published it — so every release shipped
+          #    the PREVIOUS version's binaries: v0.7.2 got 0.7.1's, v0.7.1 got
+          #    0.7.0's, v0.7.0 got none at all.
+          # 2. With `tagName` + `releaseDraft: false` it finds the published
+          #    release and calls updateRelease with `body: bodyFileContent ||
+          #    body` (create-release.ts). An omitted `releaseBody` is "", so it
+          #    would blank release-drafter's notes — five times over, once per
+          #    matrix leg.
+          #
+          # An id sidesteps both: the release is resolved once in
+          # resolve-release, and nothing here creates, renames or rewrites it.
+          # Same class of bug as #121, where two mechanisms both drove Pages
+          # deploys.
+          releaseId: ${{ needs.resolve-release.outputs.release_id }}
           args: ${{ matrix.args }}
 
   update-release-notes:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,11 +193,20 @@ jobs:
                 const commitList = diff.commits
                   .map((c) => `- ${c.commit.message.split('\n')[0]} (${c.sha.substring(0, 7)})`)
                   .join('\n');
+                // Normally the body came from release-drafter and already has
+                // a "## What's Changed" heading to slot the commits under. But
+                // if a tag is pushed directly rather than by publishing a
+                // drafter release, tauri-action creates the release itself with
+                // an empty body — so add the heading instead of silently
+                // dropping the commit list.
+                const section = `### Commits (since ${prev.tag_name})\n${commitList}\n`;
                 if (commitList && body.includes("## What's Changed")) {
                   body = body.replace(
                     "## What's Changed",
-                    `## What's Changed\n\n### Commits (since ${prev.tag_name})\n${commitList}\n`,
+                    `## What's Changed\n\n${section}`,
                   );
+                } else if (commitList) {
+                  body = `${body}${body ? '\n\n' : ''}## What's Changed\n\n${section}`;
                 }
               } catch (e) {
                 core.warning(`Failed to get commit history: ${e.message}`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,21 +122,24 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "OCPP CP Simulator ${{ github.ref_name }}"
-          releaseBody: |
-            See the assets to download this version and install.
-
-            ## What's Changed
-
-            ### Desktop App Downloads
-            - **macOS (Apple Silicon)**: `OCPP.CP.Simulator_*_aarch64.dmg`
-            - **macOS (Intel)**: `OCPP.CP.Simulator_*_x64.dmg`
-            - **Windows**: `OCPP.CP.Simulator_*_x64-setup.exe` or `.msi`
-            - **Linux (Debian/Ubuntu)**: `OCPP.CP.Simulator_*_amd64.deb`
-            - **Linux (Fedora/RHEL)**: `OCPP.CP.Simulator-*.x86_64.rpm`
-
-            ### Web Version
-            The web version is available at: https://shiv3.github.io/ocpp-cp-simulator/
-          releaseDraft: true
+          # `releaseDraft: false` is load-bearing. By the time this workflow
+          # runs, the release for this tag is ALREADY PUBLISHED — publishing
+          # release-drafter's rolling draft is what creates the tag that
+          # triggers us. With `true`, tauri-action ignored that published
+          # release and parked the binaries in a NEW draft instead. Release
+          # Drafter then adopted that leftover draft on the next merge to main
+          # (it updates the newest existing draft rather than making its own),
+          # renamed it to the next version, and the operator published it — so
+          # every release shipped the PREVIOUS version's binaries: v0.7.2 got
+          # 0.7.1's, v0.7.1 got 0.7.0's, and v0.7.0 got none at all. Same class
+          # of bug as #121, where two mechanisms both drove Pages deploys.
+          releaseDraft: false
+          # No `releaseBody`: release-drafter owns the notes (its template
+          # already emits "## What's Changed", which update-release-notes below
+          # keys off to inject the commit list). Passing a body here would
+          # clobber those categorized notes with a static blurb. The download
+          # table that used to live here now lives in the drafter template, so
+          # it lands on every release regardless of who created it.
           prerelease: false
           args: ${{ matrix.args }}
 
@@ -156,11 +159,12 @@ jobs:
           script: |
             const tag = context.ref.replace('refs/tags/', '');
 
-            // tauri-action creates the release as a draft, and
-            // getReleaseByTag() (GET /releases/tags/{tag}) does NOT return
-            // draft releases — it 404s, which failed this whole job on every
-            // release. List releases (which includes drafts) and match on
-            // tag_name instead.
+            // Match on tag_name from listReleases rather than
+            // getReleaseByTag(). The release is published by the time we run
+            // (see releaseDraft above), so getReleaseByTag() would now work —
+            // but listReleases also surfaces drafts, which keeps this job
+            // working if a tag is ever pushed directly without publishing a
+            // drafter release first.
             const releases = await github.paginate(github.rest.repos.listReleases, {
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Problem

Every release ships the **previous** version's desktop binaries.

| release | attached binaries |
|---|---|
| v0.7.2 | ❌ `0.7.1` × 8 |
| v0.7.1 | ❌ `0.7.0` × 8 |
| v0.7.0 | ❌ none |
| leftover draft (unpublished) | `0.7.2` × 8 |

## Root cause

Two mechanisms were both managing "the draft release".

The intended flow: release-drafter keeps a rolling draft on `main`; publishing it creates the `vX.Y.Z` tag; that tag triggers this workflow. **So by the time the desktop build runs, the release is already published.**

But tauri-action had `releaseDraft: true`. Rather than attaching to that published release, it created a *new* draft and parked the binaries there. Release Drafter then adopted the leftover draft on the next merge to `main` — it updates the newest existing draft rather than creating its own — renamed it to the next version, and the operator published it, binaries and all, one version stale.

### Evidence, not inference

- The assets on the published v0.7.2 were uploaded **08:19–08:23**, inside the **v0.7.1** build window (08:14:56–08:24:07). The v0.7.2 build (09:13–09:22) uploaded nothing to it.
- That release carries release-drafter's `v0.7.2` name (its template is `v$RESOLVED_VERSION`) while holding tauri-action's output — whose own naming is `OCPP CP Simulator $tag`. So the draft really was created by one mechanism and renamed by the other.
- The still-unpublished draft holding the correct `0.7.2` binaries is named `OCPP CP Simulator v0.7.2` — tauri-action's format, not yet renamed because no merge to `main` has happened since.
- v0.7.0 has no assets because it was the first turn of the cycle, with no leftover draft to inherit.

Same class of bug as #121, where two mechanisms both drove Pages deploys.

> Careful reading the API: a release's `created_at` is the **tagged commit's date**, not when the release object was created. The timeline looks contradictory until you account for that.

## Fix

- `releaseDraft: false` — tauri-action uploads into the release the tag already points at, leaving nothing for the drafter to adopt.
- Drop `releaseBody` — release-drafter owns the notes (its template already emits `## What's Changed`, which the `update-release-notes` job keys off to inject the commit list). A body passed here would clobber those categorized notes with a static blurb.
- The download table that lived in `releaseBody` moves into the drafter template, so it lands on every release regardless of which mechanism created it.
- Refresh the now-stale comment in `update-release-notes` about drafts being invisible to `getReleaseByTag()`.

## Verification

**Static only** — both files parse as YAML and are prettier-clean. I could not exercise the behaviour without cutting a real release, so I'm not claiming it's proven.

The next release is the test. Watch for:
1. binaries land on the published release itself, with matching version numbers
2. no stray draft is left behind afterwards
3. the release notes keep release-drafter's categorized `## What's Changed` plus the injected commit list

## Not included

The already-published v0.7.2 still carries 0.7.1's binaries. The correct `0.7.2` assets exist in the leftover draft, so fixing it needs no rebuild — but swapping assets on a public release is outward-facing and hard to undo, so I've left it for a deliberate decision rather than bundling it here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Release notes now link directly to the web version.
  - Updated the release template to add a “Desktop App Downloads” section and a “Web Version” subsection, with clearer artifact guidance for macOS (Intel/Apple Silicon), Windows, and Linux.
- **Chores**
  - Improved the release workflow to resolve/create releases before building, ensuring download links and notes are included reliably.
  - Made release-note updates more resilient by updating or adding the “What’s Changed” section when it’s missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->