### PR TITLE
feat(analyze): analyze a live daemon, and stop reporting toolkit false positives

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -301,13 +301,21 @@ on a mismatch.
 
 ```bash
 ocpp-cp-sim analyze <trace.jsonl> [--output <file>] [--format html|markdown]
+ocpp-cp-sim analyze --from-daemon --cp-id <id> [--http-url <url>]
+                     [--http-basic-auth-user <u> --http-basic-auth-pass <p>]
+                     [--output <file>] [--format html|markdown]
 ```
 
 Runs [OCPP DebugKit](https://github.com/ocpp-debugkit/toolkit)'s
-failure-pattern detection over a v1.1 trace file
+failure-pattern detection over a v1.1 trace
 ([docs/trace-format.md](./trace-format.md)) and writes a report. Unlike every
-mode above, `analyze` never bootstraps a charge point, opens a socket, or
-starts a server — it only reads the given file and writes a report.
+mode above, `analyze` never bootstraps a charge point or starts a server. In
+its default form it only reads the given file and writes a report; with
+`--from-daemon` it instead makes the same kind of short-lived client
+connection as `--send`/`--stop`/`--events` to pull the trace from a running
+daemon, then closes it — see
+[Reading from a running daemon](#reading-from-a-running-daemon---from-daemon)
+below.
 
 ```bash
 # Markdown to stdout (default)
@@ -318,7 +326,64 @@ ocpp-cp-sim analyze trace.jsonl --output report.html
 
 # Force a format regardless of the --output extension
 ocpp-cp-sim analyze trace.jsonl --output report.txt --format html
+
+# From a running daemon's stored logs, no trace file needed
+ocpp-cp-sim analyze --from-daemon --cp-id CP001 --output report.html
 ```
+
+### Reading from a running daemon (`--from-daemon`)
+
+A trace file only exists if the daemon was started with `--trace-output`.
+An operator running a long-lived daemon — in Kubernetes, say — usually
+wasn't, and restarting it just to get one loses whatever session is in
+flight and starts the trace from empty. `--from-daemon` avoids both: the
+daemon already persists every log line it produces and exposes them per
+charge point over the `logs.get` RPC
+([server.md → Related RPC methods](./server.md#related-rpc-methods)), and
+that log line shape (`{timestamp, level, type, message, cpId}`) is exactly
+what [`logEntryToTrace.ts`](../src/trace/logEntryToTrace.ts) already adapts
+into trace records for `--log-format json` and the browser log-viewer
+download (see
+[trace-format.md → Producing records](./trace-format.md#producing-records)).
+`--from-daemon` is that same adapter run against the live log store, not a
+second trace format, and it requires no daemon restart.
+
+- `--cp-id <id>` is required: `logs.get` is scoped to one charge point, the
+  same way `--send`/`--events` are scoped by `--cp-id`. `analyze` rejects
+  `--from-daemon` with no `--cp-id`, and rejects `--cp-id` /
+  `--http-url` / `--http-basic-auth-*` without `--from-daemon` — a daemon
+  and a trace file are two different trace sources, and silently preferring
+  one over the other would hide which of them a report actually describes,
+  so a positional trace file combined with `--from-daemon` is also rejected.
+- `--http-url <url>` targets the daemon, same as the other client modes
+  (default `http://127.0.0.1:9700`).
+- `--http-basic-auth-user <u>` / `--http-basic-auth-pass <p>` authenticate
+  against a daemon started with `--web-console-basic-auth-*`, exactly like
+  the top-level `--http-basic-auth-*` flags for `--send`/`--stop`/`--events`
+  do; the two must be given together, since a half-specified credential is a
+  misconfiguration, not a request for anonymous access.
+- `analyze --from-daemon` only sees what the log store still holds: with no
+  `--state-db`, that's the daemon's bounded in-memory Logger buffer, which
+  is lost on restart; with `--state-db`, it's the persisted `logs` table,
+  which can itself be trimmed by the `logs.clear` RPC or `state.reset`
+  ([server.md → Related RPC methods](./server.md#related-rpc-methods)). A
+  session whose log lines have aged out or were cleared is invisible to
+  `analyze --from-daemon` the same way it would be to any other consumer of
+  `logs.get` — a fresh `--trace-output` file remains the only source
+  guaranteed to have everything captured since the process last
+  (re)started.
+- If the daemon has no stored OCPP wire log lines for that charge point at
+  all — e.g. its logs are only scenario/diagnostic chatter, which
+  `logEntryToTrace.ts` maps to nothing — `analyze` exits 1 instead of
+  producing an empty report:
+
+  ```
+  Error: the daemon has no stored OCPP wire logs for charge point CP001 (nothing to analyze)
+  ```
+
+  A connection or auth failure while fetching the logs (daemon unreachable,
+  wrong `--http-basic-auth-*`, unknown `--cp-id`) is also reported and exits
+  1, prefixed `Error: cannot read logs from daemon: `.
 
 ### Formats
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -301,9 +301,11 @@ on a mismatch.
 
 ```bash
 ocpp-cp-sim analyze <trace.jsonl> [--output <file>] [--format html|markdown]
+                     [--split-by charge-point|connector]
 ocpp-cp-sim analyze --from-daemon --cp-id <id> [--http-url <url>]
                      [--http-basic-auth-user <u> --http-basic-auth-pass <p>]
                      [--output <file>] [--format html|markdown]
+                     [--split-by charge-point|connector]
 ```
 
 Runs [OCPP DebugKit](https://github.com/ocpp-debugkit/toolkit)'s
@@ -329,6 +331,9 @@ ocpp-cp-sim analyze trace.jsonl --output report.txt --format html
 
 # From a running daemon's stored logs, no trace file needed
 ocpp-cp-sim analyze --from-daemon --cp-id CP001 --output report.html
+
+# One report per connector instead of one per charge point
+ocpp-cp-sim analyze trace.jsonl --split-by connector --output report.html
 ```
 
 ### Reading from a running daemon (`--from-daemon`)
@@ -428,6 +433,58 @@ independently:
   file). An explicit `--format` always wins over the `--output` extension
   (see [Formats](#formats) above) — this applies with or without
   `--output`.
+
+### Splitting by connector (`--split-by connector`)
+
+Same root cause as the chargePointId problem above, one level down: the
+toolkit's rules operate over a whole station's events at once, and
+`connectorId` appears exactly once in the installed `dist/core/detection.js`
+— inside a comment. No rule groups by it. `STATUS_TRANSITION_VIOLATION` in
+particular treats connector A going `Available` while connector B (on the
+same station) goes `Finishing` as one invalid transition; on a real
+4-connector trace this produced 24 findings, and hand-filtering that trace
+down to a single connector reduced it to the 1 that was real.
+
+`--split-by connector` (default `--split-by charge-point`, i.e. today's
+behavior, unchanged) further splits each charge point's records by
+connector before analysis, so each connector gets its own report:
+
+- A record's connector is derived from `payload.connectorId` for
+  `StatusNotification`, `MeterValues`, `StartTransaction`, and
+  `RemoteStartTransaction`. `StopTransaction` / `RemoteStopTransaction`
+  carry only `transactionId`; their connector is resolved by correlating
+  each `StartTransaction` CALL's `messageId` to the `transactionId` in its
+  CALLRESULT, then mapping that transaction back to the StartTransaction's
+  connector. A CALLRESULT/CALLERROR itself carries no connector and
+  inherits whichever connector the CALL it answers resolved to.
+  `connectorId: 0` is station-level per OCPP 1.6 (the "whole station"
+  pseudo-connector), never connector 1.
+- Records with no derivable connector at all — `BootNotification`,
+  `Heartbeat`, `Authorize`, `DiagnosticsStatusNotification`,
+  `FirmwareStatusNotification`, `connectorId: 0`, or an unresolvable
+  `StopTransaction` — are **replicated into every connector's report**.
+  Rules like `UNEXPECTED_START` need to see the station's
+  `BootNotification`; a per-connector report that lacked it would itself
+  report a _new_ false positive ("StartTransaction without preceding
+  BootNotification"), the exact kind of artifact this flag exists to
+  remove. The consequence: a station-level finding (e.g. a real
+  `DIAGNOSTICS_FAILURE`) can appear in more than one connector's report —
+  read it as "this affects the whole station, seen from connector N's
+  report," not as N separate failures.
+- A charge point with no connector-scoped record at all (e.g. a boot-only
+  trace) has nothing to split on; it falls back to one report under its
+  plain charge point id, same as `--split-by charge-point`.
+- Report filenames follow the same `--output` splitting as multiple charge
+  points (above), with connector groups named
+  `<chargePointId>-connector<N>`: `--output out.html` with charge point
+  `CP001` and two connectors produces `out.CP001-connector1.html` and
+  `out.CP001-connector2.html`.
+
+This is opt-in rather than always-on: unlike the chargePointId split above
+(a pure toolkit bug with no legitimate alternative reading), "should
+`STATION_OFFLINE_DURING_SESSION` / `UNEXPECTED_START` etc. see the whole
+station or just one connector" is a real judgment call, so the default
+stays today's whole-station behavior.
 
 ### Excluded records
 

--- a/src/cli/analyze/__tests__/meterAnomaly.test.ts
+++ b/src/cli/analyze/__tests__/meterAnomaly.test.ts
@@ -1,0 +1,506 @@
+import { describe, expect, it } from "vitest";
+// Real @ocpp-debugkit/toolkit@0.4.0 -- deliberately not mocked, same
+// convention as runAnalyze.test.ts: these tests pin `correctMeterValueAnomalies`
+// against the toolkit's actual, verified `detectMeterValueAnomaly` (rule 14)
+// bug (probed by reading the installed dist/core/detection.js directly, not
+// inferred): it flattens every sampledValue.value in a session into one
+// `readings[]` array with no regard for `measurand`, `phase`, `unit`,
+// `location`, or `connectorId`, then asserts the flat sequence never
+// decreases.
+import {
+  buildSessionTimeline,
+  detectFailures,
+  parseOpenOcppTrace,
+} from "@ocpp-debugkit/toolkit/core";
+import type { Failure, Session } from "@ocpp-debugkit/toolkit/core";
+import {
+  correctMeterValueAnomalies,
+  detectCorrectedMeterValueAnomalies,
+} from "../meterAnomaly";
+
+function rec(o: Record<string, unknown>): string {
+  return JSON.stringify({
+    schemaVersion: "1.1",
+    ocppVersion: "1.6",
+    transport: "json",
+    chargePointId: "CP001",
+    ...o,
+  });
+}
+
+function meterValuesRecord(o: {
+  messageId: string;
+  timestamp: string;
+  connectorId: number;
+  transactionId?: number;
+  sampledValue: Record<string, unknown>[];
+}): string {
+  return rec({
+    connectorId: o.connectorId,
+    timestamp: o.timestamp,
+    direction: "cp-to-csms",
+    messageType: "CALL",
+    messageId: o.messageId,
+    action: "MeterValues",
+    payload: {
+      connectorId: o.connectorId,
+      ...(o.transactionId !== undefined
+        ? { transactionId: o.transactionId }
+        : {}),
+      meterValue: [{ timestamp: o.timestamp, sampledValue: o.sampledValue }],
+    },
+  });
+}
+
+/** Parses a joined-lines JSONL trace through the real toolkit pipeline up to
+ *  (but not including) `summarizeSessions`, exactly the slice `runAnalyze.ts`
+ *  hands to `correctMeterValueAnomalies`. */
+function runToolkitPipeline(lines: string[]): {
+  sessions: Session[];
+  failures: Failure[];
+} {
+  const { events } = parseOpenOcppTrace(lines.join("\n") + "\n");
+  const sessions = buildSessionTimeline(events);
+  const failures = detectFailures(events, sessions);
+  return { sessions, failures };
+}
+
+function meterAnomalyFindings(failures: Failure[]): Failure[] {
+  return failures.filter((f) => f.code === "METER_VALUE_ANOMALY");
+}
+
+describe("correctMeterValueAnomalies (Task B end-to-end proof)", () => {
+  it("real-world case: a strictly-monotonic Energy.Active.Import.Register series interleaved with a constant Power.Active.Import -- toolkit alone reports many METER_VALUE_ANOMALY findings, the corrected pipeline reports zero", () => {
+    // 12 MeterValues, connector 1, transaction 1001: Energy register rises
+    // +25 Wh every 30s (a healthy 3 kW session over 6 minutes), interleaved
+    // with a constant Power.Active.Import = 3000 W in the *same* message --
+    // exactly the real observed shape from the task brief.
+    const lines: string[] = [
+      rec({
+        timestamp: "2026-01-01T00:00:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "1",
+        action: "StartTransaction",
+        connectorId: 1,
+        payload: {
+          connectorId: 1,
+          idTag: "TAG1",
+          meterStart: 600,
+          timestamp: "2026-01-01T00:00:00.000Z",
+        },
+      }),
+      rec({
+        timestamp: "2026-01-01T00:00:01.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "1",
+        payload: { idTagInfo: { status: "Accepted" }, transactionId: 1001 },
+      }),
+    ];
+    let energy = 600;
+    for (let i = 0; i < 12; i++) {
+      const t = new Date(2026, 0, 1, 0, 0, 30 * (i + 1)).toISOString();
+      lines.push(
+        meterValuesRecord({
+          messageId: `mv-${i}`,
+          timestamp: t,
+          connectorId: 1,
+          transactionId: 1001,
+          sampledValue: [
+            {
+              value: String(energy),
+              measurand: "Energy.Active.Import.Register",
+              unit: "Wh",
+            },
+            {
+              value: "3000",
+              measurand: "Power.Active.Import",
+              unit: "W",
+            },
+          ],
+        }),
+      );
+      energy += 25;
+    }
+    lines.push(
+      rec({
+        timestamp: "2026-01-01T00:07:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "99",
+        action: "StopTransaction",
+        payload: {
+          transactionId: 1001,
+          meterStart: 600,
+          meterStop: energy,
+          timestamp: "2026-01-01T00:07:00.000Z",
+          idTag: "TAG1",
+          reason: "Local",
+        },
+      }),
+    );
+
+    const { sessions, failures } = runToolkitPipeline(lines);
+
+    // Baseline: the unmodified toolkit, proving the bug is real on this
+    // exact fixture, not assumed.
+    const toolkitOnly = meterAnomalyFindings(failures);
+    expect(toolkitOnly.length).toBeGreaterThan(10);
+    expect(
+      toolkitOnly.some((f) => f.description.includes("decreased from 3000")),
+    ).toBe(true);
+
+    // Fixed: the same sessions/failures, corrected.
+    const corrected = correctMeterValueAnomalies(sessions, failures);
+    expect(meterAnomalyFindings(corrected)).toEqual([]);
+  });
+
+  it("real-world case: a 4-connector-station-shaped trace with no StartTransaction correlation collapses into one toolkit session, interleaving two connectors' independent (each individually monotonic) Energy registers -- toolkit alone reports findings, corrected reports zero", () => {
+    // No StartTransaction/StopTransaction at all: buildSessionTimeline's
+    // `startTxCalls.length === 0` fallback lumps every event into a single
+    // `session-0`, with `session.transactionId` taken from whichever event
+    // is scanned first that carries one -- here, connector 1's first
+    // MeterValues. Every other connector's MeterValues still lands in that
+    // same session (buildSessionTimeline groups by chargePointId only when
+    // there is no transaction to key on), reproducing the "connectorId
+    // appears nowhere in detection.js" defect for real.
+    const lines: string[] = [];
+    let e1 = 600;
+    let e2 = 9000;
+    for (let i = 0; i < 6; i++) {
+      const t1 = new Date(2026, 0, 1, 0, 0, 60 * i).toISOString();
+      lines.push(
+        meterValuesRecord({
+          messageId: `c1-${i}`,
+          timestamp: t1,
+          connectorId: 1,
+          transactionId: 1001,
+          sampledValue: [
+            { value: String(e1), measurand: "Energy.Active.Import.Register" },
+          ],
+        }),
+      );
+      e1 += 25;
+      const t2 = new Date(2026, 0, 1, 0, 0, 60 * i + 30).toISOString();
+      lines.push(
+        meterValuesRecord({
+          messageId: `c2-${i}`,
+          timestamp: t2,
+          connectorId: 2,
+          transactionId: 2002,
+          sampledValue: [
+            { value: String(e2), measurand: "Energy.Active.Import.Register" },
+          ],
+        }),
+      );
+      e2 += 40;
+    }
+
+    const { sessions, failures } = runToolkitPipeline(lines);
+    expect(sessions).toHaveLength(1); // confirms the fallback single-session shape
+
+    const toolkitOnly = meterAnomalyFindings(failures);
+    expect(toolkitOnly.length).toBeGreaterThan(0);
+
+    const corrected = correctMeterValueAnomalies(sessions, failures);
+    expect(meterAnomalyFindings(corrected)).toEqual([]);
+  });
+
+  it("still flags a genuinely non-monotonic cumulative register (true positive preserved)", () => {
+    const lines: string[] = [
+      meterValuesRecord({
+        messageId: "mv-0",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        connectorId: 1,
+        transactionId: 1001,
+        sampledValue: [
+          { value: "1000", measurand: "Energy.Active.Import.Register" },
+        ],
+      }),
+      meterValuesRecord({
+        messageId: "mv-1",
+        timestamp: "2026-01-01T00:00:30.000Z",
+        connectorId: 1,
+        transactionId: 1001,
+        sampledValue: [
+          // meter reset / rollover -- a real anomaly.
+          { value: "500", measurand: "Energy.Active.Import.Register" },
+        ],
+      }),
+    ];
+
+    const { sessions, failures } = runToolkitPipeline(lines);
+    const corrected = meterAnomalyFindings(
+      correctMeterValueAnomalies(sessions, failures),
+    );
+    expect(corrected).toHaveLength(1);
+    expect(corrected[0]?.description).toContain("decreased from 1000 to 500");
+  });
+
+  it("flags a negative cumulative register value", () => {
+    const lines: string[] = [
+      meterValuesRecord({
+        messageId: "mv-0",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        connectorId: 1,
+        transactionId: 1001,
+        sampledValue: [
+          { value: "-5", measurand: "Energy.Active.Import.Register" },
+        ],
+      }),
+    ];
+    const { sessions, failures } = runToolkitPipeline(lines);
+    const corrected = meterAnomalyFindings(
+      correctMeterValueAnomalies(sessions, failures),
+    );
+    expect(corrected).toHaveLength(1);
+    expect(corrected[0]?.description).toContain("Negative meter value");
+  });
+
+  it("does NOT flag a negative Power.Active.Import value (legitimate on a bidirectional/V2G charger)", () => {
+    const lines: string[] = [
+      meterValuesRecord({
+        messageId: "mv-0",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        connectorId: 1,
+        transactionId: 1001,
+        sampledValue: [
+          // Discharging back to the grid: negative power is expected, not
+          // an anomaly.
+          { value: "-3000", measurand: "Power.Active.Import" },
+        ],
+      }),
+    ];
+    const { sessions, failures } = runToolkitPipeline(lines);
+    expect(
+      meterAnomalyFindings(correctMeterValueAnomalies(sessions, failures)),
+    ).toEqual([]);
+  });
+
+  it("does NOT flag a negative Current.Import value either", () => {
+    const lines: string[] = [
+      meterValuesRecord({
+        messageId: "mv-0",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        connectorId: 1,
+        transactionId: 1001,
+        sampledValue: [{ value: "-16", measurand: "Current.Import" }],
+      }),
+    ];
+    const { sessions, failures } = runToolkitPipeline(lines);
+    expect(
+      meterAnomalyFindings(correctMeterValueAnomalies(sessions, failures)),
+    ).toEqual([]);
+  });
+
+  it("treats a missing measurand as Energy.Active.Import.Register (OCPP 1.6 default) and still flags it if non-monotonic", () => {
+    const lines: string[] = [
+      meterValuesRecord({
+        messageId: "mv-0",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        connectorId: 1,
+        transactionId: 1001,
+        sampledValue: [{ value: "1000" }], // no measurand at all
+      }),
+      meterValuesRecord({
+        messageId: "mv-1",
+        timestamp: "2026-01-01T00:00:30.000Z",
+        connectorId: 1,
+        transactionId: 1001,
+        sampledValue: [{ value: "900" }],
+      }),
+    ];
+    const { sessions, failures } = runToolkitPipeline(lines);
+    const corrected = meterAnomalyFindings(
+      correctMeterValueAnomalies(sessions, failures),
+    );
+    expect(corrected).toHaveLength(1);
+  });
+
+  it("does not flag non-cumulative measurands even when they legitimately fall and rise (SoC, Power, Current, Voltage, Temperature)", () => {
+    const lines: string[] = [
+      meterValuesRecord({
+        messageId: "mv-0",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        connectorId: 1,
+        transactionId: 1001,
+        sampledValue: [
+          { value: "80", measurand: "SoC" },
+          { value: "7200", measurand: "Power.Active.Import" },
+          { value: "32", measurand: "Current.Import" },
+          { value: "230", measurand: "Voltage" },
+          { value: "35", measurand: "Temperature" },
+        ],
+      }),
+      meterValuesRecord({
+        messageId: "mv-1",
+        timestamp: "2026-01-01T00:00:30.000Z",
+        connectorId: 1,
+        transactionId: 1001,
+        sampledValue: [
+          { value: "60", measurand: "SoC" }, // taper -- falling is normal
+          { value: "1200", measurand: "Power.Active.Import" }, // taper
+          { value: "5", measurand: "Current.Import" },
+          { value: "228", measurand: "Voltage" },
+          { value: "34", measurand: "Temperature" },
+        ],
+      }),
+    ];
+    const { sessions, failures } = runToolkitPipeline(lines);
+    // Sanity: the unfixed toolkit *does* misfire on this fixture (proves the
+    // fixture actually exercises the bug).
+    expect(meterAnomalyFindings(failures).length).toBeGreaterThan(0);
+    expect(
+      meterAnomalyFindings(correctMeterValueAnomalies(sessions, failures)),
+    ).toEqual([]);
+  });
+
+  it("keeps separate phases of the same cumulative measurand from cross-contaminating", () => {
+    const lines: string[] = [
+      meterValuesRecord({
+        messageId: "mv-0",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        connectorId: 1,
+        transactionId: 1001,
+        sampledValue: [
+          {
+            value: "100",
+            measurand: "Energy.Active.Import.Register",
+            phase: "L1",
+          },
+          {
+            value: "9000",
+            measurand: "Energy.Active.Import.Register",
+            phase: "L2",
+          },
+        ],
+      }),
+      meterValuesRecord({
+        messageId: "mv-1",
+        timestamp: "2026-01-01T00:00:30.000Z",
+        connectorId: 1,
+        transactionId: 1001,
+        sampledValue: [
+          {
+            value: "125",
+            measurand: "Energy.Active.Import.Register",
+            phase: "L1",
+          },
+          {
+            value: "9025",
+            measurand: "Energy.Active.Import.Register",
+            phase: "L2",
+          },
+        ],
+      }),
+    ];
+    const { sessions, failures } = runToolkitPipeline(lines);
+    // Without phase-awareness the toolkit sees 100, 9000, 125, 9025 and
+    // flags 9000 -> 125 as a decrease.
+    expect(meterAnomalyFindings(failures).length).toBeGreaterThan(0);
+    expect(
+      meterAnomalyFindings(correctMeterValueAnomalies(sessions, failures)),
+    ).toEqual([]);
+  });
+
+  it("does not touch failures of other codes", () => {
+    const lines: string[] = [
+      rec({
+        timestamp: "2026-01-01T00:00:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "1",
+        action: "Authorize",
+        payload: { idTag: "TAG1" },
+      }),
+      rec({
+        timestamp: "2026-01-01T00:00:01.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "1",
+        payload: { idTagInfo: { status: "Invalid" } },
+      }),
+    ];
+    const { sessions, failures } = runToolkitPipeline(lines);
+    expect(failures.some((f) => f.code === "FAILED_AUTHORIZATION")).toBe(true);
+
+    const corrected = correctMeterValueAnomalies(sessions, failures);
+    expect(corrected.some((f) => f.code === "FAILED_AUTHORIZATION")).toBe(true);
+    expect(corrected.length).toBe(failures.length); // no METER_VALUE_ANOMALY in or out
+  });
+
+  it("emits findings in exactly the shape the toolkit produces (code/severity/suggestedSteps), verified against the toolkit's own single-measurand (bug-free) output for the same failure kind", () => {
+    // Single-measurand case: the toolkit's own detector is correct here (no
+    // interleaving to confuse it), so its own output is a reliable oracle
+    // for severity/suggestedSteps wording, decoupled from hardcoding it and
+    // therefore resistant to upstream wording drift within 0.4.0.
+    const lines: string[] = [
+      meterValuesRecord({
+        messageId: "mv-0",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        connectorId: 1,
+        transactionId: 1001,
+        sampledValue: [
+          { value: "1000", measurand: "Energy.Active.Import.Register" },
+        ],
+      }),
+      meterValuesRecord({
+        messageId: "mv-1",
+        timestamp: "2026-01-01T00:00:30.000Z",
+        connectorId: 1,
+        transactionId: 1001,
+        sampledValue: [
+          { value: "500", measurand: "Energy.Active.Import.Register" },
+        ],
+      }),
+    ];
+    const { sessions, failures } = runToolkitPipeline(lines);
+    const oracle = meterAnomalyFindings(failures);
+    expect(oracle).toHaveLength(1); // toolkit alone already gets this one right
+
+    const corrected = meterAnomalyFindings(
+      correctMeterValueAnomalies(sessions, failures),
+    );
+    expect(corrected).toHaveLength(1);
+    expect(corrected[0]?.code).toBe(oracle[0]?.code);
+    expect(corrected[0]?.severity).toBe(oracle[0]?.severity);
+    expect(corrected[0]?.suggestedSteps).toEqual(oracle[0]?.suggestedSteps);
+    // eventIds must reference real events in the session so
+    // summarizeSessions' per-session failureCount (eventIds intersection)
+    // keeps working.
+    const sessionEventIds = new Set(
+      sessions.flatMap((s) => s.events.map((e) => e.id)),
+    );
+    for (const id of corrected[0]?.eventIds ?? []) {
+      expect(sessionEventIds.has(id)).toBe(true);
+    }
+  });
+
+  it("skips sessions with no transactionId, matching the toolkit's own rule-14 scope", () => {
+    // No StartTransaction anywhere and only one connector -> single
+    // no-transaction session; the (buggy) toolkit already skips it, so the
+    // corrected version must too (same scope, just correct within it).
+    const lines: string[] = [
+      rec({
+        timestamp: "2026-01-01T00:00:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "1",
+        action: "Heartbeat",
+        payload: {},
+      }),
+      rec({
+        timestamp: "2026-01-01T00:00:01.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "1",
+        payload: { currentTime: "2026-01-01T00:00:01.000Z" },
+      }),
+    ];
+    const { sessions, failures } = runToolkitPipeline(lines);
+    expect(sessions[0]?.transactionId).toBeNull();
+    expect(detectCorrectedMeterValueAnomalies(sessions)).toEqual([]);
+    expect(correctMeterValueAnomalies(sessions, failures)).toEqual(failures);
+  });
+});

--- a/src/cli/analyze/__tests__/parseAnalyzeArgs.test.ts
+++ b/src/cli/analyze/__tests__/parseAnalyzeArgs.test.ts
@@ -176,4 +176,80 @@ describe("parseAnalyzeArgs", () => {
       }
     });
   });
+
+  describe("--split-by", () => {
+    it("defaults to undefined when not passed, so current behavior (split by charge point) is unchanged", () => {
+      const result = parseAnalyzeArgs(["trace.jsonl"]);
+      expect(result).toEqual({
+        ok: true,
+        args: {
+          file: "trace.jsonl",
+          output: undefined,
+          format: undefined,
+        },
+      });
+      if (result.ok) {
+        expect(result.args.splitBy).toBeUndefined();
+      }
+    });
+
+    it("parses --split-by connector", () => {
+      const result = parseAnalyzeArgs([
+        "trace.jsonl",
+        "--split-by",
+        "connector",
+      ]);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.args.splitBy).toBe("connector");
+      }
+    });
+
+    it("parses an explicit --split-by charge-point", () => {
+      const result = parseAnalyzeArgs([
+        "trace.jsonl",
+        "--split-by",
+        "charge-point",
+      ]);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.args.splitBy).toBe("charge-point");
+      }
+    });
+
+    it("rejects any value other than charge-point or connector", () => {
+      const result = parseAnalyzeArgs(["trace.jsonl", "--split-by", "phase"]);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toContain(
+          "--split-by must be 'charge-point' or 'connector'",
+        );
+      }
+    });
+
+    it("rejects --split-by with a missing value", () => {
+      const result = parseAnalyzeArgs(["trace.jsonl", "--split-by"]);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toContain(
+          "--split-by must be 'charge-point' or 'connector'",
+        );
+      }
+    });
+
+    it("combines with --from-daemon (an independent dimension from the trace source)", () => {
+      const result = parseAnalyzeArgs([
+        "--from-daemon",
+        "--cp-id",
+        "CP001",
+        "--split-by",
+        "connector",
+      ]);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.args.splitBy).toBe("connector");
+        expect(result.args.fromDaemon).toBe(true);
+      }
+    });
+  });
 });

--- a/src/cli/analyze/__tests__/parseAnalyzeArgs.test.ts
+++ b/src/cli/analyze/__tests__/parseAnalyzeArgs.test.ts
@@ -93,4 +93,87 @@ describe("parseAnalyzeArgs", () => {
     const result = parseAnalyzeArgs(["--format", "html"]);
     expect(result.ok).toBe(false);
   });
+
+  describe("--from-daemon", () => {
+    it("takes the trace from a running daemon instead of a file", () => {
+      const result = parseAnalyzeArgs([
+        "--from-daemon",
+        "--cp-id",
+        "CP001",
+        "--output",
+        "out.html",
+      ]);
+      expect(result).toEqual({
+        ok: true,
+        args: {
+          file: undefined,
+          output: "out.html",
+          format: undefined,
+          fromDaemon: true,
+          cpId: "CP001",
+        },
+      });
+    });
+
+    it("parses the daemon connection flags", () => {
+      const result = parseAnalyzeArgs([
+        "--from-daemon",
+        "--cp-id",
+        "CP001",
+        "--http-url",
+        "https://sim.example",
+        "--http-basic-auth-user",
+        "admin",
+        "--http-basic-auth-pass",
+        "secret",
+      ]);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.args.httpUrl).toBe("https://sim.example");
+        expect(result.args.httpBasicAuth).toEqual({
+          username: "admin",
+          password: "secret",
+        });
+      }
+    });
+
+    it("requires --cp-id (logs.get is per charge point)", () => {
+      const result = parseAnalyzeArgs(["--from-daemon"]);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toContain("--from-daemon requires --cp-id");
+      }
+    });
+
+    it("rejects combining a trace file with --from-daemon", () => {
+      const result = parseAnalyzeArgs([
+        "trace.jsonl",
+        "--from-daemon",
+        "--cp-id",
+        "CP001",
+      ]);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toContain(
+          "--from-daemon cannot be combined with a trace file",
+        );
+      }
+    });
+
+    it("rejects a daemon flag without --from-daemon", () => {
+      const result = parseAnalyzeArgs(["trace.jsonl", "--cp-id", "CP001"]);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toContain("only valid with --from-daemon");
+      }
+    });
+
+    it("rejects a missing value on a daemon flag", () => {
+      const result = parseAnalyzeArgs(["--from-daemon", "--cp-id"]);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toContain("--cp-id requires a value");
+      }
+    });
+  });
 });

--- a/src/cli/analyze/__tests__/runAnalyze.fromDaemon.test.ts
+++ b/src/cli/analyze/__tests__/runAnalyze.fromDaemon.test.ts
@@ -1,0 +1,210 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `fetchStoredLogs` (src/cli/client.ts) talks to a real daemon over the
+// socket.io RPC transport via RemoteChargePointService; these tests exercise
+// runAnalyze()'s --from-daemon branch one layer above that, the same way
+// client.remote.test.ts mocks RemoteChargePointService one layer below it.
+// vi.hoisted is required (not a plain outer-scope vi.fn()) because vi.mock's
+// factory is hoisted above these imports, so a normal module-scope const
+// would be read before its own initializer runs.
+const clientMockState = vi.hoisted(() => {
+  return { fetchStoredLogs: vi.fn() };
+});
+
+vi.mock("../../client", () => ({
+  fetchStoredLogs: clientMockState.fetchStoredLogs,
+}));
+
+import { DEFAULT_HTTP_PORT } from "../../server/constants";
+import {
+  ANALYZE_DISCLAIMER,
+  describeTraceSource,
+  runAnalyze,
+} from "../runAnalyze";
+
+const DEFAULT_DAEMON_URL = `http://127.0.0.1:${DEFAULT_HTTP_PORT}`;
+
+/** Builds a `logs.get`-shaped log line carrying a raw OCPP-J wire frame, the
+ *  same shape `fetchStoredLogs` returns and `logLinesToTrace` (src/trace/
+ *  logEntryToTrace.ts) parses via its "Sent: "/"Received: " prefix contract. */
+function wireLogLine(
+  direction: "sent" | "received",
+  frame: unknown,
+  timestamp: string,
+): { timestamp: string; message: string } {
+  const prefix = direction === "sent" ? "Sent: " : "Received: ";
+  return { timestamp, message: `${prefix}${JSON.stringify(frame)}` };
+}
+
+async function withCapturedIo<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; stdout: string; stderr: string }> {
+  const originalStdout = process.stdout.write.bind(process.stdout);
+  const originalStderr = process.stderr.write.bind(process.stderr);
+  let stdout = "";
+  let stderr = "";
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdout += chunk.toString();
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += chunk.toString();
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const result = await fn();
+    return { result, stdout, stderr };
+  } finally {
+    process.stdout.write = originalStdout;
+    process.stderr.write = originalStderr;
+  }
+}
+
+describe("describeTraceSource", () => {
+  it("names the trace file for a file-sourced run", () => {
+    expect(describeTraceSource({ file: "trace.jsonl" })).toBe("trace.jsonl");
+  });
+
+  it("names the daemon target and charge point for a --from-daemon run", () => {
+    expect(
+      describeTraceSource({
+        fromDaemon: true,
+        cpId: "CP001",
+        httpUrl: "https://sim.example",
+      }),
+    ).toBe("daemon https://sim.example (cp CP001)");
+  });
+
+  it("falls back to the same default daemon URL as the other client modes (--send/--stop/--events) when --http-url is omitted", () => {
+    expect(describeTraceSource({ fromDaemon: true, cpId: "CP001" })).toBe(
+      `daemon ${DEFAULT_DAEMON_URL} (cp CP001)`,
+    );
+  });
+});
+
+describe("runAnalyze --from-daemon", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    clientMockState.fetchStoredLogs.mockReset();
+  });
+
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("builds the trace from the daemon's stored logs and stamps the report's Source with the daemon target", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "analyze-daemon-"));
+    const outPath = path.join(dir, "report.md");
+
+    clientMockState.fetchStoredLogs.mockResolvedValue([
+      wireLogLine(
+        "sent",
+        [2, "1", "Authorize", { idTag: "TAG1" }],
+        "2026-01-01T00:00:00.000Z",
+      ),
+      wireLogLine(
+        "received",
+        [3, "1", { idTagInfo: { status: "Accepted" } }],
+        "2026-01-01T00:00:01.000Z",
+      ),
+    ]);
+
+    const { result: code } = await withCapturedIo(() =>
+      runAnalyze({ fromDaemon: true, cpId: "CP001", output: outPath }),
+    );
+
+    expect(code).toBe(0);
+    expect(clientMockState.fetchStoredLogs).toHaveBeenCalledWith(
+      { httpUrl: DEFAULT_DAEMON_URL, basicAuth: null },
+      "CP001",
+    );
+    const content = fs.readFileSync(outPath, "utf8");
+    expect(content).toContain(
+      `**Source:** daemon ${DEFAULT_DAEMON_URL} (cp CP001)`,
+    );
+    expect(content).toContain(ANALYZE_DISCLAIMER);
+  });
+
+  it("passes --http-url and --http-basic-auth-* through to fetchStoredLogs", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "analyze-daemon-auth-"));
+    const outPath = path.join(dir, "report.md");
+
+    clientMockState.fetchStoredLogs.mockResolvedValue([
+      wireLogLine(
+        "sent",
+        [2, "1", "Authorize", { idTag: "TAG1" }],
+        "2026-01-01T00:00:00.000Z",
+      ),
+      wireLogLine(
+        "received",
+        [3, "1", { idTagInfo: { status: "Accepted" } }],
+        "2026-01-01T00:00:01.000Z",
+      ),
+    ]);
+
+    await withCapturedIo(() =>
+      runAnalyze({
+        fromDaemon: true,
+        cpId: "CP001",
+        httpUrl: "https://sim.example",
+        httpBasicAuth: { username: "admin", password: "secret" },
+        output: outPath,
+      }),
+    );
+
+    expect(clientMockState.fetchStoredLogs).toHaveBeenCalledWith(
+      {
+        httpUrl: "https://sim.example",
+        basicAuth: { username: "admin", password: "secret" },
+      },
+      "CP001",
+    );
+  });
+
+  // logLinesToTrace (src/trace/logEntryToTrace.ts) maps any log line that
+  // isn't a "Sent: "/"Received: " OCPP-J wire frame to null and drops it --
+  // scenario/diagnostic chatter is exactly that. A daemon whose stored logs
+  // for this CP are all such chatter therefore yields empty trace text, and
+  // must fail the same "nothing to analyze" way an all-excluded trace file
+  // does, rather than e.g. crashing on an empty toolkit run.
+  it("reports 'nothing to analyze' when the daemon's stored logs are all non-wire chatter", async () => {
+    clientMockState.fetchStoredLogs.mockResolvedValue([
+      {
+        timestamp: "2026-01-01T00:00:00.000Z",
+        message: "Scenario 'demo' started",
+      },
+      {
+        timestamp: "2026-01-01T00:00:01.000Z",
+        message: "Connector 1 -> Charging",
+      },
+    ]);
+
+    const { result: code, stderr } = await withCapturedIo(() =>
+      runAnalyze({ fromDaemon: true, cpId: "CP001" }),
+    );
+
+    expect(code).toBe(1);
+    expect(stderr).toContain(
+      "Error: the daemon has no stored OCPP wire logs for charge point CP001 (nothing to analyze)",
+    );
+  });
+
+  it("reports a read error and exits 1 when fetchStoredLogs throws", async () => {
+    clientMockState.fetchStoredLogs.mockRejectedValue(
+      new Error("Cannot connect to http://127.0.0.1:9700"),
+    );
+
+    const { result: code, stderr } = await withCapturedIo(() =>
+      runAnalyze({ fromDaemon: true, cpId: "CP001" }),
+    );
+
+    expect(code).toBe(1);
+    expect(stderr).toContain(
+      "Error: cannot read logs from daemon: Cannot connect to http://127.0.0.1:9700",
+    );
+  });
+});

