### PR TITLE
fix(console): session analysis Buffer crash and per-CP Message Log consistency

### DIFF
--- a/src/console/pages/CpDetailPage.tsx
+++ b/src/console/pages/CpDetailPage.tsx
@@ -19,6 +19,7 @@ import { getConfigBasicAuthPassword } from "@/data/configPort";
 import { useChargePointView } from "@/data/hooks/useChargePointView";
 import { useConfig } from "@/data/hooks/useConfig";
 import { useDataContext } from "@/data/providers/DataProvider";
+import { useGlobalLogs } from "../lib/useGlobalLogs";
 import type { ChargePointSnapshot } from "@/data/interfaces/ChargePointService";
 import type { WireSimulatorConfig } from "@/protocol";
 import type {
@@ -150,6 +151,7 @@ const CpDetailPage: React.FC = () => {
   const { updateCp } = useCpConfigActions();
 
   const view = useChargePointView(cpId || null);
+  const { entries: globalLogEntries } = useGlobalLogs();
   const [snapshot, setSnapshot] = useState<ChargePointSnapshot | undefined>();
   const [activeTab, setActiveTab] = useState<TabValue>("transactions");
   const [isEditOpen, setIsEditOpen] = useState(false);
@@ -165,6 +167,9 @@ const CpDetailPage: React.FC = () => {
   const [networkSimLoadError, setNetworkSimLoadError] = useState<string | null>(
     null,
   );
+  // Watermark to track which global log entries have been cleared from this
+  // tab's view. Only entries with seq > logsClearedBeforeSeq are shown.
+  const [logsClearedBeforeSeq, setLogsClearedBeforeSeq] = useState(-1);
 
   /** Global rules minus tombstones, as the per-CP editor's inherited baseline. */
   const inheritedNetworkSimRules = useMemo(() => {
@@ -220,10 +225,39 @@ const CpDetailPage: React.FC = () => {
     refreshNetworkSim();
   }, [refreshSnapshot, refreshNetworkSim]);
 
+  // When navigating to a different CP, reset the watermark so all entries in
+  // the global ring buffer for this CP become visible (old cleared entries are
+  // not rehydrated; only new/existing entries in the buffer).
+  useEffect(() => {
+    setLogsClearedBeforeSeq(-1);
+  }, [cpId]);
+
   const connectorList = useMemo(
     () => Array.from(view.connectors.values()).sort((a, b) => a.id - b.id),
     [view.connectors],
   );
+
+  // Derive the logs to show in the Message Log tab by filtering global entries
+  // for this CP and reversing them to match the chronological order expected
+  // by LogViewer (oldest-first). Entries are newest-first in globalLogEntries,
+  // so we reverse after filtering. The watermark only hides entries the user
+  // cleared from this tab; old cleared entries remain cleared across tab
+  // switches but new global entries appear.
+  const tabLogs = useMemo(() => {
+    const filtered = globalLogEntries.filter(
+      (e) => e.cpId === cpId && e.seq > logsClearedBeforeSeq,
+    );
+    return filtered.reverse().map((e) => e.entry);
+  }, [globalLogEntries, cpId, logsClearedBeforeSeq]);
+
+  const handleClearTabLogs = useCallback(() => {
+    // Set watermark to the highest seq in globalLogEntries (newest-first, so [0]
+    // has the max). This ensures only entries logged after this Clear persist
+    // in the tab view. Ignores scope parameter from LogViewer (which offers
+    // "screen" vs "all" options) because the global buffer is read-only from
+    // this tab's perspective; clearing only affects this tab's watermark.
+    setLogsClearedBeforeSeq(globalLogEntries[0]?.seq ?? -1);
+  }, [globalLogEntries]);
 
   const diagnosticsConnectorId =
     diagnosticsConnectorOverride ?? connectorList[0]?.id ?? null;
@@ -373,7 +407,7 @@ const CpDetailPage: React.FC = () => {
           <TransactionsTab cpId={cpId} />
         </TabsContent>
         <TabsContent value="logs">
-          <LogViewer logs={view.logs} onClear={view.clearLogs} />
+          <LogViewer logs={tabLogs} onClear={handleClearTabLogs} />
         </TabsContent>
         <TabsContent value="analysis">
           <Suspense

--- a/src/console/pages/cp/CpDetailPage.dom.test.tsx
+++ b/src/console/pages/cp/CpDetailPage.dom.test.tsx
@@ -6,9 +6,12 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   createFakeChargePointService,
   renderConsole,
+  type FakeChargePointService,
 } from "../../test/harness";
 import { OCPPStatus } from "../../../cp/domain/types/OcppTypes";
+import { LogLevel, LogType } from "../../../cp/shared/Logger";
 import type { ChargePointSnapshot } from "../../../data/interfaces/ChargePointService";
+import type { ChargePointEvent } from "../../../data/interfaces/ChargePointService";
 import type { StateHistoryEntry } from "../../../cp/application/services/types/StateSnapshot";
 import { useCpConfigActions } from "../dashboard/useCpConfigActions";
 
@@ -44,6 +47,21 @@ async function flush(times = 3): Promise<void> {
       await Promise.resolve();
     });
   }
+}
+
+/** Pushes a synthetic event to all handlers subscribed to a specific CP. */
+async function pushEvent(
+  service: FakeChargePointService,
+  cpId: string,
+  event: ChargePointEvent,
+): Promise<void> {
+  const handlers = service.__handlers.subscribe.get(cpId);
+  if (!handlers || handlers.size === 0) {
+    throw new Error(`no subscribe handler recorded for ${cpId}`);
+  }
+  await act(async () => {
+    handlers.forEach((handler) => handler(event));
+  });
 }
 
 function connector(
@@ -433,5 +451,171 @@ describe("CpDetailPage", () => {
     );
 
     consoleErrorSpy.mockRestore();
+  });
+
+  it("Message Log tab shows entries logged before navigating to the CP (from global ring buffer)", async () => {
+    const cp = snapshot({
+      id: "CP-1",
+      status: OCPPStatus.Available,
+      connectors: [connector({ id: 1 })],
+    });
+    const service = createFakeChargePointService({
+      snapshots: [cp],
+      getStateHistory: vi.fn(async () => []),
+    });
+
+    // Render at dashboard (/) so CpDetailPage is NOT mounted yet, but
+    // GlobalLogsProvider IS mounted (via AppShell). This is the key to
+    // reproducing the bug: log events delivered now go into globalLogEntries
+    // but will NOT be in useChargePointView's view.logs (which only exists
+    // after CpDetailPage mounts).
+    const { container, root } = await renderConsole("/", { service });
+    cleanup = () => unmount(root);
+    await flush();
+
+    // Notify GlobalLogsProvider about the CP registry snapshot so it knows to
+    // subscribe to CP-1.
+    await act(async () => {
+      for (const handler of service.__handlers.subscribeRegistry) {
+        handler({ type: "snapshot", cps: [cp] });
+      }
+      await Promise.resolve();
+    });
+    await flush();
+
+    // Emit a log entry for CP-1 BEFORE navigating to its detail page. This
+    // log will be in the global ring buffer but NOT in useChargePointView
+    // (which doesn't exist yet). This is what the bug reproduces: the old code
+    // would show nothing in the tab because view.logs is empty.
+    await pushEvent(service, "CP-1", {
+      type: "log",
+      entry: {
+        timestamp: new Date("2026-01-01T10:00:00.000Z"),
+        level: LogLevel.INFO,
+        type: LogType.OCPP,
+        message: "BootNotification accepted",
+      },
+    });
+    await flush();
+
+    // Navigate to CP-1's detail page by clicking the link to it in the
+    // dashboard. Find the link by looking for CP-1 text and finding an <a> tag.
+    const cpLink = Array.from(container.querySelectorAll("a")).find((a) =>
+      a.textContent?.trim().startsWith("CP-1"),
+    );
+    expect(cpLink, "expected a link to CP-1 in the dashboard").toBeTruthy();
+
+    await act(async () => {
+      cpLink!.click();
+      await Promise.resolve();
+    });
+    await flush();
+
+    // Click on the "Message Log" tab to see if pre-navigation logs are visible.
+    const logsTrigger = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="tab"]'),
+    ).find((el) => el.textContent?.trim() === "Message Log");
+    expect(logsTrigger, "expected a Message Log tab").toBeTruthy();
+
+    await act(async () => {
+      logsTrigger!.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+      );
+      logsTrigger!.click();
+      await Promise.resolve();
+    });
+    await flush();
+
+    // The message emitted BEFORE navigating to this CP should now be visible.
+    // The old code would fail here because useChargePointView's view.logs
+    // never received the event (it wasn't mounted yet). The fix makes the tab
+    // read from the global ring buffer instead, so it shows all entries for
+    // this CP, including those logged before the page mounted.
+    expect(container.textContent).toContain("BootNotification accepted");
+  });
+
+  it("Message Log tab Clear button hides old entries but shows new ones", async () => {
+    const cp = snapshot({
+      id: "CP-1",
+      status: OCPPStatus.Available,
+      connectors: [connector({ id: 1 })],
+    });
+    const service = createFakeChargePointService({
+      snapshots: [cp],
+      getStateHistory: vi.fn(async () => []),
+    });
+
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+
+    // Notify GlobalLogsProvider about the CP registry snapshot.
+    await act(async () => {
+      for (const handler of service.__handlers.subscribeRegistry) {
+        handler({ type: "snapshot", cps: [cp] });
+      }
+      await Promise.resolve();
+    });
+    await flush();
+
+    // Emit an initial log entry.
+    await pushEvent(service, "CP-1", {
+      type: "log",
+      entry: {
+        timestamp: new Date("2026-01-01T10:00:00.000Z"),
+        level: LogLevel.INFO,
+        type: LogType.OCPP,
+        message: "initial entry",
+      },
+    });
+    await flush();
+
+    // Click on the "Message Log" tab to show the logs.
+    const logsTrigger = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="tab"]'),
+    ).find((el) => el.textContent?.trim() === "Message Log");
+    expect(logsTrigger, "expected a Message Log tab").toBeTruthy();
+
+    await act(async () => {
+      logsTrigger!.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+      );
+      logsTrigger!.click();
+      await Promise.resolve();
+    });
+    await flush();
+
+    // Verify the initial entry is shown.
+    expect(container.textContent).toContain("initial entry");
+
+    // Click the "Clear screen" button to clear the tab's visible logs.
+    const clearButton = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Clear screen",
+    );
+    expect(clearButton, "expected a Clear screen button").toBeTruthy();
+
+    await act(async () => {
+      clearButton!.click();
+      await Promise.resolve();
+    });
+    await flush();
+
+    // The old entry should now be gone.
+    expect(container.textContent).not.toContain("initial entry");
+
+    // Emit a new log entry after clearing.
+    await pushEvent(service, "CP-1", {
+      type: "log",
+      entry: {
+        timestamp: new Date("2026-01-01T10:00:01.000Z"),
+        level: LogLevel.INFO,
+        type: LogType.OCPP,
+        message: "new entry after clear",
+      },
+    });
+    await flush();
+
+    // The new entry should be visible.
+    expect(container.textContent).toContain("new entry after clear");
   });
 });

