### PR TITLE
build(deps): ignore typescript majors until typescript-eslint supports TS 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,15 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      # typescript-eslint 8.x hard-errors on TS 7 ("typescript-eslint does not
+      # support TS 7.0."), so a typescript major fails lint and — now that
+      # majors ride in the group PR — takes the whole weekly batch red with it.
+      # Minor and patch bumps still flow. Drop this once typescript-eslint
+      # ships TS 7 support.
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
     groups:
       js-dependencies:
         patterns:


### PR DESCRIPTION
## Symptom

The first weekly group PR produced under the new grouping, #230, is red. Its lint step:

```
Oops! Something went wrong! :(
Error: typescript-eslint does not support TS 7.0.
##[error]Process completed with exit code 2.
```

#230 bumps `typescript` `^5` → `^7` (7.0.2) alongside `postcss` 8.5.21 and `prettier` 3.9.6.

## Root cause

typescript-eslint 8.x refuses to run against TypeScript 7 — a known upstream constraint, and the reason this repo has stayed on TS 5.x.

That constraint was previously invisible in CI terms: the `minor`/`patch` group filter pushed every major into its own PR, so the typescript major sat in a perpetually-red PR of its own while the group PR stayed green. #229 removed that filter, which is what the grouping change was for — but it also means one unmergeable dependency now takes the whole weekly batch down with it. `postcss` and `prettier` are blocked behind a bump we cannot take.

## Fix

Express the constraint in config instead of leaving it for a human to re-discover each week:

```yaml
ignore:
  - dependency-name: "typescript"
    update-types:
      - "version-update:semver-major"
```

Scoped as narrowly as possible — typescript **majors** only. Minor and patch bumps still flow, and majors for every other package still ride in the group. Remove this block once typescript-eslint ships TS 7 support.

## Verification

- `.github/dependabot.yml` parses and resolves to the intended shape:
  ```
  bun            | groups: ['js-dependencies'] | ignore: [typescript / semver-major]
  github-actions | groups: ['github-actions']  | ignore: none
  docker         | groups: ['docker']          | ignore: none
  ```
- After this merges, Dependabot should regenerate #230 without the typescript entry; the remaining postcss + prettier bumps are expected to go green. Worth confirming on the regenerated PR rather than assuming.

## Related

- #229 introduced the grouping that surfaced this.
- #231 fixes the separate, pre-existing `Dependabot Updates` job failure (`dtolnay/rust-toolchain` pinned to an orphaned SHA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzSMAykoEU6bEYCDUGnSBB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to defer major TypeScript upgrades while continuing to allow minor and patch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->