--- a/src/cli/analyze/__tests__/runAnalyze.splitByConnector.test.ts
+++ b/src/cli/analyze/__tests__/runAnalyze.splitByConnector.test.ts
@@ -1,0 +1,248 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runAnalyze } from "../runAnalyze";
+
+// Real @ocpp-debugkit/toolkit@0.4.0 -- deliberately not mocked, same
+// convention as runAnalyze.test.ts. These pin `--split-by connector`'s
+// end-to-end behavior (splitTrace.ts's connector grouping, wired through
+// runAnalyze.ts) against the real toolkit pipeline.
+
+function rec(o: Record<string, unknown>): string {
+  return JSON.stringify({
+    schemaVersion: "1.1",
+    ocppVersion: "1.6",
+    transport: "json",
+    chargePointId: "CP001",
+    ...o,
+  });
+}
+
+function session(
+  connectorId: number,
+  startMsgId: string,
+  transactionId: number,
+  stopMsgId: string,
+): string[] {
+  return [
+    rec({
+      connectorId,
+      timestamp: "2026-01-01T00:00:10.000Z",
+      direction: "cp-to-csms",
+      messageType: "CALL",
+      messageId: startMsgId,
+      action: "StartTransaction",
+      payload: {
+        connectorId,
+        idTag: `TAG-${connectorId}`,
+        meterStart: 0,
+        timestamp: "2026-01-01T00:00:10.000Z",
+      },
+    }),
+    rec({
+      timestamp: "2026-01-01T00:00:11.000Z",
+      direction: "csms-to-cp",
+      messageType: "CALLRESULT",
+      messageId: startMsgId,
+      payload: { idTagInfo: { status: "Accepted" }, transactionId },
+    }),
+    rec({
+      connectorId,
+      timestamp: "2026-01-01T00:00:20.000Z",
+      direction: "cp-to-csms",
+      messageType: "CALL",
+      messageId: `${startMsgId}-status`,
+      action: "StatusNotification",
+      payload: { connectorId, status: "Charging", errorCode: "NoError" },
+    }),
+    rec({
+      timestamp: "2026-01-01T00:01:00.000Z",
+      direction: "cp-to-csms",
+      messageType: "CALL",
+      messageId: stopMsgId,
+      action: "StopTransaction",
+      payload: {
+        transactionId,
+        meterStop: 1000,
+        timestamp: "2026-01-01T00:01:00.000Z",
+        idTag: `TAG-${connectorId}`,
+        reason: "Local",
+      },
+    }),
+    rec({
+      timestamp: "2026-01-01T00:01:01.000Z",
+      direction: "csms-to-cp",
+      messageType: "CALLRESULT",
+      messageId: stopMsgId,
+      payload: {},
+    }),
+  ];
+}
+
+async function withCapturedIo<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; stdout: string; stderr: string }> {
+  const originalStdout = process.stdout.write.bind(process.stdout);
+  const originalStderr = process.stderr.write.bind(process.stderr);
+  let stdout = "";
+  let stderr = "";
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdout += chunk.toString();
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += chunk.toString();
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const result = await fn();
+    return { result, stdout, stderr };
+  } finally {
+    process.stdout.write = originalStdout;
+    process.stderr.write = originalStderr;
+  }
+}
+
+describe("runAnalyze --split-by connector (integration, real @ocpp-debugkit/toolkit)", () => {
+  let dir: string;
+
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("defaults to charge-point splitting when --split-by is not given: one report for the whole station", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "analyze-splitby-default-"));
+    const tracePath = path.join(dir, "trace.jsonl");
+    const outPath = path.join(dir, "out.md");
+
+    const lines = [
+      rec({
+        timestamp: "2026-01-01T00:00:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "boot",
+        action: "BootNotification",
+        payload: {},
+      }),
+      ...session(1, "s1", 1001, "e1"),
+      ...session(2, "s2", 2002, "e2"),
+    ];
+    fs.writeFileSync(tracePath, lines.join("\n") + "\n");
+
+    const { result: code } = await withCapturedIo(() =>
+      runAnalyze({ file: tracePath, output: outPath }),
+    );
+
+    expect(code).toBe(0);
+    // Single group (the whole trace is one charge point, unsplit by
+    // connector) -> the plain --output path, same as any other single-CP
+    // trace (runAnalyze.ts only suffixes the filename per-group when there
+    // is more than one group).
+    expect(fs.existsSync(outPath)).toBe(true);
+    expect(fs.existsSync(path.join(dir, "out.CP001-connector1.md"))).toBe(
+      false,
+    );
+    expect(fs.existsSync(path.join(dir, "out.CP001-connector2.md"))).toBe(
+      false,
+    );
+  });
+
+  it("--split-by connector produces one report per connector, each containing the replicated station-level BootNotification, and named <cpId>-connector<N>", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "analyze-splitby-connector-"));
+    const tracePath = path.join(dir, "trace.jsonl");
+    const outPath = path.join(dir, "out.md");
+
+    const lines = [
+      rec({
+        timestamp: "2026-01-01T00:00:00.000Z",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "boot",
+        action: "BootNotification",
+        payload: { chargePointVendor: "V", chargePointModel: "M" },
+      }),
+      rec({
+        timestamp: "2026-01-01T00:00:01.000Z",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: "boot",
+        payload: {
+          status: "Accepted",
+          currentTime: "2026-01-01T00:00:01.000Z",
+          interval: 300,
+        },
+      }),
+      ...session(1, "s1", 1001, "e1"),
+      ...session(2, "s2", 2002, "e2"),
+    ];
+    fs.writeFileSync(tracePath, lines.join("\n") + "\n");
+
+    const { result: code, stdout } = await withCapturedIo(() =>
+      runAnalyze({ file: tracePath, output: outPath, splitBy: "connector" }),
+    );
+
+    expect(code).toBe(0);
+
+    const conn1Path = path.join(dir, "out.CP001-connector1.md");
+    const conn2Path = path.join(dir, "out.CP001-connector2.md");
+    expect(fs.existsSync(conn1Path)).toBe(true);
+    expect(fs.existsSync(conn2Path)).toBe(true);
+    expect(stdout).toContain(`Wrote report: ${conn1Path}`);
+    expect(stdout).toContain(`Wrote report: ${conn2Path}`);
+
+    const conn1 = fs.readFileSync(conn1Path, "utf8");
+    const conn2 = fs.readFileSync(conn2Path, "utf8");
+
+    // Each connector's own session (identified by its transaction id, since
+    // the markdown reporter doesn't dump full payloads) is present in its
+    // own report...
+    expect(conn1).toContain("1001");
+    expect(conn2).toContain("2002");
+    // ...and NOT in the other connector's report -- the whole point of the
+    // split (mirrors STATUS_TRANSITION_VIOLATION cross-connector noise from
+    // the task brief: connector 1 and connector 2's StatusNotifications no
+    // longer land in the same timeline).
+    expect(conn1).not.toContain("2002");
+    expect(conn2).not.toContain("1001");
+    expect(conn1).toContain("s1");
+    expect(conn1).not.toContain("s2");
+    expect(conn2).toContain("s2");
+    expect(conn2).not.toContain("s1-status");
+
+    // The station-level BootNotification is replicated into both.
+    expect(conn1).toContain("BootNotification");
+    expect(conn2).toContain("BootNotification");
+  });
+
+  it("--split-by connector still isolates two charge points from each other (chargePointId split still applies first)", async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "analyze-splitby-multicp-"));
+    const tracePath = path.join(dir, "trace.jsonl");
+    const outPath = path.join(dir, "out.md");
+
+    const cpBLine = JSON.stringify({
+      schemaVersion: "1.1",
+      ocppVersion: "1.6",
+      transport: "json",
+      chargePointId: "CP002",
+      connectorId: 1,
+      timestamp: "2026-01-01T00:00:00.000Z",
+      direction: "cp-to-csms",
+      messageType: "CALL",
+      messageId: "b1",
+      action: "StatusNotification",
+      payload: { connectorId: 1, status: "Available", errorCode: "NoError" },
+    });
+
+    const lines = [...session(1, "s1", 1001, "e1"), cpBLine];
+    fs.writeFileSync(tracePath, lines.join("\n") + "\n");
+
+    const { result: code } = await withCapturedIo(() =>
+      runAnalyze({ file: tracePath, output: outPath, splitBy: "connector" }),
+    );
+
+    expect(code).toBe(0);
+    expect(fs.existsSync(path.join(dir, "out.CP001-connector1.md"))).toBe(true);
+    expect(fs.existsSync(path.join(dir, "out.CP002-connector1.md"))).toBe(true);
+  });
+});