--- a/src/console/pages/cp/SessionAnalysisPanel.dom.test.tsx
+++ b/src/console/pages/cp/SessionAnalysisPanel.dom.test.tsx
@@ -497,4 +497,35 @@ describe("SessionAnalysisPanel", () => {
     ).toBeTruthy();
     expect(findAnalyze()!.disabled).toBe(false);
   });
+
+  it("analyzes without Node's Buffer global (real browsers, issue #238)", async () => {
+    // The toolkit's input-size guard (`Buffer.byteLength` in
+    // dist/core/parseLimits.js) runs before any parsing, and browsers have
+    // no `Buffer` — every in-browser analysis died with "Analysis failed:
+    // Buffer is not defined" (issue #238). vitest/jsdom runs in Node where
+    // `Buffer` always exists, so this test deletes the global around the
+    // click. Kept last-ish in this file: earlier tests have already loaded
+    // the panel chunk and the toolkit, so no module transform I/O (which
+    // may legitimately need Buffer) happens inside the deletion window.
+    const service = makeService({
+      snapshots: [snapshot("CP-1")],
+      listStoredLogs: vi.fn(async () => CLEAN_SESSION_ROWS),
+    });
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+    await openAnalysisTab(container);
+
+    const holder = globalThis as { Buffer?: unknown };
+    const savedBuffer = holder.Buffer;
+    delete holder.Buffer;
+    try {
+      await clickAnalyzeAndWait(container);
+    } finally {
+      holder.Buffer = savedBuffer;
+    }
+
+    expect(container.textContent).not.toContain("Buffer is not defined");
+    expect(container.textContent).toContain("No failures detected");
+  });
 });

