### PR TITLE
fix(release-drafter): use $REPOSITORY, not $REPO, in the notes template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -59,7 +59,7 @@ template: |
 
   $CHANGES
 
-  **Full Changelog**: https://github.com/$OWNER/$REPO/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 
   ### Desktop App Downloads
 
@@ -78,4 +78,4 @@ template: |
   https://shiv3.github.io/ocpp-cp-simulator/
 
   ---
-  Container image: `ghcr.io/$OWNER/$REPO:$RESOLVED_VERSION` (published when this release is tagged).
+  Container image: `ghcr.io/$OWNER/$REPOSITORY:$RESOLVED_VERSION` (published when this release is tagged).


### PR DESCRIPTION
## Problem

The notes template referenced `$REPO`, which release-drafter doesn't define, so it was emitted literally. Every release has shipped two broken references:

```
**Full Changelog**: https://github.com/shiv3/$REPO/compare/v0.7.1...v0.7.2
Container image: `ghcr.io/shiv3/$REPO:0.7.2`
```

The changelog link 404s and the image reference isn't pullable. `$OWNER` resolved correctly right next to it, which is what made this easy to miss.

## Fix

The documented variable is **`$REPOSITORY`** — [README table](https://github.com/release-drafter/release-drafter#template-variables), substituted in `build-release-payload.ts` alongside `$OWNER` from `context.repo.repo`.

## Scope

Pre-existing, not introduced by #227. Confirmed on the published v0.7.1 and v0.7.2 bodies, and the pending v0.7.3 draft has it too.

Merging this re-runs the drafter on `main`, which regenerates the v0.7.3 draft body — so **v0.7.3 picks up the fix before it's published**.

The two already-published releases still carry the broken text. Editing their bodies is a separate call since they're public, so I've left them alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected generated release links so full changelogs and container image references point to the correct repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->