--- a/src/cli/analyze/__tests__/splitTrace.test.ts
+++ b/src/cli/analyze/__tests__/splitTrace.test.ts
@@ -187,4 +187,255 @@ describe("splitTraceJsonl", () => {
 
     expect(split.byChargePoint.get("CP-A")).toBe(raw + "\n");
   });
+
+  it("defaults to splitBy 'charge-point' -- an explicit 'charge-point' produces byte-identical output to the implicit default", () => {
+    const a1 = line({
+      ocppVersion: "1.6",
+      transport: "json",
+      chargePointId: "CP-A",
+      messageType: "CALL",
+      messageId: "1",
+      action: "Heartbeat",
+    });
+    const jsonl = a1 + "\n";
+
+    const implicit = splitTraceJsonl(jsonl);
+    const explicit = splitTraceJsonl(jsonl, "charge-point");
+
+    expect(explicit.byChargePoint.get("CP-A")).toBe(
+      implicit.byChargePoint.get("CP-A"),
+    );
+    expect(Array.from(explicit.byChargePoint.keys())).toEqual(
+      Array.from(implicit.byChargePoint.keys()),
+    );
+  });
+});
+
+describe("splitTraceJsonl (splitBy: 'connector')", () => {
+  /** Builds one CP-A connector-scoped session (Start/MeterValues/Stop) whose
+   *  StartTransaction messageId, transactionId and connectorId are all
+   *  distinct per call, so cross-connector mixups would be caught. */
+  function session(
+    connectorId: number,
+    startMsgId: string,
+    transactionId: number,
+    stopMsgId: string,
+  ): string[] {
+    return [
+      line({
+        ocppVersion: "1.6",
+        transport: "json",
+        chargePointId: "CP-A",
+        connectorId,
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: startMsgId,
+        action: "StartTransaction",
+        payload: { connectorId, idTag: `TAG-${connectorId}`, meterStart: 0 },
+      }),
+      line({
+        ocppVersion: "1.6",
+        transport: "json",
+        chargePointId: "CP-A",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: startMsgId,
+        payload: { idTagInfo: { status: "Accepted" }, transactionId },
+      }),
+      line({
+        ocppVersion: "1.6",
+        transport: "json",
+        chargePointId: "CP-A",
+        connectorId,
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: `${startMsgId}-mv`,
+        action: "MeterValues",
+        payload: {
+          connectorId,
+          transactionId,
+          meterValue: [{ sampledValue: [{ value: "100" }] }],
+        },
+      }),
+      line({
+        ocppVersion: "1.6",
+        transport: "json",
+        chargePointId: "CP-A",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: stopMsgId,
+        action: "StopTransaction",
+        payload: { transactionId, meterStop: 100, reason: "Local" },
+      }),
+      line({
+        ocppVersion: "1.6",
+        transport: "json",
+        chargePointId: "CP-A",
+        direction: "csms-to-cp",
+        messageType: "CALLRESULT",
+        messageId: stopMsgId,
+        payload: {},
+      }),
+    ];
+  }
+
+  it("groups a station's own-connectorId-carrying records (StatusNotification/MeterValues/StartTransaction) by connectorId, keyed '<cpId>-connector<N>'", () => {
+    const lines = [
+      ...session(1, "s1", 1001, "e1"),
+      ...session(2, "s2", 2002, "e2"),
+    ];
+
+    const split = splitTraceJsonl(lines.join("\n") + "\n", "connector");
+
+    expect(Array.from(split.byChargePoint.keys())).toEqual([
+      "CP-A-connector1",
+      "CP-A-connector2",
+    ]);
+    const conn1 = split.byChargePoint.get("CP-A-connector1") ?? "";
+    const conn2 = split.byChargePoint.get("CP-A-connector2") ?? "";
+    expect(conn1).toContain('"messageId":"s1"');
+    expect(conn1).toContain('"messageId":"s1-mv"');
+    expect(conn1).toContain('"messageId":"e1"');
+    expect(conn1).not.toContain('"messageId":"s2"');
+    expect(conn1).not.toContain('"messageId":"e2"');
+    expect(conn2).toContain('"messageId":"s2"');
+    expect(conn2).toContain('"messageId":"s2-mv"');
+    expect(conn2).toContain('"messageId":"e2"');
+    expect(conn2).not.toContain('"messageId":"s1"');
+  });
+
+  it("resolves StopTransaction's connector via StartTransaction messageId -> CALLRESULT transactionId -> StartTransaction connectorId correlation (StopTransaction itself carries only transactionId)", () => {
+    const lines = [
+      ...session(1, "s1", 1001, "e1"),
+      ...session(2, "s2", 2002, "e2"),
+    ];
+
+    const split = splitTraceJsonl(lines.join("\n") + "\n", "connector");
+
+    const conn1 = split.byChargePoint.get("CP-A-connector1") ?? "";
+    const conn2 = split.byChargePoint.get("CP-A-connector2") ?? "";
+    // The StopTransaction CALL for transaction 1001 (connector 1) lands only
+    // in connector 1's group, not connector 2's, even though its own
+    // payload has no connectorId field at all.
+    expect(conn1).toContain('"messageId":"e1"');
+    expect(conn1).toContain('"action":"StopTransaction"');
+    expect(conn2).not.toContain('"messageId":"e1"');
+  });
+
+  it("routes a CALLRESULT to the same connector group as the CALL it answers (inherits by messageId), instead of treating every response as station-level", () => {
+    const lines = [
+      ...session(1, "s1", 1001, "e1"),
+      ...session(2, "s2", 2002, "e2"),
+    ];
+
+    const split = splitTraceJsonl(lines.join("\n") + "\n", "connector");
+
+    const conn1 = split.byChargePoint.get("CP-A-connector1") ?? "";
+    const conn2 = split.byChargePoint.get("CP-A-connector2") ?? "";
+    // StartTransaction's CALLRESULT (messageId "s1") carries the
+    // transactionId used to resolve StopTransaction's connector, and must
+    // itself only live in connector 1's group -- if it were replicated to
+    // every group as "station-level", it would produce a phantom session in
+    // connector 2's report too (a new false positive, the exact artifact
+    // this feature exists to avoid).
+    expect(conn1).toContain('"messageType":"CALLRESULT","messageId":"s1"');
+    expect(conn2).not.toContain('"messageType":"CALLRESULT","messageId":"s1"');
+  });
+
+  it("replicates station-level records (no connector at all, e.g. BootNotification/Heartbeat) into every connector group", () => {
+    const boot = line({
+      ocppVersion: "1.6",
+      transport: "json",
+      chargePointId: "CP-A",
+      direction: "cp-to-csms",
+      messageType: "CALL",
+      messageId: "boot",
+      action: "BootNotification",
+      payload: {},
+    });
+    const lines = [
+      boot,
+      ...session(1, "s1", 1001, "e1"),
+      ...session(2, "s2", 2002, "e2"),
+    ];
+
+    const split = splitTraceJsonl(lines.join("\n") + "\n", "connector");
+
+    expect(split.byChargePoint.get("CP-A-connector1")).toContain(
+      '"messageId":"boot"',
+    );
+    expect(split.byChargePoint.get("CP-A-connector2")).toContain(
+      '"messageId":"boot"',
+    );
+  });
+
+  it("treats connectorId: 0 as station-level (not connector 1), replicated into every connector group", () => {
+    const stationStatus = line({
+      ocppVersion: "1.6",
+      transport: "json",
+      chargePointId: "CP-A",
+      connectorId: 0,
+      direction: "cp-to-csms",
+      messageType: "CALL",
+      messageId: "st0",
+      action: "StatusNotification",
+      payload: { connectorId: 0, status: "Available", errorCode: "NoError" },
+    });
+    const lines = [
+      stationStatus,
+      ...session(1, "s1", 1001, "e1"),
+      ...session(2, "s2", 2002, "e2"),
+    ];
+
+    const split = splitTraceJsonl(lines.join("\n") + "\n", "connector");
+
+    expect(split.byChargePoint.get("CP-A-connector1")).toContain(
+      '"messageId":"st0"',
+    );
+    expect(split.byChargePoint.get("CP-A-connector2")).toContain(
+      '"messageId":"st0"',
+    );
+  });
+
+  it("falls back to one plain-cpId group (not connector-suffixed) when a charge point has no connector-scoped records at all, so nothing is silently dropped", () => {
+    const lines = [
+      line({
+        ocppVersion: "1.6",
+        transport: "json",
+        chargePointId: "CP-B",
+        direction: "cp-to-csms",
+        messageType: "CALL",
+        messageId: "1",
+        action: "Heartbeat",
+        payload: {},
+      }),
+    ];
+
+    const split = splitTraceJsonl(lines.join("\n") + "\n", "connector");
+
+    expect(Array.from(split.byChargePoint.keys())).toEqual(["CP-B"]);
+    expect(split.byChargePoint.get("CP-B")).toContain('"action":"Heartbeat"');
+  });
+
+  it("keeps the split independent per charge point: CP-A's connector groups don't see CP-B's records", () => {
+    const cpBLine = line({
+      ocppVersion: "1.6",
+      transport: "json",
+      chargePointId: "CP-B",
+      connectorId: 1,
+      direction: "cp-to-csms",
+      messageType: "CALL",
+      messageId: "b1",
+      action: "StatusNotification",
+      payload: { connectorId: 1, status: "Available", errorCode: "NoError" },
+    });
+    const lines = [...session(1, "s1", 1001, "e1"), cpBLine];
+
+    const split = splitTraceJsonl(lines.join("\n") + "\n", "connector");
+
+    expect(Array.from(split.byChargePoint.keys())).toEqual([
+      "CP-A-connector1",
+      "CP-B-connector1",
+    ]);
+  });
 });