--- a/src/console/pages/cp/SessionAnalysisPanel.tsx
+++ b/src/console/pages/cp/SessionAnalysisPanel.tsx
@@ -26,6 +26,7 @@ import {
   type SerializedLogLine,
 } from "@/trace/logEntryToTrace";
 import { ANALYZE_DISCLAIMER } from "@/trace/analysisDisclaimer";
+import { ensureToolkitBufferShim } from "@/trace/toolkitBufferShim";
 
 import EmptyState from "../../components/EmptyState";
 
@@ -123,6 +124,10 @@ const SessionAnalysisPanel: React.FC<SessionAnalysisPanelProps> = ({
         return;
       }
       const jsonl = records.map((record) => JSON.stringify(record)).join("\n");
+
+      // The toolkit's parse guards call Node's `Buffer.byteLength`; in a
+      // browser that global doesn't exist (issue #238) — see the shim's doc.
+      ensureToolkitBufferShim();
 
       let core: typeof import("@ocpp-debugkit/toolkit/core");
       try {

--- a/src/trace/__tests__/toolkitBufferShim.test.ts
+++ b/src/trace/__tests__/toolkitBufferShim.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ensureToolkitBufferShim } from "../toolkitBufferShim";
+
+type BufferHolder = { Buffer?: { byteLength(input: string): number } };
+
+const holder = globalThis as BufferHolder;
+const realBuffer = holder.Buffer;
+
+describe("ensureToolkitBufferShim", () => {
+  afterEach(() => {
+    holder.Buffer = realBuffer;
+  });
+
+  it("leaves a present Buffer global untouched", () => {
+    expect(realBuffer, "test must run where Buffer exists").toBeDefined();
+    ensureToolkitBufferShim();
+    expect(holder.Buffer).toBe(realBuffer);
+  });
+
+  it("installs a byteLength stand-in when Buffer is absent (browser)", () => {
+    delete holder.Buffer;
+    ensureToolkitBufferShim();
+    expect(holder.Buffer).toBeDefined();
+    expect(holder.Buffer).not.toBe(realBuffer);
+
+    // UTF-8 byte lengths, not UTF-16 code-unit counts: ASCII, a 3-byte
+    // kana, and a 4-byte surrogate-pair emoji — each checked against the
+    // real Buffer's answer.
+    for (const s of ["", "abc", "あ", "🔌", 'Sent: [2,"1","Heartbeat",{}]']) {
+      expect(holder.Buffer!.byteLength(s)).toBe(realBuffer!.byteLength(s));
+    }
+  });
+});

--- a/src/trace/toolkitBufferShim.ts
+++ b/src/trace/toolkitBufferShim.ts
@@ -1,0 +1,19 @@
+/**
+ * `@ocpp-debugkit/toolkit/core` guards every parse entry point with
+ * `Buffer.byteLength(input, "utf8")` (dist/core/parseLimits.js) — a Node
+ * global that browsers don't have, so every in-browser analysis run threw
+ * `ReferenceError: Buffer is not defined` before parsing anything
+ * (issue #238). vitest/jsdom runs in Node where `Buffer` always exists,
+ * which is why no test caught it.
+ *
+ * Installs a minimal `byteLength`-only stand-in when (and only when) the
+ * global is absent. A real `Buffer` (Node, Bun, tests) is never touched.
+ */
+export function ensureToolkitBufferShim(): void {
+  const holder = globalThis as { Buffer?: unknown };
+  if (typeof holder.Buffer !== "undefined") return;
+  holder.Buffer = {
+    byteLength: (input: string): number =>
+      new TextEncoder().encode(input).length,
+  };
+}


### PR DESCRIPTION
Fixes the two bugs reported in #238 (the feature requests there — expert tools, scenario run history, surfacing active scenarios — stay open).

## Bug 1: `Analysis failed: Buffer is not defined`

`@ocpp-debugkit/toolkit/core` guards every parse entry point with `Buffer.byteLength(input, "utf8")` (`dist/core/parseLimits.js`) — a Node-only global — so clicking **Analyze** in a real browser always failed with `Analysis failed: Buffer is not defined`, with or without a charging session. vitest/jsdom run in Node where `Buffer` always exists, which is why no test ever caught it.

**Fix:** `src/trace/toolkitBufferShim.ts` installs a minimal `byteLength`-only stand-in (TextEncoder-based) just before the panel's dynamic toolkit import, only when the global is absent; a real `Buffer` is never touched. With the crash gone, the no-session case reported in the issue now renders normally (events with zero sessions / zero failures).

**Tests:** a dom regression test deletes `globalThis.Buffer` around the Analyze click to reproduce the browser runtime (fails with the exact reported error before the fix), plus unit tests for the shim (UTF-8 byte lengths checked against the real `Buffer`, and no-op when `Buffer` exists).

## Bug 2: scenario messages missing from the charger's Message Log tab

The charger detail page's Message Log tab rendered `useChargePointView`'s component-local log array, which starts empty on mount. Messages generated while on another page — e.g. a scenario launched from the Scenarios page — landed in the global Message Log (its provider is mounted app-wide in `AppShell`) but never in the charger's own tab.

**Fix:** the tab now reads the app-wide ring buffer from `GlobalLogsProvider`, filtered to the CP, so both views are consistent by construction. A seq watermark keeps the tab's **Clear** scoped to that view (the global Message Log page is unaffected) and resets when the route moves to a different CP. `useChargePointView` itself is untouched (`ScenarioRunPage` still uses its live tail).

**Tests:** the regression test emits a log event while on the dashboard, then navigates to the CP page and expects the entry in the tab — verified to fail against the previous implementation. A second test covers the Clear watermark (old entries hidden, new ones still appear).

## Verification

- `npx vitest run --dir src/console/pages` — 49/49
- `npx vitest run --dir src/trace` — 24/24
- ESLint clean on all touched files
- Both regression tests confirmed RED against the pre-fix code (via `git stash` of the implementation) and GREEN with it restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Message Logs now include entries recorded before opening a charge point’s detail page.
  - “Clear screen” removes existing messages while continuing to display newly received logs.

- **Bug Fixes**
  - Session analysis now works reliably in browser environments without a built-in `Buffer`, preventing related analysis errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->