### PR TITLE
fix(ci): stop release-tag Docker builds from clobbering the sha-<short> image tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -88,8 +88,14 @@ jobs:
             # main       → `main` + `sha-<short>` + `latest`
             # feat/...   → branch-slug + `sha-<short>` (no `latest`)
             # v1.2.3 tag → `1.2.3` + `1.2` + `1` (semver release pins)
+            #
+            # `sha-<short>` is branch-builds ONLY: a `vX.Y.Z` tag build runs a
+            # version-stamped rebuild of the same commit, and without the
+            # enable guard it would push the same `sha-<short>` tag a second
+            # time and clobber the branch image the sha pin already points at
+            # (last writer wins — happened on v0.7.4).
             type=ref,event=branch
-            type=sha,format=short
+            type=sha,format=short,enable=${{ github.ref_type == 'branch' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -20,6 +20,13 @@ Semver tags are published when a `vX.Y.Z` git tag is pushed (the same tag that c
 docker pull ghcr.io/shiv3/ocpp-cp-simulator:1.2.3
 ```
 
+> **Why `X.Y.Z` and `sha-<short>`/`latest` digests differ for the same commit:**
+> a release-tag build stamps the semver into `package.json` before building so
+> the CLI and web-console footer report the real version, then rebuilds the
+> image. The stamped bytes make it a different image (different digest) from
+> the `main` build of the same commit — expected, not a packaging error.
+> `sha-<short>` always refers to the un-stamped branch build.
+
 ## Quick start
 
 ```sh

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -6,13 +6,13 @@ Hosted images live at **`ghcr.io/shiv3/ocpp-cp-simulator`** (built by [`.github/
 
 ### Image tags
 
-| Tag                      | Moves?    | Use it for                                                       |
-| ------------------------ | --------- | ---------------------------------------------------------------- |
-| `latest`                 | mutable   | Bleeding edge — tracks the newest `main` build.                  |
-| `main`                   | mutable   | Same as `latest`; explicit about the source branch.              |
-| `sha-<short>`            | immutable | Pin to one exact `main` commit.                                  |
-| `X.Y.Z` (e.g. `1.2.3`)   | immutable | **Reproducible release pin** — recommended for IaC / production. |
-| `X.Y` (e.g. `1.2`) / `X` | mutable   | Auto-track patch / minor releases within a version line.         |
+| Tag                      | Moves?    | Use it for                                                                                                  |
+| ------------------------ | --------- | ----------------------------------------------------------------------------------------------------------- |
+| `latest`                 | mutable   | Bleeding edge — tracks the newest `main` build.                                                             |
+| `main`                   | mutable   | Same as `latest`; explicit about the source branch.                                                         |
+| `sha-<short>`            | immutable | Pin to one exact branch commit (`main` or a published feature branch) — always the un-stamped branch build. |
+| `X.Y.Z` (e.g. `1.2.3`)   | immutable | **Reproducible release pin** — recommended for IaC / production.                                            |
+| `X.Y` (e.g. `1.2`) / `X` | mutable   | Auto-track patch / minor releases within a version line.                                                    |
 
 Semver tags are published when a `vX.Y.Z` git tag is pushed (the same tag that cuts the desktop-app [release](../.github/workflows/release.yml)). For production, pin to a full `X.Y.Z` (or a digest) rather than `latest`/`main`:
 


### PR DESCRIPTION
## Problem

For one commit, two Docker builds run: the `main`-push build and (after publishing a release) the `vX.Y.Z` tag build. Both emitted the same `sha-<short>` tag, so the last one to finish owned the pin.

On v0.7.4 (commit 938f92c) this actually happened:

| ghcr tag | digest | built by |
|---|---|---|
| `latest` / `main` | `sha256:7934916…` | main-push build (23:16:34Z) |
| `0.7.4` / `0.7` / `0` | `sha256:b85caae…` | v0.7.4 tag build (23:17:31Z) |
| `sha-938f92c` | `sha256:b85caae…` | pushed by the main build, **overwritten 57 s later by the tag build** |

So `sha-<short>` — documented as "pin to one exact main commit" — silently changed digests depending on when it was pulled, and no longer matched `latest` for the same commit.

Note the `0.7.4` vs `latest` digest difference itself is **by design**: tag builds stamp the semver into `package.json` before building (#93), so the release image is a legitimately different image of the same commit. Verified via layer comparison: base layers identical, app layers differ only by the stamped version.

## Fix

- Gate `type=sha` in docker-publish.yml on `github.ref_type == 'branch'`, so tag builds publish only their semver pins (`X.Y.Z` / `X.Y` / `X`) — matching the tag matrix the workflow header already documents.
- docs/docker.md: explain why `X.Y.Z` digests differ from same-commit `sha-<short>`/`latest` (version stamping), and that `sha-<short>` always means the un-stamped branch build.

The existing stale pin (`sha-938f92c` → release image) is left as-is; re-pushing it would mint yet another digest. Future commits are unaffected once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRbE2ENtDAtAEW6A6gwkpM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate `sha-<short>` Docker image publishing by only emitting the short-SHA tag for branch builds.
  * Ensured versioned release (`vX.Y.Z`) builds don’t also publish the branch SHA tag a second time.

* **Documentation**
  * Clarified how to pin immutable Docker tags, including that `sha-<short>` targets a specific branch commit.
  * Added an explanation for why `vX.Y.Z` release image digests can differ from `sha-<short>`/`latest` for the same commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->