--- a/src/cli/analyze/meterAnomaly.ts
+++ b/src/cli/analyze/meterAnomaly.ts
@@ -1,0 +1,291 @@
+/**
+ * Post-processing layer for `analyze` (issue #188 Track 3): recomputes
+ * `METER_VALUE_ANOMALY` findings correctly and replaces the toolkit's own
+ * (wrong) findings with them.
+ *
+ * Exists to compensate for two real defects in the OCPP DebugKit toolkit's
+ * rule 14, `detectMeterValueAnomaly` (probed against the real 0.4.0 install
+ * by reading `node_modules/@ocpp-debugkit/toolkit/dist/core/detection.js`
+ * directly, not inferred):
+ *
+ * 1. It pushes every `sampledValue.value` in a session into one flat
+ *    `readings[]` array -- across ALL `measurand`s, `phase`s, `unit`s, and
+ *    `location`s at once -- and then asserts that flat sequence never
+ *    decreases. Only cumulative registers (`Energy.*.Register`) are
+ *    monotonic per OCPP 1.6 §7.28; `Power.Active.Import`, `SoC`,
+ *    `Current.Import`, `Voltage`, `Temperature`, etc. legitimately rise and
+ *    fall within a session (a charge taper, a V2G discharge, ambient
+ *    heating). A charge point that reports two measurands per sample --
+ *    completely normal -- gets a false warning on nearly every message: a
+ *    real observed trace with a strictly-monotonic
+ *    `Energy.Active.Import.Register` (+25 Wh every 30s, exactly 3 kW) that
+ *    also sent a constant `Power.Active.Import = 3000 W` in the same
+ *    `MeterValues` produced 22 false "Non-monotonic meter reading: value
+ *    decreased from 3000 to 625" warnings.
+ * 2. `connectorId` appears exactly once in the whole file -- inside a
+ *    comment. No rule groups by connector, so on a multi-connector station,
+ *    two connectors' independent (each individually monotonic) meters can
+ *    be interleaved into that same one flat series too (observed: 80 false
+ *    warnings on a real 4-connector trace). This happens whenever
+ *    `buildSessionTimeline` can't key events by `transactionId` (e.g. a
+ *    trace excerpt with `MeterValues` but no correlated `StartTransaction`)
+ *    and falls back to lumping every event from every connector into one
+ *    `session-0`.
+ *
+ * The fix: bucket readings by `(connectorId, measurand, phase, unit,
+ * location)` and only run the monotonicity/negative-value check within a
+ * bucket, and only for the four cumulative registers. See
+ * `detectCorrectedMeterValueAnomalies` below.
+ *
+ * This is deliberately a POST-processing step -- it runs on `sessions` and
+ * `failures` already produced by the real toolkit pipeline -- rather than
+ * scrubbing/regrouping the `events` handed to the toolkit beforehand (the
+ * way `splitTrace.ts` pre-processes by `chargePointId`). The report's
+ * timeline and Event Appendix must still show the real, unmodified
+ * `MeterValues` payloads exactly as the charge point sent them; rewriting
+ * or splitting events before `parseOpenOcppTrace`/`buildSessionTimeline`
+ * would corrupt that record. Recomputing findings afterward, from the same
+ * `session.events` the toolkit already built, keeps the event list honest
+ * while still fixing what gets reported as a failure.
+ */
+
+import type {
+  Failure,
+  FailureSeverity,
+  Session,
+} from "@ocpp-debugkit/toolkit/core";
+
+/**
+ * Cumulative (monotonically non-decreasing, per OCPP 1.6 §7.28) energy
+ * register measurands. Everything else (`Power.Active.Import`, `SoC`,
+ * `Current.Import`, `Voltage`, `Temperature`, `Frequency`, ...) is expected
+ * to rise and fall within a session and must never be monotonicity-checked.
+ */
+const CUMULATIVE_MEASURANDS = new Set<string>([
+  "Energy.Active.Import.Register",
+  "Energy.Reactive.Import.Register",
+  "Energy.Active.Export.Register",
+  "Energy.Reactive.Export.Register",
+]);
+
+/**
+ * `SEVERITY.METER_VALUE_ANOMALY` and `SUGGESTED_STEPS.METER_VALUE_ANOMALY`,
+ * copied verbatim from the installed
+ * `node_modules/@ocpp-debugkit/toolkit/dist/core/detection.js` (0.4.0).
+ * Neither is exported from the toolkit's public `/core` entry point --
+ * `dist/core/index.js` only re-exports `detectFailures` itself, not the
+ * internal `SEVERITY`/`SUGGESTED_STEPS` tables it's built from -- and
+ * they're not reachable via any other subpath export either, so there is
+ * nothing to import here; this is a deliberate, pinned copy, not a guess.
+ * `@ocpp-debugkit/toolkit` is pinned to an exact `0.4.0` (no `^` range) in
+ * package.json specifically so an upstream wording change can't silently
+ * drift this copy out from under us (docs/cli.md -> analyze -> Dependency).
+ */
+const METER_VALUE_ANOMALY_SEVERITY: FailureSeverity = "warning";
+const METER_VALUE_ANOMALY_SUGGESTED_STEPS: string[] = [
+  "Verify the meter is functioning correctly and is properly calibrated",
+  "Check for meter communication errors or data corruption",
+  "Review the meter value sampling and reporting configuration",
+  "Inspect for potential tampering or hardware malfunction",
+  "Contact the meter vendor if the issue persists",
+];
+
+interface Reading {
+  eventId: string;
+  value: number;
+}
+
+/** Bucket key: distinct (connectorId, measurand, phase, unit, location)
+ *  combinations are physically distinct meter series and must never be
+ *  compared against each other for monotonicity. `null`/`undefined`
+ *  components are kept distinct from any concrete value via JSON encoding,
+ *  not coerced to a shared sentinel that could collide with a real value. */
+function bucketKey(
+  connectorId: number | null,
+  measurand: string,
+  phase: string | undefined,
+  unit: string | undefined,
+  location: string | undefined,
+): string {
+  return JSON.stringify([
+    connectorId,
+    measurand,
+    phase ?? null,
+    unit ?? null,
+    location ?? null,
+  ]);
+}
+
+/** Shape mirrors the toolkit's own MeterValues payload assumption (see the
+ *  comment in detection.js): `{ connectorId, transactionId, meterValue: [{
+ *  timestamp, sampledValue: [{ value, measurand?, phase?, unit?, location?
+ *  }] }] }`. `payload` is `unknown` on the normalized `Event`, so every
+ *  field is read defensively, same as the toolkit itself does. */
+interface MeterValuesPayloadLike {
+  connectorId?: unknown;
+  meterValue?: unknown;
+}
+interface MeterValueEntryLike {
+  sampledValue?: unknown;
+}
+interface SampledValueLike {
+  value?: unknown;
+  measurand?: unknown;
+  phase?: unknown;
+  unit?: unknown;
+  location?: unknown;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Extracts one session's cumulative-register readings, correctly bucketed.
+ *  Mirrors detection.js's own MeterValues traversal order (event ->
+ *  meterValue[] -> sampledValue[]) so findings still enumerate in a
+ *  reading's natural chronological order within each bucket. */
+function collectBuckets(session: Session): Map<string, Reading[]> {
+  const buckets = new Map<string, Reading[]>();
+  const meterEvents = session.events.filter(
+    (e) => e.messageType === "Call" && e.action === "MeterValues",
+  );
+
+  for (const event of meterEvents) {
+    const payload = event.payload as MeterValuesPayloadLike | null | undefined;
+    const connectorId =
+      typeof payload?.connectorId === "number" ? payload.connectorId : null;
+    const meterValues = payload?.meterValue;
+    if (!Array.isArray(meterValues)) continue;
+
+    for (const mv of meterValues as MeterValueEntryLike[]) {
+      const sampledValues = mv?.sampledValue;
+      if (!Array.isArray(sampledValues)) continue;
+
+      for (const sv of sampledValues as SampledValueLike[]) {
+        const rawValue = sv?.value;
+        let numValue: number | undefined;
+        if (typeof rawValue === "string") {
+          const parsed = Number.parseFloat(rawValue);
+          if (!Number.isNaN(parsed)) numValue = parsed;
+        } else if (typeof rawValue === "number") {
+          numValue = rawValue;
+        }
+        if (numValue === undefined) continue;
+
+        // OCPP 1.6 §7.28: `sampledValue.measurand` is OPTIONAL and defaults
+        // to "Energy.Active.Import.Register" when absent. An absent
+        // measurand is NOT "unknown, skip it" -- it has a spec-defined
+        // meaning, so it must be treated as the cumulative register, same
+        // as an explicit one.
+        const measurand =
+          asString(sv?.measurand) ?? "Energy.Active.Import.Register";
+        if (!CUMULATIVE_MEASURANDS.has(measurand)) {
+          // Not a cumulative register (Power.Active.Import, SoC,
+          // Current.Import, Voltage, Temperature, ...): these legitimately
+          // rise and fall within a session (charge taper, V2G discharge,
+          // thermal drift). Neither the monotonicity check nor the
+          // negative-value check below applies to them -- a negative
+          // Power.Active.Import / Current.Import in particular is the
+          // normal, expected shape of a bidirectional (V2G) charger
+          // discharging back to the grid, not an anomaly.
+          continue;
+        }
+
+        const key = bucketKey(
+          connectorId,
+          measurand,
+          asString(sv?.phase),
+          asString(sv?.unit),
+          asString(sv?.location),
+        );
+        const reading: Reading = { eventId: event.id, value: numValue };
+        const bucket = buckets.get(key);
+        if (bucket) bucket.push(reading);
+        else buckets.set(key, [reading]);
+      }
+    }
+  }
+
+  return buckets;
+}
+
+function makeFinding(description: string, eventIds: string[]): Failure {
+  return {
+    code: "METER_VALUE_ANOMALY",
+    description,
+    severity: METER_VALUE_ANOMALY_SEVERITY,
+    eventIds,
+    suggestedSteps: METER_VALUE_ANOMALY_SUGGESTED_STEPS,
+  };
+}
+
+/**
+ * Correctly-derived replacement for the toolkit's rule 14
+ * (`detectMeterValueAnomaly`). Same scope as the toolkit's own rule --
+ * sessions with no `transactionId` are skipped, matching
+ * `detectMeterValueAnomaly`'s own `if (session.transactionId === null)
+ * continue;` -- but within that scope, cumulative-register readings are
+ * bucketed by `(connectorId, measurand, phase, unit, location)` before the
+ * monotonicity/negative-value checks run, instead of the toolkit's single
+ * flat per-session array.
+ */
+export function detectCorrectedMeterValueAnomalies(
+  sessions: Session[],
+): Failure[] {
+  const findings: Failure[] = [];
+
+  for (const session of sessions) {
+    if (session.transactionId === null) continue;
+
+    const buckets = collectBuckets(session);
+    for (const readings of buckets.values()) {
+      for (const reading of readings) {
+        if (reading.value < 0) {
+          findings.push(
+            makeFinding(
+              `Negative meter value detected: ${reading.value} in session ${session.sessionId} (transaction ${session.transactionId})`,
+              [reading.eventId],
+            ),
+          );
+        }
+      }
+      for (let i = 1; i < readings.length; i++) {
+        const prev = readings[i - 1];
+        const curr = readings[i];
+        if (!prev || !curr) continue;
+        if (curr.value < prev.value) {
+          findings.push(
+            makeFinding(
+              `Non-monotonic meter reading: value decreased from ${prev.value} to ${curr.value} in session ${session.sessionId} (transaction ${session.transactionId})`,
+              [prev.eventId, curr.eventId],
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Strips every `METER_VALUE_ANOMALY` finding the toolkit produced and
+ * replaces them with `detectCorrectedMeterValueAnomalies`'s correctly-scoped
+ * ones, leaving every other failure code untouched. Called between
+ * `detectFailures(...)` and `summarizeSessions(...)` in `runAnalyze.ts` so
+ * `summarizeSessions`' per-session failure counts (which intersect a
+ * failure's `eventIds` against `session.events`) count the corrected set,
+ * not the toolkit's raw one.
+ */
+export function correctMeterValueAnomalies(
+  sessions: Session[],
+  failures: Failure[],
+): Failure[] {
+  const withoutMeterAnomalies = failures.filter(
+    (f) => f.code !== "METER_VALUE_ANOMALY",
+  );
+  return [
+    ...withoutMeterAnomalies,
+    ...detectCorrectedMeterValueAnomalies(sessions),
+  ];
+}

--- a/src/cli/analyze/parseAnalyzeArgs.ts
+++ b/src/cli/analyze/parseAnalyzeArgs.ts
@@ -9,21 +9,47 @@
  */
 
 export interface AnalyzeCliArgs {
-  file: string;
+  /** Trace file to read. Undefined when `fromDaemon` is set. */
+  file?: string;
   output?: string;
   format?: "html" | "markdown";
+  /** Build the trace from a running daemon's stored logs instead of a file.
+   *  Only ever `true` or absent, so `toEqual` assertions that predate this
+   *  flag keep passing. */
+  fromDaemon?: true;
+  /** Charge point whose logs to pull. Required by `--from-daemon` because
+   *  the daemon's `logs.get` RPC is scoped to one charge point. */
+  cpId?: string;
+  httpUrl?: string;
+  httpBasicAuth?: { username: string; password: string };
 }
 
 export type AnalyzeCliParseResult =
   { ok: true; args: AnalyzeCliArgs } | { ok: false; message: string };
 
 export const ANALYZE_USAGE =
-  "Usage: ocpp-cp-sim analyze <trace.jsonl> [--output <file>] [--format html|markdown]";
+  "Usage: ocpp-cp-sim analyze <trace.jsonl> [--output <file>] [--format html|markdown]\n" +
+  "       ocpp-cp-sim analyze --from-daemon --cp-id <id> [--http-url <url>]\n" +
+  "                           [--http-basic-auth-user <u> --http-basic-auth-pass <p>]\n" +
+  "                           [--output <file>] [--format html|markdown]";
+
+/** Flags that only mean something when the trace comes from a daemon. */
+const DAEMON_ONLY_FLAGS = [
+  "--cp-id",
+  "--http-url",
+  "--http-basic-auth-user",
+  "--http-basic-auth-pass",
+];
 
 export function parseAnalyzeArgs(argv: string[]): AnalyzeCliParseResult {
   let file: string | undefined;
   let output: string | undefined;
   let format: "html" | "markdown" | undefined;
+  let fromDaemon = false;
+  let cpId: string | undefined;
+  let httpUrl: string | undefined;
+  let basicAuthUser: string | undefined;
+  let basicAuthPass: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -44,6 +70,18 @@ export function parseAnalyzeArgs(argv: string[]): AnalyzeCliParseResult {
       }
       format = next;
       i++;
+    } else if (arg === "--from-daemon") {
+      fromDaemon = true;
+    } else if (DAEMON_ONLY_FLAGS.includes(arg)) {
+      const next = argv[i + 1];
+      if (!next || next.startsWith("-")) {
+        return { ok: false, message: `Error: ${arg} requires a value` };
+      }
+      if (arg === "--cp-id") cpId = next;
+      else if (arg === "--http-url") httpUrl = next;
+      else if (arg === "--http-basic-auth-user") basicAuthUser = next;
+      else basicAuthPass = next;
+      i++;
     } else if (arg.startsWith("-")) {
       return { ok: false, message: `Unknown option: ${arg}` };
     } else if (file === undefined) {
@@ -52,6 +90,65 @@ export function parseAnalyzeArgs(argv: string[]): AnalyzeCliParseResult {
       // A second positional argument: analyze only takes one trace file.
       return { ok: false, message: `Unknown option: ${arg}` };
     }
+  }
+
+  const daemonFlagsUsed =
+    cpId !== undefined ||
+    httpUrl !== undefined ||
+    basicAuthUser !== undefined ||
+    basicAuthPass !== undefined;
+
+  if (!fromDaemon && daemonFlagsUsed) {
+    return {
+      ok: false,
+      message:
+        "Error: --cp-id / --http-url / --http-basic-auth-* are only valid " +
+        `with --from-daemon\n${ANALYZE_USAGE}`,
+    };
+  }
+
+  if (fromDaemon) {
+    // A file and a daemon are two different trace sources; silently
+    // preferring one would hide which of the two the report describes.
+    if (file !== undefined) {
+      return {
+        ok: false,
+        message:
+          "Error: --from-daemon cannot be combined with a trace file " +
+          `(got "${file}")\n${ANALYZE_USAGE}`,
+      };
+    }
+    if (!cpId) {
+      return {
+        ok: false,
+        message: `Error: --from-daemon requires --cp-id <id>\n${ANALYZE_USAGE}`,
+      };
+    }
+    // Half-specified Basic Auth is a misconfiguration, not a request for
+    // anonymous access -- the daemon would reject it with an opaque 401.
+    if ((basicAuthUser === undefined) !== (basicAuthPass === undefined)) {
+      return {
+        ok: false,
+        message:
+          "Error: --http-basic-auth-user and --http-basic-auth-pass must be " +
+          `given together\n${ANALYZE_USAGE}`,
+      };
+    }
+    return {
+      ok: true,
+      args: {
+        file: undefined,
+        output,
+        format,
+        fromDaemon: true,
+        cpId,
+        httpUrl,
+        httpBasicAuth:
+          basicAuthUser !== undefined && basicAuthPass !== undefined
+            ? { username: basicAuthUser, password: basicAuthPass }
+            : undefined,
+      },
+    };
   }
 
   if (!file) {

--- a/src/cli/analyze/parseAnalyzeArgs.ts
+++ b/src/cli/analyze/parseAnalyzeArgs.ts
@@ -22,6 +22,12 @@ export interface AnalyzeCliArgs {
   cpId?: string;
   httpUrl?: string;
   httpBasicAuth?: { username: string; password: string };
+  /** How to group trace records before handing them to the toolkit.
+   *  Undefined means "charge-point" (current behavior, unchanged) -- kept
+   *  undefined rather than defaulted here so `toEqual` assertions that
+   *  predate this flag keep passing (see splitTrace.ts for what each mode
+   *  does). */
+  splitBy?: "charge-point" | "connector";
 }
 
 export type AnalyzeCliParseResult =
@@ -29,9 +35,11 @@ export type AnalyzeCliParseResult =
 
 export const ANALYZE_USAGE =
   "Usage: ocpp-cp-sim analyze <trace.jsonl> [--output <file>] [--format html|markdown]\n" +
+  "                           [--split-by charge-point|connector]\n" +
   "       ocpp-cp-sim analyze --from-daemon --cp-id <id> [--http-url <url>]\n" +
   "                           [--http-basic-auth-user <u> --http-basic-auth-pass <p>]\n" +
-  "                           [--output <file>] [--format html|markdown]";
+  "                           [--output <file>] [--format html|markdown]\n" +
+  "                           [--split-by charge-point|connector]";
 
 /** Flags that only mean something when the trace comes from a daemon. */
 const DAEMON_ONLY_FLAGS = [
@@ -50,6 +58,7 @@ export function parseAnalyzeArgs(argv: string[]): AnalyzeCliParseResult {
   let httpUrl: string | undefined;
   let basicAuthUser: string | undefined;
   let basicAuthPass: string | undefined;
+  let splitBy: "charge-point" | "connector" | undefined;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -72,6 +81,16 @@ export function parseAnalyzeArgs(argv: string[]): AnalyzeCliParseResult {
       i++;
     } else if (arg === "--from-daemon") {
       fromDaemon = true;
+    } else if (arg === "--split-by") {
+      const next = argv[i + 1];
+      if (next !== "charge-point" && next !== "connector") {
+        return {
+          ok: false,
+          message: "Error: --split-by must be 'charge-point' or 'connector'",
+        };
+      }
+      splitBy = next;
+      i++;
     } else if (DAEMON_ONLY_FLAGS.includes(arg)) {
       const next = argv[i + 1];
       if (!next || next.startsWith("-")) {
@@ -147,6 +166,7 @@ export function parseAnalyzeArgs(argv: string[]): AnalyzeCliParseResult {
           basicAuthUser !== undefined && basicAuthPass !== undefined
             ? { username: basicAuthUser, password: basicAuthPass }
             : undefined,
+        splitBy,
       },
     };
   }
@@ -158,5 +178,5 @@ export function parseAnalyzeArgs(argv: string[]): AnalyzeCliParseResult {
     };
   }
 
-  return { ok: true, args: { file, output, format } };
+  return { ok: true, args: { file, output, format, splitBy } };
 }

--- a/src/cli/analyze/runAnalyze.ts
+++ b/src/cli/analyze/runAnalyze.ts
@@ -18,6 +18,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { splitTraceJsonl } from "./splitTrace";
+import { correctMeterValueAnomalies } from "./meterAnomaly";
 import { fetchStoredLogs } from "../client";
 import { logLinesToTrace } from "../../trace/logEntryToTrace";
 import { DEFAULT_HTTP_PORT } from "../server/constants";
@@ -313,7 +314,15 @@ export async function runAnalyze(opts: AnalyzeOptions): Promise<number> {
     try {
       const { events, warnings } = parseOpenOcppTrace(group.jsonl);
       const sessions = buildSessionTimeline(events);
-      const failures = detectFailures(events, sessions);
+      const rawFailures = detectFailures(events, sessions);
+      // Toolkit fact (probed against the real 0.4.0 install, not inferred --
+      // see meterAnomaly.ts's module docstring): rule 14's
+      // METER_VALUE_ANOMALY flattens every measurand/phase/connector into
+      // one series per session, so a station sending more than one
+      // measurand per sample (routine) gets false non-monotonic warnings.
+      // Corrected here, between detectFailures and summarizeSessions, so
+      // the per-session failure counts below reflect the corrected set.
+      const failures = correctMeterValueAnomalies(sessions, rawFailures);
       const summaries = summarizeSessions(sessions, failures);
       const result: AnalysisResult = {
         events,

--- a/src/cli/analyze/runAnalyze.ts
+++ b/src/cli/analyze/runAnalyze.ts
@@ -18,7 +18,37 @@
 import * as fs from "fs";
 import * as path from "path";
 import { splitTraceJsonl } from "./splitTrace";
+import { fetchStoredLogs } from "../client";
+import { logLinesToTrace } from "../../trace/logEntryToTrace";
+import { DEFAULT_HTTP_PORT } from "../server/constants";
 import type { AnalysisResult } from "@ocpp-debugkit/toolkit/reporter";
+
+/** Same default the other client modes (--send/--stop/--events) resolve to. */
+const DEFAULT_DAEMON_URL = `http://127.0.0.1:${DEFAULT_HTTP_PORT}`;
+
+/**
+ * Pull a charge point's stored logs off a running daemon and adapt them into
+ * trace JSONL, so `analyze` works against a daemon that was started WITHOUT
+ * `--trace-output`.
+ *
+ * The daemon persists its log entries, and `logEntryToTrace` already maps
+ * exactly that `{timestamp, level, type, message, cpId}` shape, so no new
+ * wire format is involved: this is the file-less path through the same
+ * adapter, not a second one. Non-wire log lines (scenario/diagnostic chatter)
+ * map to null and drop out here, which is why an all-chatter log yields empty
+ * text and the caller reports "nothing to analyze".
+ */
+async function fetchDaemonTraceJsonl(opts: AnalyzeOptions): Promise<string> {
+  const lines = await fetchStoredLogs(
+    {
+      httpUrl: opts.httpUrl ?? DEFAULT_DAEMON_URL,
+      basicAuth: opts.httpBasicAuth ?? null,
+    },
+    opts.cpId as string,
+  );
+  const records = logLinesToTrace(lines, { chargePointId: opts.cpId });
+  return records.map((r) => JSON.stringify(r)).join("\n");
+}
 
 // Shared with the web console's Session Analysis tab (issue #188 PoC item
 // 8) -- moved to a browser-safe module (no node imports) so both surfaces
@@ -28,9 +58,15 @@ import { ANALYZE_DISCLAIMER } from "../../trace/analysisDisclaimer";
 export { ANALYZE_DISCLAIMER };
 
 export interface AnalyzeOptions {
-  file: string;
+  /** Trace file to read. Undefined when `fromDaemon` is set. */
+  file?: string;
   output?: string;
   format?: "html" | "markdown";
+  /** Build the trace from a running daemon's stored logs instead of a file. */
+  fromDaemon?: true;
+  cpId?: string;
+  httpUrl?: string;
+  httpBasicAuth?: { username: string; password: string };
 }
 
 /** Label for the bucket of records with no `chargePointId` at all. */
@@ -157,17 +193,48 @@ interface Group {
   jsonl: string;
 }
 
+/** What the report's `metadata.source` should say about where the trace
+ *  came from. A daemon-sourced run has no file to name, and "which daemon,
+ *  which charge point" is what makes the report reproducible. */
+export function describeTraceSource(opts: AnalyzeOptions): string {
+  if (opts.fromDaemon) {
+    const target = opts.httpUrl ?? DEFAULT_DAEMON_URL;
+    return `daemon ${target} (cp ${opts.cpId})`;
+  }
+  return opts.file ?? "(unknown)";
+}
+
 export async function runAnalyze(opts: AnalyzeOptions): Promise<number> {
   let text: string;
-  try {
-    text = fs.readFileSync(opts.file, "utf8");
-  } catch (err) {
-    process.stderr.write(
-      `Error: cannot read trace file: ${
-        err instanceof Error ? err.message : String(err)
-      }\n`,
-    );
-    return 1;
+  if (opts.fromDaemon) {
+    try {
+      text = await fetchDaemonTraceJsonl(opts);
+    } catch (err) {
+      process.stderr.write(
+        `Error: cannot read logs from daemon: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+      return 1;
+    }
+    if (text.trim() === "") {
+      process.stderr.write(
+        `Error: the daemon has no stored OCPP wire logs for charge point ` +
+          `${opts.cpId} (nothing to analyze)\n`,
+      );
+      return 1;
+    }
+  } else {
+    try {
+      text = fs.readFileSync(opts.file as string, "utf8");
+    } catch (err) {
+      process.stderr.write(
+        `Error: cannot read trace file: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+      return 1;
+    }
   }
 
   const split = splitTraceJsonl(text);
@@ -252,7 +319,7 @@ export async function runAnalyze(opts: AnalyzeOptions): Promise<number> {
         warnings,
         metadata: {
           stationId: group.id,
-          source: opts.file,
+          source: describeTraceSource(opts),
           ocppVersion: detectUniformOcppVersion(group.jsonl),
         },
       };

--- a/src/cli/analyze/runAnalyze.ts
+++ b/src/cli/analyze/runAnalyze.ts
@@ -67,6 +67,10 @@ export interface AnalyzeOptions {
   cpId?: string;
   httpUrl?: string;
   httpBasicAuth?: { username: string; password: string };
+  /** How to group trace records before analysis. Undefined means
+   *  "charge-point" (see splitTrace.ts's module docstring for what
+   *  "connector" does and why it's opt-in). */
+  splitBy?: "charge-point" | "connector";
 }
 
 /** Label for the bucket of records with no `chargePointId` at all. */
@@ -237,7 +241,7 @@ export async function runAnalyze(opts: AnalyzeOptions): Promise<number> {
     }
   }
 
-  const split = splitTraceJsonl(text);
+  const split = splitTraceJsonl(text, opts.splitBy ?? "charge-point");
 
   const groups: Group[] = [];
   for (const [cpId, jsonl] of split.byChargePoint)

--- a/src/cli/analyze/splitTrace.ts
+++ b/src/cli/analyze/splitTrace.ts
@@ -1,6 +1,7 @@
 /**
  * Pre-processing layer for `analyze` (issue #188 Track 3): splits a v1.1
- * trace JSONL file into one JSONL blob per charge point.
+ * trace JSONL file into one JSONL blob per charge point, and optionally
+ * further into one blob per connector.
  *
  * Exists to compensate for a real limitation of the OCPP DebugKit toolkit
  * (probed against the real 0.4.0 install, not inferred): its analysis
@@ -22,12 +23,92 @@
  * Deliberately has no dependency on the toolkit (or anything else) so it is
  * cheap to unit test in isolation and cannot be affected by how the toolkit
  * is imported/loaded elsewhere in the analyze code path.
+ *
+ * ---------------------------------------------------------------------------
+ * Optional connector splitting (`splitBy: "connector"`, issue #188 usability
+ * follow-up)
+ * ---------------------------------------------------------------------------
+ *
+ * The toolkit's rules operate over a whole station's events at once, same
+ * root defect as the chargePointId problem above: `connectorId` appears
+ * exactly once in the installed `dist/core/detection.js` — inside a comment
+ * — and no rule groups by it. `STATUS_TRANSITION_VIOLATION` in particular
+ * treats connector A going `Available` while connector B (on the same
+ * station) goes `Finishing` as one, invalid, transition (observed: 24
+ * findings on a real 4-connector trace; hand-filtering that trace down to a
+ * single connector reduced it to 1 real one). Unlike the measurand defect
+ * fixed in `meterAnomaly.ts`, this cannot be corrected by re-deriving
+ * findings after the fact — `STATUS_TRANSITION_VIOLATION` needs to never see
+ * another connector's `StatusNotification`s in the first place, which means
+ * the split has to happen here, before `parseOpenOcppTrace`, exactly like
+ * the chargePointId split above.
+ *
+ * This is opt-in (`--split-by connector`, default `"charge-point"`) rather
+ * than the always-on chargePointId split: chargePointId cross-talk is a pure
+ * toolkit bug with no legitimate reading of the data, but "should
+ * STATION_OFFLINE_DURING_SESSION / UNEXPECTED_START etc. see the whole
+ * station or just one connector" is a real judgment call an operator may
+ * want either way, so the default stays the current, whole-station
+ * behavior.
+ *
+ * Deriving a record's connector:
+ * - `StatusNotification`, `MeterValues`, `StartTransaction`,
+ *   `RemoteStartTransaction` carry `payload.connectorId` directly.
+ * - `StopTransaction` / `RemoteStopTransaction` carry only
+ *   `transactionId` — resolved by first correlating each `StartTransaction`
+ *   CALL's `messageId` to the `transactionId` in its CALLRESULT, then
+ *   mapping that transaction back to the StartTransaction's connector.
+ * - A CALLRESULT/CALLERROR itself carries no connectorId at all; it
+ *   inherits the connector of the CALL it answers (matched by messageId).
+ *   Without this, e.g. StartTransaction's own CALLRESULT — which carries
+ *   the transactionId the StopTransaction correlation above depends on —
+ *   would have nowhere connector-specific to go and would be replicated
+ *   into every connector group as "station-level" (see below), producing a
+ *   phantom session with that transactionId in every OTHER connector's
+ *   report too. That is a new false positive: the exact kind of artifact
+ *   this whole feature exists to remove.
+ * - `connectorId: 0` is station-level per OCPP 1.6 (the connector-0 /
+ *   "whole station" pseudo-connector), never connector 1.
+ *
+ * Station-level records — no derivable connector at all, whether because
+ * the action carries none (`BootNotification`, `Heartbeat`, `Authorize`,
+ * `DiagnosticsStatusNotification`, `FirmwareStatusNotification`, ...) or
+ * because it resolved to `connectorId: 0` or an unresolvable
+ * StopTransaction — are replicated into EVERY connector group. Rules like
+ * `UNEXPECTED_START` need to see the station's `BootNotification`; a
+ * per-connector group that lacked it would itself report a *new* false
+ * positive ("StartTransaction without preceding BootNotification"), again
+ * the exact artifact this change exists to remove. The unavoidable
+ * consequence: a station-level finding (e.g. a real `DIAGNOSTICS_FAILURE`)
+ * can appear in more than one per-connector report — read as "this affects
+ * the whole station, seen from connector N's report," not as N separate
+ * failures.
+ *
+ * A charge point with no connector-scoped record at all (e.g. a
+ * boot-only trace, or one connector-less OCPP profile) has nothing to
+ * derive a connector split from; rather than silently dropping every
+ * record, it falls back to a single group under its plain chargePointId,
+ * identical to `splitBy: "charge-point"` for that one charge point.
+ *
+ * Group keys are `<chargePointId>-connector<N>` (ascending numeric order),
+ * which `runAnalyze.ts` already treats as an opaque group id — its
+ * filename-sanitization and collision-disambiguation logic
+ * (`sanitizeCpIdForFilename` / `resolveGroupOutputPaths`) needs no changes
+ * to keep working on these longer ids.
  */
 
+export type TraceSplitMode = "charge-point" | "connector";
+
 export interface TraceSplit {
-  /** chargePointId -> that CP's records re-serialized as JSONL text. */
+  /** Group id -> that group's records re-serialized as JSONL text.
+   *  `splitBy: "charge-point"` (default): keyed by chargePointId.
+   *  `splitBy: "connector"`: keyed by `<chargePointId>-connector<N>`, or
+   *  the plain chargePointId for a CP with no connector-scoped records
+   *  (see module docstring). */
   byChargePoint: Map<string, string>;
-  /** Records with no chargePointId, as JSONL text ("" if none). */
+  /** Records with no chargePointId, as JSONL text ("" if none). Never
+   *  connector-split, regardless of `splitBy`: with no chargePointId there
+   *  is no meaningful transactionId/connectorId correlation scope either. */
   unattributed: string;
   excluded: {
     soap: number;
@@ -40,8 +121,174 @@ export interface TraceSplit {
   total: number;
 }
 
-export function splitTraceJsonl(jsonlText: string): TraceSplit {
-  const byChargePointLines = new Map<string, string[]>();
+interface ParsedRecord {
+  line: string;
+  record: Record<string, unknown>;
+}
+
+/** CALL actions that carry their connector directly in `payload.connectorId`. */
+const CONNECTOR_ID_ACTIONS = new Set([
+  "StatusNotification",
+  "MeterValues",
+  "StartTransaction",
+  "RemoteStartTransaction",
+]);
+/** CALL actions that carry only `payload.transactionId`; their connector is
+ *  resolved via the StartTransaction correlation (see module docstring). */
+const TRANSACTION_ID_ACTIONS = new Set([
+  "StopTransaction",
+  "RemoteStopTransaction",
+]);
+
+function getPayloadObject(
+  payload: unknown,
+): Record<string, unknown> | undefined {
+  return typeof payload === "object" &&
+    payload !== null &&
+    !Array.isArray(payload)
+    ? (payload as Record<string, unknown>)
+    : undefined;
+}
+
+/** A positive (>0) connectorId from a payload, or undefined if absent,
+ *  non-numeric, or 0 (0 is station-level, see module docstring). */
+function positiveConnectorId(
+  payload: Record<string, unknown> | undefined,
+): number | undefined {
+  const value = payload?.connectorId;
+  return typeof value === "number" && value > 0 ? value : undefined;
+}
+
+/** "station" is a distinct sentinel from `undefined`: `undefined` means "we
+ *  never looked at this messageId at all" (used as the Map's natural
+ *  not-found return), while "station" means "we looked, and this CALL's own
+ *  action/payload doesn't resolve to a specific connector" -- both end up
+ *  replicated into every connector group, but keeping them distinct avoids
+ *  the two cases silently meaning the same thing by accident as this logic
+ *  evolves. */
+type ConnectorResolution = number | "station";
+
+/**
+ * Derives each CALL messageId's connector for one charge point's records,
+ * per the rules in the module docstring. CALLRESULT/CALLERROR responses are
+ * NOT in this map; callers look them up by their own messageId anyway, which
+ * naturally inherits the answered CALL's resolution.
+ */
+function resolveConnectorsByMessageId(
+  records: ParsedRecord[],
+): Map<string, ConnectorResolution> {
+  // Pass 1: StartTransaction CALL messageId -> connectorId (only when it
+  // resolves to an actual connector; an unresolvable/station-level
+  // StartTransaction can't anchor any StopTransaction correlation either).
+  const startTxMessageIdToConnector = new Map<string, number>();
+  for (const { record } of records) {
+    if (record.messageType !== "CALL" || record.action !== "StartTransaction")
+      continue;
+    const messageId =
+      typeof record.messageId === "string" ? record.messageId : undefined;
+    if (messageId === undefined) continue;
+    const connectorId = positiveConnectorId(getPayloadObject(record.payload));
+    if (connectorId !== undefined)
+      startTxMessageIdToConnector.set(messageId, connectorId);
+  }
+
+  // Pass 2: transactionId -> connectorId, from the CALLRESULT that answers
+  // each StartTransaction CALL found above (the transactionId only appears
+  // in the response, never the request).
+  const txIdToConnector = new Map<number, number>();
+  for (const { record } of records) {
+    if (record.messageType !== "CALLRESULT") continue;
+    const messageId =
+      typeof record.messageId === "string" ? record.messageId : undefined;
+    if (messageId === undefined) continue;
+    const connectorId = startTxMessageIdToConnector.get(messageId);
+    if (connectorId === undefined) continue;
+    const transactionId = getPayloadObject(record.payload)?.transactionId;
+    if (typeof transactionId === "number") {
+      txIdToConnector.set(transactionId, connectorId);
+    }
+  }
+
+  // Pass 3: every connector-scoped CALL's own messageId -> resolution.
+  const messageIdToConnector = new Map<string, ConnectorResolution>();
+  for (const { record } of records) {
+    if (record.messageType !== "CALL") continue;
+    const messageId =
+      typeof record.messageId === "string" ? record.messageId : undefined;
+    if (messageId === undefined) continue;
+    const action =
+      typeof record.action === "string" ? record.action : undefined;
+    if (action === undefined) continue;
+
+    if (action === "StartTransaction") {
+      messageIdToConnector.set(
+        messageId,
+        startTxMessageIdToConnector.get(messageId) ?? "station",
+      );
+    } else if (CONNECTOR_ID_ACTIONS.has(action)) {
+      const connectorId = positiveConnectorId(getPayloadObject(record.payload));
+      messageIdToConnector.set(messageId, connectorId ?? "station");
+    } else if (TRANSACTION_ID_ACTIONS.has(action)) {
+      const transactionId = getPayloadObject(record.payload)?.transactionId;
+      const resolved =
+        typeof transactionId === "number"
+          ? txIdToConnector.get(transactionId)
+          : undefined;
+      messageIdToConnector.set(messageId, resolved ?? "station");
+    }
+    // Any other action (BootNotification, Heartbeat, Authorize, ...) is not
+    // connector-scoped at all: no entry -> resolves to "station" by the
+    // lookup default in groupRecordsByConnector below.
+  }
+
+  return messageIdToConnector;
+}
+
+/**
+ * Splits one charge point's already-filtered records into per-connector
+ * JSONL blobs, keyed by connector number, plus a station-level lines list
+ * replicated into each. Returns `null` when no record resolves to an actual
+ * connector (the all-station-level fallback case, see module docstring) so
+ * the caller can fall back to a single plain-chargePointId group instead of
+ * silently discarding every record.
+ */
+function groupRecordsByConnector(
+  records: ParsedRecord[],
+): { connectorId: number; lines: string[] }[] | null {
+  const messageIdToConnector = resolveConnectorsByMessageId(records);
+
+  const resolutionOf = (
+    record: Record<string, unknown>,
+  ): ConnectorResolution => {
+    const messageId =
+      typeof record.messageId === "string" ? record.messageId : undefined;
+    if (messageId === undefined) return "station";
+    return messageIdToConnector.get(messageId) ?? "station";
+  };
+
+  const resolutions = records.map(({ record }) => resolutionOf(record));
+  const connectorIds = Array.from(
+    new Set(resolutions.filter((r): r is number => typeof r === "number")),
+  ).sort((a, b) => a - b);
+
+  if (connectorIds.length === 0) return null;
+
+  return connectorIds.map((connectorId) => ({
+    connectorId,
+    lines: records
+      .filter((_, i) => {
+        const r = resolutions[i];
+        return r === connectorId || r === "station";
+      })
+      .map(({ line }) => line),
+  }));
+}
+
+export function splitTraceJsonl(
+  jsonlText: string,
+  splitBy: TraceSplitMode = "charge-point",
+): TraceSplit {
+  const byChargePointRecords = new Map<string, ParsedRecord[]>();
   const unattributedLines: string[] = [];
   const excluded = { soap: 0, unsupportedOcppVersion: 0, unparseableLine: 0 };
   let total = 0;
@@ -87,17 +334,37 @@ export function splitTraceJsonl(jsonlText: string): TraceSplit {
       unattributedLines.push(line);
       continue;
     }
-    const bucket = byChargePointLines.get(cpId);
+    const bucket = byChargePointRecords.get(cpId);
+    const parsedRecord: ParsedRecord = { line, record };
     if (bucket) {
-      bucket.push(line);
+      bucket.push(parsedRecord);
     } else {
-      byChargePointLines.set(cpId, [line]);
+      byChargePointRecords.set(cpId, [parsedRecord]);
     }
   }
 
   const byChargePoint = new Map<string, string>();
-  for (const [cpId, lines] of byChargePointLines) {
-    byChargePoint.set(cpId, lines.map((l) => l + "\n").join(""));
+  for (const [cpId, records] of byChargePointRecords) {
+    if (splitBy === "connector") {
+      const groups = groupRecordsByConnector(records);
+      if (groups === null) {
+        // No connector-scoped record for this CP at all -- fall back to a
+        // single group under its plain chargePointId (module docstring).
+        byChargePoint.set(
+          cpId,
+          records.map(({ line }) => line + "\n").join(""),
+        );
+        continue;
+      }
+      for (const { connectorId, lines } of groups) {
+        byChargePoint.set(
+          `${cpId}-connector${connectorId}`,
+          lines.map((l) => l + "\n").join(""),
+        );
+      }
+    } else {
+      byChargePoint.set(cpId, records.map(({ line }) => line + "\n").join(""));
+    }
   }
 
   return {

--- a/src/cli/client.ts
+++ b/src/cli/client.ts
@@ -2,6 +2,7 @@ import type { EventEnvelope } from "../protocol";
 import { RemoteChargePointService } from "../data/remote/RemoteChargePointService";
 import { toJsonResponse } from "./output";
 import type { JsonCommand } from "./types";
+import type { SerializedLogLine } from "../trace/logEntryToTrace";
 
 export interface ClientLocation {
   readonly httpUrl: string;
@@ -53,6 +54,48 @@ export async function sendCommand(
   } finally {
     service.dispose();
   }
+}
+
+/**
+ * Fetch a charge point's stored log entries from a running daemon
+ * (`logs.get`), for callers that need the data rather than a printed line —
+ * `analyze --from-daemon` turns them into a trace via
+ * {@link logLinesToTrace}.
+ *
+ * Unlike {@link sendCommand} this throws instead of writing to stdout/stderr
+ * and setting `process.exitCode`, so the caller decides how a failure is
+ * reported. Entries the daemon returns in an unexpected shape are dropped
+ * rather than failing the whole fetch: the log store is append-only history
+ * from possibly-older daemon versions, and one odd row should not cost the
+ * operator the rest of the trace.
+ */
+export async function fetchStoredLogs(
+  loc: ClientLocation,
+  cpId: string,
+): Promise<SerializedLogLine[]> {
+  const service = createRemoteService(loc);
+  try {
+    const ack = await service.runRawRpc("logs.get", { cpId }, cpId);
+    if (!ack.ok) {
+      throw new Error(`daemon rejected logs.get: ${ack.error.message}`);
+    }
+    if (!Array.isArray(ack.result)) {
+      throw new Error("daemon returned a non-array result for logs.get");
+    }
+    return ack.result.filter(isSerializedLogLine);
+  } catch (err) {
+    throw new Error(formatSocketError(err, loc), { cause: err });
+  } finally {
+    service.dispose();
+  }
+}
+
+function isSerializedLogLine(value: unknown): value is SerializedLogLine {
+  if (typeof value !== "object" || value === null) return false;
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.timestamp === "string" && typeof entry.message === "string"
+  );
 }
 
 export async function stopDaemon(loc: ClientLocation): Promise<void> {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -784,6 +784,16 @@ Options:
   analyze <trace.jsonl> [--output <file>] [--format html|markdown]
                            Analyze a trace with OCPP DebugKit and write a
                            report.
+  analyze --from-daemon --cp-id <id> [--http-url <url>]
+          [--http-basic-auth-user <u> --http-basic-auth-pass <p>]
+          [--output <file>] [--format html|markdown]
+                           Same report, built from a running daemon's stored
+                           logs (the logs.get RPC) instead of a trace file --
+                           no --trace-output needed, and no daemon restart.
+                           --cp-id is required (logs.get is scoped to one
+                           charge point); --http-url defaults to
+                           http://127.0.0.1:${DEFAULT_HTTP_PORT}, matching
+                           the other client modes (--send/--stop/--events).
   --health-path <path>     Absolute path the health-check JSON is served on
                            (default: /v1/healthz). Change this when running
                            behind a proxy that reserves the default path

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -782,11 +782,13 @@ Options:
                            record (docs/trace-format.md) — works in REPL,
                            JSON, and daemon modes.
   analyze <trace.jsonl> [--output <file>] [--format html|markdown]
+          [--split-by charge-point|connector]
                            Analyze a trace with OCPP DebugKit and write a
                            report.
   analyze --from-daemon --cp-id <id> [--http-url <url>]
           [--http-basic-auth-user <u> --http-basic-auth-pass <p>]
           [--output <file>] [--format html|markdown]
+          [--split-by charge-point|connector]
                            Same report, built from a running daemon's stored
                            logs (the logs.get RPC) instead of a trace file --
                            no --trace-output needed, and no daemon restart.
@@ -794,6 +796,12 @@ Options:
                            charge point); --http-url defaults to
                            http://127.0.0.1:${DEFAULT_HTTP_PORT}, matching
                            the other client modes (--send/--stop/--events).
+                           --split-by connector further splits each charge
+                           point's report by connector (default:
+                           charge-point, i.e. current behavior). See
+                           docs/cli.md -> analyze -> "Splitting by
+                           connector" for what gets replicated into every
+                           connector's report and why.
   --health-path <path>     Absolute path the health-check JSON is served on
                            (default: /v1/healthz). Change this when running
                            behind a proxy that reserves the default path


### PR DESCRIPTION
Three independent improvements to `analyze`, found while using it to debug a real
charging session on a deployed simulator. Each is a separate commit.

## 1. `--from-daemon`: analyze a running daemon without restarting it

`analyze` could only read a trace **file**, which only exists if the daemon was
started with `--trace-output`. A long-lived daemon (e.g. in Kubernetes) therefore
had to be **restarted** — losing the very state you wanted to inspect — before it
could be analyzed at all.

It turns out nothing new was needed to fix this: the daemon already stores its log
entries and serves them over the `logs.get` RPC, and `src/trace/logEntryToTrace.ts`
already adapts exactly that `{timestamp, level, type, message, cpId}` shape into
trace records. This is just the file-less path through the same adapter:

```bash
ocpp-cp-sim analyze --from-daemon --cp-id CP001 \
  --http-url https://sim.example --http-basic-auth-user admin --http-basic-auth-pass … \
  --output report.html
```

Before this, the equivalent was a manual `kubectl logs` → copy into the pod → hand-written
conversion script → `analyze` pipeline.

Note it only sees what the log store still holds, and non-wire log lines (scenario
chatter) map to nothing — an all-chatter log reports "nothing to analyze" rather than
producing an empty report.

## 2. `--split-by connector`: stop cross-connector false positives

The toolkit models a single station with no notion of connectors, so on a
multi-connector charge point every connector's `StatusNotification`s land in one
timeline. Connector A going `Available` while connector B goes `Finishing` is then
reported as an invalid transition. On a real 4-connector trace this produced **24
`STATUS_TRANSITION_VIOLATION` findings; filtering the trace down to a single connector
left 1.**

`--split-by connector` (default stays `charge-point`, so existing behaviour is
**unchanged**) groups records per connector before analysis. Resolving a record's
connector needs a little care, all covered by tests:

- `StopTransaction` / `RemoteStopTransaction` carry only a `transactionId`, so it is
  correlated back through the `StartTransaction` CALL → CALLRESULT `transactionId` →
  `connectorId` chain.
- CALLRESULT/CALLERROR inherit their CALL's connector — otherwise a StartTransaction's
  own CALLRESULT would replicate into every group and seed phantom sessions.
- `connectorId: 0` and connector-less actions are station-level and are **replicated
  into every connector group**, because a group missing its `BootNotification` would
  report a fresh false `UNEXPECTED_START` — exactly the class of artifact this is
  meant to remove. A station-level finding can therefore appear in more than one
  per-connector report.

## 3. `METER_VALUE_ANOMALY` is recomputed instead of trusted

Upstream defect, reported as https://github.com/ocpp-debugkit/toolkit/issues/127
(verified by reading the real installed `dist/core/detection.js`, not inferred).

`detectMeterValueAnomaly` flattens **every** `sampledValue` in a session into one array
— across all `measurand`s, `phase`s, `unit`s and `location`s — and asserts that flat
sequence never decreases. But only cumulative registers (`Energy.*.Register`) are
monotonic per OCPP 1.6 §7.28; `Power.Active.Import`, `SoC`, `Current.Import`, `Voltage`
and `Temperature` all legitimately rise and fall.

So **any** charge point reporting more than one measurand per sample gets a warning on
nearly every message. A real, perfectly healthy 3 kW session whose energy register went
`600 → 1150 Wh` (+25 Wh every 30 s, exactly 3 kW, strictly monotonic) but which also
sent a constant `Power.Active.Import = 3000 W` produced **22 false**
`Non-monotonic meter reading: value decreased from 3000 to 625` warnings.

`src/cli/analyze/meterAnomaly.ts` strips the toolkit's findings for this code and
re-derives them, bucketed by `(connectorId, measurand, phase, unit, location)` and
checked only for the four cumulative registers (an absent `measurand` defaults to
`Energy.Active.Import.Register` per §7.28). Negative values are flagged only on those
same registers — a negative `Power.Active.Import` / `Current.Import` is normal on a
bidirectional V2G charger.

This is deliberately **post**-processing, unlike `splitTrace.ts`: the report's timeline
and Event Appendix must keep showing the real, unmodified `MeterValues` payloads the
charge point actually sent, so findings are recomputed from the sessions the toolkit
already built rather than by scrubbing events beforehand.

Measured on fixtures asserted in `meterAnomaly.test.ts`:

| fixture | before | after |
|---|---|---|
| monotonic energy register + constant `Power.Active.Import` | 11 | **0** |
| two connectors' independently-monotonic registers in one session | 5 | **0** |

Genuinely non-monotonic registers and genuinely negative registers are still flagged —
also asserted.

## Verification

```
npx tsc --noEmit                  clean
npm run lint                      clean
npx prettier --check <changed>    clean
npx vitest run src/cli src/trace  216 passed (23 files)
bun test bun.test                 225 pass / 0 fail
```

Each of the three commits typechecks and passes the suite on its own.

## Follow-up (not in this PR)

`src/console/pages/cp/SessionAnalysisPanel.tsx` — the web console's Session Analysis tab
runs the same toolkit pipeline independently, so it very likely shows the same
`METER_VALUE_ANOMALY` / `STATUS_TRANSITION_VIOLATION` false positives. Fixing it means
sharing this correction layer with the browser build; left out to keep this PR to the CLI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analyze persisted charge point logs directly from a running daemon with configurable URL and basic authentication.
  * Split analysis reports by connector, while retaining charge-point grouping by default.
  * Added connector-specific report naming and station-level event inclusion.

* **Bug Fixes**
  * Corrected false-positive meter-value anomaly findings while preserving legitimate issues.
  * Added clearer errors for unavailable logs, connection failures, and invalid option combinations.

* **Documentation**
  * Expanded CLI help and usage guidance for daemon analysis and connector-based reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->