### PR TITLE
fix(network-sim): omit blank optional fields when the editor builds a rule

### DIFF
--- a/src/console/components/network-sim/__tests__/NetworkSimEditor.dom.test.tsx
+++ b/src/console/components/network-sim/__tests__/NetworkSimEditor.dom.test.tsx
@@ -242,6 +242,57 @@ describe("NetworkSimEditor", () => {
     });
   });
 
+  it("re-enables Save once the invalid field is edited", async () => {
+    // Save is gated on `hasError`. Errors used to be cleared only by a
+    // successful save, so one invalid rule left the button dead with no way
+    // back short of a page reload.
+    const { NetworkSimEditor } = await import("../NetworkSimEditor");
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    cleanup = () => unmount(root);
+
+    await act(async () => {
+      root.render(
+        <NetworkSimEditor
+          mode="global"
+          value={{ enabled: true, seed: 1, rules: {} }}
+          onSave={async () => {}}
+        />,
+      );
+    });
+
+    const button = (label: string) =>
+      [...host.querySelectorAll("button")].find((b) =>
+        b.textContent?.includes(label),
+      );
+
+    await act(async () => {
+      button("Add Rule")!.click();
+    });
+
+    // A latency rule with no delay is rejected by formToLayerConfig.
+    const delay = host.querySelector<HTMLInputElement>('input[type="number"]');
+    expect(delay).not.toBeNull();
+    await act(async () => {
+      setInputValue(delay!, "");
+    });
+    await act(async () => {
+      button("Save")!.click();
+    });
+
+    expect(button("Save")!.disabled).toBe(true);
+
+    await act(async () => {
+      setInputValue(
+        host.querySelector<HTMLInputElement>('input[type="number"]')!,
+        "250",
+      );
+    });
+
+    expect(button("Save")!.disabled).toBe(false);
+  });
+
   describe("CP mode (per-charge point)", () => {
     it("shows invalid edit with inline error and disables Save", async () => {
       // Create a simple test that validates the formToCpLayer rejects on invalid input

--- a/src/console/components/network-sim/__tests__/ruleFormState.test.ts
+++ b/src/console/components/network-sim/__tests__/ruleFormState.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it } from "vitest";
 import {
   type LayerFormState,
   type CpLayerFormState,
+  type RuleFormEntry,
   emptyLayerForm,
   layerConfigToForm,
   formToLayerConfig,
   cpLayerToForm,
   formToCpLayer,
 } from "../ruleFormState";
+import { validateLayerConfig } from "../../../../cp/infrastructure/transport/network-sim/config";
 import type {
   NetworkSimLayerConfig,
   LatencyRule,
@@ -925,5 +927,67 @@ describe("Per-CP layer form state (cpLayerToForm, formToCpLayer)", () => {
         expect(errorKey).toBe("rules.1.delayMs");
       }
     });
+  });
+});
+
+describe("form output survives the config validator", () => {
+  // The editor's output goes straight to saveNetworkSimGlobal /
+  // saveNetworkSimCp, which validate before applying. Asserting on the shape
+  // alone missed that optional fields were emitted as explicit `undefined`,
+  // which validateLayerConfig rejects — so a default latency rule could be
+  // built by the form and then refused on save.
+  const row = (over: Partial<RuleFormEntry> = {}): RuleFormEntry => ({
+    id: "r1",
+    type: "latency",
+    delayMs: 100,
+    ...over,
+  });
+
+  it("accepts a latency rule with every optional field left blank", () => {
+    const result = formToLayerConfig({
+      enabled: true,
+      seed: "1",
+      rules: [row()],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(validateLayerConfig(result.config).ok).toBe(true);
+      expect("direction" in result.config.rules["r1"]!).toBe(false);
+      expect("jitterMs" in result.config.rules["r1"]!).toBe(false);
+    }
+  });
+
+  it("accepts a periodic-disconnect rule without jitter", () => {
+    const result = formToLayerConfig({
+      enabled: true,
+      seed: "1",
+      rules: [
+        row({
+          type: "periodic-disconnect",
+          delayMs: undefined,
+          intervalMs: 30000,
+          reconnectDelayMs: 5000,
+        }),
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(validateLayerConfig(result.config).ok).toBe(true);
+    }
+  });
+
+  it("accepts a per-CP layer whose local rule leaves optionals blank", () => {
+    const result = formToCpLayer({
+      enabled: true,
+      seed: "1",
+      rules: [{ ...row(), classification: "local" }],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok && result.config) {
+      expect(validateLayerConfig(result.config).ok).toBe(true);
+    }
   });
 });

--- a/src/console/components/network-sim/ruleFormState.ts
+++ b/src/console/components/network-sim/ruleFormState.ts
@@ -124,6 +124,53 @@ export function layerConfigToForm(
  * Convert form state to domain config with validation.
  * Reject-only: never partial. Returns keyed field errors on failure.
  */
+/**
+ * Build the domain rule for one form row, omitting every optional field the
+ * user left blank. The key must be absent, not present-and-undefined:
+ * `validateLayerConfig` rejects an explicit `undefined` so that a required
+ * field lost in a JSON round-trip is caught rather than silently dropped.
+ */
+function buildRule(
+  rule: RuleFormEntry | CpRuleFormEntry,
+): NetworkSimRule | null {
+  if (rule.type === "latency") {
+    const actionList = rule.actions
+      ? rule.actions
+          .split(",")
+          .map((a) => a.trim())
+          .filter((a) => a.length > 0)
+      : [];
+
+    const latency: LatencyRule = { type: "latency", delayMs: rule.delayMs! };
+    if (rule.direction !== undefined) latency.direction = rule.direction;
+    if (actionList.length > 0) latency.match = { actions: actionList };
+    if (rule.jitterMs !== undefined) latency.jitterMs = rule.jitterMs;
+    return latency;
+  }
+
+  if (rule.type === "manual-disconnect") {
+    const manual: ManualDisconnectRule = {
+      type: "manual-disconnect",
+      reconnectDelayMs: rule.reconnectDelayMs!,
+    };
+    return manual;
+  }
+
+  if (rule.type === "periodic-disconnect") {
+    const periodic: PeriodicDisconnectRule = {
+      type: "periodic-disconnect",
+      intervalMs: rule.intervalMs!,
+      reconnectDelayMs: rule.reconnectDelayMs!,
+    };
+    if (rule.intervalJitterMs !== undefined) {
+      periodic.intervalJitterMs = rule.intervalJitterMs;
+    }
+    return periodic;
+  }
+
+  return null;
+}
+
 export function formToLayerConfig(
   form: LayerFormState,
 ):
@@ -271,34 +318,8 @@ export function formToLayerConfig(
   const rules: Record<string, NetworkSimRule | null> = {};
 
   for (const rule of form.rules) {
-    if (rule.type === "latency") {
-      const actionList = rule.actions
-        ? rule.actions
-            .split(",")
-            .map((a) => a.trim())
-            .filter((a) => a.length > 0)
-        : [];
-
-      rules[rule.id] = {
-        type: "latency",
-        direction: rule.direction,
-        match: actionList.length > 0 ? { actions: actionList } : undefined,
-        delayMs: rule.delayMs!,
-        jitterMs: rule.jitterMs,
-      };
-    } else if (rule.type === "manual-disconnect") {
-      rules[rule.id] = {
-        type: "manual-disconnect",
-        reconnectDelayMs: rule.reconnectDelayMs!,
-      };
-    } else if (rule.type === "periodic-disconnect") {
-      rules[rule.id] = {
-        type: "periodic-disconnect",
-        intervalMs: rule.intervalMs!,
-        intervalJitterMs: rule.intervalJitterMs,
-        reconnectDelayMs: rule.reconnectDelayMs!,
-      };
-    }
+    const built = buildRule(rule);
+    if (built) rules[rule.id] = built;
   }
 
   const config: NetworkSimLayerConfig = {
@@ -557,34 +578,8 @@ export function formToCpLayer(
     // In this form, deleted rules are simply not included in editable rules
     // Tombstones are managed by keeping null entries in perCpLayer
 
-    if (rule.type === "latency") {
-      const actionList = rule.actions
-        ? rule.actions
-            .split(",")
-            .map((a) => a.trim())
-            .filter((a) => a.length > 0)
-        : [];
-
-      rules[rule.id] = {
-        type: "latency",
-        direction: rule.direction,
-        match: actionList.length > 0 ? { actions: actionList } : undefined,
-        delayMs: rule.delayMs!,
-        jitterMs: rule.jitterMs,
-      };
-    } else if (rule.type === "manual-disconnect") {
-      rules[rule.id] = {
-        type: "manual-disconnect",
-        reconnectDelayMs: rule.reconnectDelayMs!,
-      };
-    } else if (rule.type === "periodic-disconnect") {
-      rules[rule.id] = {
-        type: "periodic-disconnect",
-        intervalMs: rule.intervalMs!,
-        intervalJitterMs: rule.intervalJitterMs,
-        reconnectDelayMs: rule.reconnectDelayMs!,
-      };
-    }
+    const built = buildRule(rule);
+    if (built) rules[rule.id] = built;
   }
 
   // Add tombstones for disabled entries


### PR DESCRIPTION
Follow-up to #242, found while exercising the merged feature in a browser.

## The bug

Add a latency rule in the Network Simulation editor, leave Direction on its default "Not set", press Save:

```
Invalid global networkSim config: 0: config.rules.<id>.direction:
config serialized form contains an invalid undefined value
```

That is the feature's primary happy path in local (browser) mode.

## Cause

Both form-to-config converters wrote every optional field unconditionally:

```ts
rules[rule.id] = {
  type: "latency",
  direction: rule.direction,   // undefined when the user left it blank
  match: actionList.length > 0 ? { actions: actionList } : undefined,
  delayMs: rule.delayMs!,
  jitterMs: rule.jitterMs,
};
```

A blank field became a present-but-`undefined` key, and `validateLayerConfig` rejects explicit `undefined` deliberately — so that a required field silently dropped in a JSON round-trip is caught instead of being treated as absent. Same for `intervalJitterMs` on periodic-disconnect.

It stayed invisible because `LocalChargePointService.saveNetworkSim*` used to `console.warn` and return; the promise resolved and the save quietly did nothing. #242 changed that to throw (to match the remote contract), which surfaced it.

## Fix

Both converters now share one builder that only sets keys that have a value.

## Why the tests missed it

The existing assertions were `expect(rule.direction).toBeUndefined()`, which passes for an omitted key *and* for an explicit-undefined one, and no test ran converter output through the real validator. The new tests do exactly that, and all three fail without the fix.

Also added a DOM test for Save recovering after a validation error — the button is gated on `hasError`, so clearing errors on every mutation is what makes it usable again; removing one `setErrors({})` fails the test.

Verified in the browser: the rule now saves and persists as `{"type":"latency","delayMs":750}` with no stray keys.
