### PR TITLE
build(deps): group major updates into the weekly per-ecosystem PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,11 @@
 #                      comments together.
 #   * docker         — the oven/bun base image in the Dockerfile.
 #
-# Non-major updates are grouped into a single weekly PR per ecosystem to keep
-# the review load low; majors still come as individual PRs so breaking changes
-# get their own scrutiny.
+# Every update — majors included — is grouped into a single weekly PR per
+# ecosystem to keep the review load low. Omitting `update-types` from a group
+# is what pulls majors in; splitting them out again just means three or four
+# PRs land the same morning, and the breaking change gets read no more closely
+# for having its own branch. Read the group PR's changelog table instead.
 version: 2
 updates:
   - package-ecosystem: "bun"
@@ -20,10 +22,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      js-minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
+      js-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -38,3 +39,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Majors now join the weekly group PR instead of arriving as individual PRs.

- `bun`: group renamed `js-minor-and-patch` → `js-dependencies` and `update-types` dropped, so the group covers every update type.
- `docker`: gains a `patterns: ["*"]` group so a second image wouldn't split into a second PR.
- `github-actions`: unchanged — its pattern-based group already had no `update-types` filter, which is why #218 carried the `setup-node` v7 major.

The schedule was already `weekly` on all three ecosystems; this PR does not change frequency, only how many PRs that weekly run produces.

## Why

#218 / #219 / #220 all landed the same morning: the group PR plus a major that the `minor`/`patch` filter pushed out on its own. The split was meant to give breaking changes their own scrutiny, but in practice the major gets read no more closely for having its own branch — Dependabot's group PR body carries the same per-package changelog table either way.

## Verification

`.github/dependabot.yml` parses as valid YAML and resolves to one all-update-types group per ecosystem:

```
bun            weekly ['js-dependencies']  ['ALL']
github-actions weekly ['github-actions']   ['ALL']
docker         weekly ['docker']           ['ALL']
```

Config-only change; no source or lockfile is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzSMAykoEU6bEYCDUGnSBB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency updates are now consolidated into a single weekly update per ecosystem, including major versions.
  * JavaScript and Docker updates will be grouped together to reduce update volume and simplify maintenance review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->