### PR TITLE
fix(ci): pin rust-toolchain to the v1 tag, not a force-pushed stable SHA

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -79,7 +79,12 @@ jobs:
       - name: Install Rust stable
         # rust-toolchain derives the toolchain from the ref name, so a pinned
         # SHA needs the toolchain named explicitly.
-        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        #
+        # Pin to the `v1` tag, never to a `stable` branch head: upstream
+        # force-pushes `stable`, which orphans the SHA and leaves Dependabot
+        # unable to resolve it back to a ref (`unknown_error`, and the whole
+        # github-actions ecosystem job fails).
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           targets: ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,12 @@ jobs:
       - name: Install Rust stable
         # rust-toolchain derives the toolchain from the ref name, so a pinned
         # SHA needs the toolchain named explicitly.
-        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        #
+        # Pin to the `v1` tag, never to a `stable` branch head: upstream
+        # force-pushes `stable`, which orphans the SHA and leaves Dependabot
+        # unable to resolve it back to a ref (`unknown_error`, and the whole
+        # github-actions ecosystem job fails).
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           targets: ${{ matrix.target }}


### PR DESCRIPTION
## Symptom

The `Dependabot Updates` job for the **github-actions** ecosystem fails:

```
+------------------------+---------------+---------------+
| Dependency             | Error Type    | Error Details |
+------------------------+---------------+---------------+
| dtolnay/rust-toolchain | unknown_error | null          |
+------------------------+---------------+---------------+
Dependabot encountered '1' error(s) during execution
```

This is **pre-existing** — it first appeared in the 2026-07-20 21:44 weekly run (commit `6c6f2e2`), before #229. The 2026-07-13 run was green.

## Root cause

`dtolnay/rust-toolchain` force-pushes its `stable` branch — that is how the branch tracks each new stable release. Our pin `4be7066a` was that branch's head when it was written (commit dated 2026-06-30, message `toolchain: stable`).

Upstream moved `stable` to `4cda84d5` on **2026-07-16**, which orphaned our SHA:

| check | result |
|---|---|
| `commits/4be7066a/branches-where-head` | *(empty)* |
| `branches/stable` head | `4cda84d5`, 2026-07-16 |
| repo tags | `v1` only, → `e97e2d8c` |

Dependabot's github-actions updater resolves a pinned SHA back to a ref in order to determine the current version. With the SHA reachable from no branch and no tag there is nothing to resolve, so it reports `unknown_error` — and one dependency error fails the whole ecosystem job. The timing lines up exactly: the 07-20 run was the first scheduled run after the 07-16 force-push.

## Fix

Re-pin both workflows to `e97e2d8c` — the commit behind the `v1` **tag**, which Dependabot can resolve and track. Tags accumulate along history rather than being force-pushed out from under us, so this pin does not rot the same way.

Safe as a drop-in: `toolchain` is a declared input at `v1` (`required: true`), and both call sites already pass `toolchain: stable` explicitly, so nothing here relied on rust-toolchain's ref-name derivation. `targets` is likewise a declared input at that commit.

## Scope check

`rust-toolchain` was the only branch-head pin. Every other action across `.github/workflows/` is pinned to a version tag (`# v7.0.1`, `# v2.2.0`, …), so no other pin can rot this way.

## Verification

- Both workflow files parse as valid YAML.
- `action.yml` at `e97e2d8c` declares the `toolchain` and `targets` inputs both call sites pass.
- The `Dependabot Updates` job cannot be dispatched manually, so the conclusive check is the next github-actions run after this merges — it should complete without the error table. Worth watching rather than assuming.
- Rust itself is only built in the release workflows, so a tag build (or a `manual-release` dispatch) is what exercises the action at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzSMAykoEU6bEYCDUGnSBB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflows to use a more reliable Rust toolchain action reference.
  * Preserved the existing stable toolchain and target configuration.
  * Added comments documenting the toolchain pinning approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->