### PR TITLE
feat: certificate quirks and the octt preset (OCTT quirks Phases 2–3)

### DIFF
--- a/docs/scenario-format.md
+++ b/docs/scenario-format.md
@@ -17,7 +17,7 @@ that schema, not a replacement for it.
 ## Status & scope
 
 - **Version `1.0`** (`schemaVersion`).
-- Covers the full 20-node discriminated union the scenario engine supports
+- Covers the full 22-node discriminated union the scenario engine supports
   (see [Node types](#node-types) below).
 - **Validation against this schema is advisory in this version**: the
   simulator warns (`console.warn` in the browser, stderr / server log on the
@@ -72,7 +72,7 @@ Mirrors the [OCPP trace format](./trace-format.md#versioning)'s rules:
 ```
 
 Every node has `id` (string), `type` (the discriminator — a closed
-enum of the 20 values below), `position` (`{ x: number, y: number }`), and
+enum of the 22 values below), `position` (`{ x: number, y: number }`), and
 `data` (an object requiring at least `label: string`; the rest of `data`'s
 shape depends on `type`).
 

--- a/docs/scenario-format.md
+++ b/docs/scenario-format.md
@@ -78,28 +78,30 @@ shape depends on `type`).
 
 ## Node types
 
-| `type`               | Required `data` fields (beyond `label`)                          | Notable optional fields                                                                                                                                                    |
-| -------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `statusChange`       | `status`                                                         |                                                                                                                                                                            |
-| `transaction`        | `action` (`"start"` \| `"stop"`)                                 | `tagId`, `batteryCapacityKwh`, `initialSoc`, `stopReason`                                                                                                                  |
-| `meterValue`         | `value`, `sendMessage`                                           | `autoIncrement`, `outputKw`, `maxChargeKwh`, `incrementInterval`, `incrementAmount`, `stopMode`, `maxTime`, `maxValue`, `useCurve`, `curvePoints`, `autoCalculateInterval` |
-| `delay`              | `delaySeconds`                                                   |                                                                                                                                                                            |
-| `notification`       | `messageType`, `payload`                                         |                                                                                                                                                                            |
-| `connectorPlug`      | `action` (`"plugin"` \| `"plugout"`)                             |                                                                                                                                                                            |
-| `remoteStartTrigger` | —                                                                | `timeout`                                                                                                                                                                  |
-| `remoteStopTrigger`  | —                                                                | `timeout`                                                                                                                                                                  |
-| `statusTrigger`      | `targetStatus`                                                   | `timeout`                                                                                                                                                                  |
-| `reserveNow`         | `expiryMinutes`, `idTag`                                         | `parentIdTag`, `reservationId`                                                                                                                                             |
-| `cancelReservation`  | `reservationId`                                                  |                                                                                                                                                                            |
-| `reservationTrigger` | —                                                                | `timeout`                                                                                                                                                                  |
-| `start`              | —                                                                | `triggerOn` (`"connect"` \| `"status"`), `targetStatus`                                                                                                                    |
-| `end`                | —                                                                |                                                                                                                                                                            |
-| `statusNotification` | `status`                                                         | `errorCode`, `info`, `vendorErrorCode`, `vendorId`, `connectorId`                                                                                                          |
-| `unlockOutcome`      | `outcome` (`"Unlocked"` \| `"UnlockFailed"` \| `"NotSupported"`) |                                                                                                                                                                            |
-| `configSet`          | `key`, `value`                                                   |                                                                                                                                                                            |
-| `dataTransfer`       | `vendorId`                                                       | `messageId`, `data`                                                                                                                                                        |
-| `csmsCallTrigger`    | `action`                                                         | `timeout`                                                                                                                                                                  |
-| `responseOverride`   | `action`, `status`                                               | See [note](#responseoverride-notes) below.                                                                                                                                 |
+| `type`               | Required `data` fields (beyond `label`)                          | Notable optional fields                                                                                                                                                               |
+| -------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `statusChange`       | `status`                                                         |                                                                                                                                                                                       |
+| `transaction`        | `action` (`"start"` \| `"stop"`)                                 | `tagId`, `batteryCapacityKwh`, `initialSoc`, `stopReason`                                                                                                                             |
+| `meterValue`         | `value`, `sendMessage`                                           | `autoIncrement`, `outputKw`, `maxChargeKwh`, `incrementInterval`, `incrementAmount`, `stopMode`, `maxTime`, `maxValue`, `useCurve`, `curvePoints`, `autoCalculateInterval`            |
+| `delay`              | `delaySeconds`                                                   |                                                                                                                                                                                       |
+| `notification`       | `messageType`, `payload`                                         |                                                                                                                                                                                       |
+| `connectorPlug`      | `action` (`"plugin"` \| `"plugout"`)                             |                                                                                                                                                                                       |
+| `remoteStartTrigger` | —                                                                | `timeout`                                                                                                                                                                             |
+| `remoteStopTrigger`  | —                                                                | `timeout`                                                                                                                                                                             |
+| `statusTrigger`      | `targetStatus`                                                   | `timeout`                                                                                                                                                                             |
+| `reserveNow`         | `expiryMinutes`, `idTag`                                         | `parentIdTag`, `reservationId`                                                                                                                                                        |
+| `cancelReservation`  | `reservationId`                                                  |                                                                                                                                                                                       |
+| `reservationTrigger` | —                                                                | `timeout`                                                                                                                                                                             |
+| `start`              | —                                                                | `triggerOn` (`"connect"` \| `"status"`), `targetStatus`                                                                                                                               |
+| `end`                | —                                                                |                                                                                                                                                                                       |
+| `statusNotification` | `status`                                                         | `errorCode`, `info`, `vendorErrorCode`, `vendorId`, `connectorId`                                                                                                                     |
+| `unlockOutcome`      | `outcome` (`"Unlocked"` \| `"UnlockFailed"` \| `"NotSupported"`) |                                                                                                                                                                                       |
+| `configSet`          | `key`, `value`                                                   |                                                                                                                                                                                       |
+| `dataTransfer`       | `vendorId`                                                       | `messageId`, `data`                                                                                                                                                                   |
+| `csmsCallTrigger`    | `action`                                                         | `timeout`                                                                                                                                                                             |
+| `responseOverride`   | `action`, `status`                                               | See [note](#responseoverride-notes) below.                                                                                                                                            |
+| `inboundPolicy`      | `action`, `policy` (`"answer"` \| `"callerror"` \| `"ignore"`)   | `errorCode`, `errorDescription`. See [note](#inboundpolicy-and-certificate-quirks-notes) below.                                                                                       |
+| `certQuirks`         | `mode` (`"set"` \| `"clear"`)                                    | `preset`, `csrKeyAlgorithm`, `csrPemLineEndings`, `requiredCertificateSignatureAlgorithms`, `hiddenConfigurationKeys`. See [note](#inboundpolicy-and-certificate-quirks-notes) below. |
 
 `status` / `targetStatus` fields use the `OCPPStatus` enum: `Available`,
 `Preparing`, `Charging`, `SuspendedEVSE`, `SuspendedEV`, `Finishing`,
@@ -116,6 +118,24 @@ action → status constraint — encoding the full per-action status matrix
 into JSON Schema would make the schema harder to read for little benefit
 over the existing editor-side check. This is called out as a `$comment` in
 the schema itself.
+
+### `inboundPolicy` and certificate quirks notes
+
+**Issue #247**: `inboundPolicy` sets a persistent policy for CSMS→CP calls
+(`policy: "callerror"` sends a CALLRESULT with the given error code, `"ignore"`
+sends no response, `"answer"` clears any prior policy). Policies survive
+reconnects and are only cleared at the end of the scenario run or via another
+`inboundPolicy` node with `policy: "answer"`.
+
+**Issue #247 Phase 3**: `certQuirks` (mode `"set"` or `"clear"`) arms
+ChargePoint domain-specific certificate behaviors. Mode `"set"` supports an
+optional `preset: "octt"` (encodes legacy OCTT behaviors: RSA CSR, CRLF PEM,
+RSASSA-PKCS1-v1_5 signature algorithm only, hidden CpoName config — see
+[steve-community/steve#2093](https://github.com/steve-community/steve/issues/2093)).
+Explicit fields override preset values. Together with `inboundPolicy` and
+declarative `assertions` (e.g., `ocpp_absent`, `no_unexpected`), certificate
+quirks let you emulate certification-tool strictness to verify a CP's
+conformance.
 
 ## Edge shape
 

--- a/schema/scenario.schema.json
+++ b/schema/scenario.schema.json
@@ -198,7 +198,9 @@
             "configSet",
             "dataTransfer",
             "csmsCallTrigger",
-            "responseOverride"
+            "responseOverride",
+            "inboundPolicy",
+            "certQuirks"
           ]
         },
         "position": { "$ref": "#/$defs/position" },
@@ -476,6 +478,49 @@
                 "properties": {
                   "action": { "type": "string" },
                   "status": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "inboundPolicy" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "$comment": "Valid `action` values are the csmsCallTrigger action set (INBOUND_POLICY_ACTIONS in ScenarioTypes.ts). Not schema-enforced here — advisory only.",
+                "required": ["action", "policy"],
+                "properties": {
+                  "action": { "type": "string" },
+                  "policy": { "enum": ["answer", "callerror", "ignore"] },
+                  "errorCode": { "type": "string" },
+                  "errorDescription": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "certQuirks" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["mode"],
+                "properties": {
+                  "mode": { "enum": ["set", "clear"] },
+                  "preset": { "enum": ["octt"] },
+                  "csrKeyAlgorithm": { "enum": ["ECDSA", "RSA"] },
+                  "csrPemLineEndings": { "enum": ["lf", "crlf"] },
+                  "requiredCertificateSignatureAlgorithms": {
+                    "type": "array",
+                    "items": {
+                      "enum": ["ECDSA", "RSASSA-PKCS1-v1_5", "RSA-PSS"]
+                    }
+                  },
+                  "hiddenConfigurationKeys": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  }
                 }
               }
             }

--- a/src/components/scenario/ScenarioEditor.tsx
+++ b/src/components/scenario/ScenarioEditor.tsx
@@ -81,6 +81,7 @@ import RemoteStopTriggerNode from "./nodes/RemoteStopTriggerNode";
 import CsmsCallTriggerNode from "./nodes/CsmsCallTriggerNode";
 import ResponseOverrideNode from "./nodes/ResponseOverrideNode";
 import InboundPolicyNode from "./nodes/InboundPolicyNode";
+import CertQuirksNode from "./nodes/CertQuirksNode";
 import StatusTriggerNode from "./nodes/StatusTriggerNode";
 import ReserveNowNode from "./nodes/ReserveNowNode";
 import CancelReservationNode from "./nodes/CancelReservationNode";
@@ -199,6 +200,7 @@ const nodeTypes: NodeTypes = {
   [ScenarioNodeType.CSMS_CALL_TRIGGER]: CsmsCallTriggerNode,
   [ScenarioNodeType.RESPONSE_OVERRIDE]: ResponseOverrideNode,
   [ScenarioNodeType.INBOUND_POLICY]: InboundPolicyNode,
+  [ScenarioNodeType.CERT_QUIRKS]: CertQuirksNode,
   [ScenarioNodeType.STATUS_TRIGGER]: StatusTriggerNode,
   [ScenarioNodeType.RESERVE_NOW]: ReserveNowNode,
   [ScenarioNodeType.CANCEL_RESERVATION]: CancelReservationNode,
@@ -234,6 +236,7 @@ const MINIMAP_NODE_COLORS: Record<string, string> = {
   [ScenarioNodeType.UNLOCK_OUTCOME]: "#06b6d4",
   [ScenarioNodeType.CONFIG_SET]: "#6b7280",
   [ScenarioNodeType.DATA_TRANSFER]: "#a8a29e",
+  [ScenarioNodeType.CERT_QUIRKS]: "#f59e0b",
 };
 
 // slate-500 fallback — stays visible on both the white (light) and
@@ -2259,6 +2262,16 @@ function createNodeByType(
           policy: "callerror",
           errorCode: "NotImplemented",
           errorDescription: "",
+        },
+      };
+    case ScenarioNodeType.CERT_QUIRKS:
+      return {
+        id,
+        type,
+        position,
+        data: {
+          label: "Certificate Quirks",
+          mode: "set",
         },
       };
     case ScenarioNodeType.STATUS_TRIGGER:

--- a/src/components/scenario/forms/CertQuirksForm.tsx
+++ b/src/components/scenario/forms/CertQuirksForm.tsx
@@ -3,8 +3,10 @@ import type { NodeFormComponentProps, NodeFormData } from "./types";
 import { CERT_SIGNATURE_ALGORITHMS } from "../../../cp/application/scenario/ScenarioTypes";
 
 const DEFAULT_MODE = "set";
-const DEFAULT_CSR_KEY_ALGORITHM = "RSA";
-const DEFAULT_CSR_LINE_ENDINGS = "lf";
+// Unset quirks must render as "(none)": defaulting the selects to a real
+// value would display quirks the node does not persist or apply.
+const DEFAULT_CSR_KEY_ALGORITHM = "";
+const DEFAULT_CSR_LINE_ENDINGS = "";
 
 export default function CertQuirksForm({
   value,
@@ -21,11 +23,13 @@ export default function CertQuirksForm({
   ];
 
   const csrKeyOptions = [
+    { value: "", label: "(none)" },
     { value: "ECDSA", label: "ECDSA" },
     { value: "RSA", label: "RSA" },
   ];
 
   const lineEndingsOptions = [
+    { value: "", label: "(none)" },
     { value: "lf", label: "LF (Unix)" },
     { value: "crlf", label: "CRLF (Windows)" },
   ];

--- a/src/components/scenario/forms/CertQuirksForm.tsx
+++ b/src/components/scenario/forms/CertQuirksForm.tsx
@@ -1,0 +1,165 @@
+import { SelectField, TextField } from "./FormFields";
+import type { NodeFormComponentProps, NodeFormData } from "./types";
+import { CERT_SIGNATURE_ALGORITHMS } from "../../../cp/application/scenario/ScenarioTypes";
+
+const DEFAULT_MODE = "set";
+const DEFAULT_CSR_KEY_ALGORITHM = "RSA";
+const DEFAULT_CSR_LINE_ENDINGS = "lf";
+
+export default function CertQuirksForm({
+  value,
+  onChange,
+}: NodeFormComponentProps<NodeFormData>) {
+  const modeOptions = [
+    { value: "set", label: "Set Quirks" },
+    { value: "clear", label: "Clear Quirks" },
+  ];
+
+  const presetOptions = [
+    { value: "", label: "(none)" },
+    { value: "octt", label: "OCTT (legacy SHA256withRSA)" },
+  ];
+
+  const csrKeyOptions = [
+    { value: "ECDSA", label: "ECDSA" },
+    { value: "RSA", label: "RSA" },
+  ];
+
+  const lineEndingsOptions = [
+    { value: "lf", label: "LF (Unix)" },
+    { value: "crlf", label: "CRLF (Windows)" },
+  ];
+
+  const algorithmOptions = CERT_SIGNATURE_ALGORITHMS.map((alg) => ({
+    value: alg,
+    label: alg,
+  }));
+
+  const currentMode = (value.mode as string | undefined) ?? DEFAULT_MODE;
+  const currentPreset = (value.preset as string | undefined) ?? "";
+  const currentCsrKeyAlgorithm =
+    (value.csrKeyAlgorithm as string | undefined) ?? DEFAULT_CSR_KEY_ALGORITHM;
+  const currentLineEndings =
+    (value.csrPemLineEndings as string | undefined) ?? DEFAULT_CSR_LINE_ENDINGS;
+  const currentAlgorithms = Array.isArray(
+    value.requiredCertificateSignatureAlgorithms,
+  )
+    ? (value.requiredCertificateSignatureAlgorithms as string[])
+    : [];
+  const currentHiddenKeys = Array.isArray(value.hiddenConfigurationKeys)
+    ? (value.hiddenConfigurationKeys as string[])
+    : [];
+
+  const handleModeChange = (mode: string) => {
+    const updated = { ...value, mode };
+    if (mode === "clear") {
+      // Remove mode-specific fields for clear mode
+      delete updated.preset;
+      delete updated.csrKeyAlgorithm;
+      delete updated.csrPemLineEndings;
+      delete updated.requiredCertificateSignatureAlgorithms;
+      delete updated.hiddenConfigurationKeys;
+    }
+    onChange(updated);
+  };
+
+  const handlePresetChange = (preset: string) => {
+    onChange({ ...value, preset: preset || undefined });
+  };
+
+  const handleCsrKeyChange = (algorithm: string) => {
+    onChange({ ...value, csrKeyAlgorithm: algorithm || undefined });
+  };
+
+  const handleLineEndingsChange = (endings: string) => {
+    onChange({ ...value, csrPemLineEndings: endings || undefined });
+  };
+
+  const handleAlgorithmsChange = (text: string) => {
+    const algorithms = text
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s);
+    onChange({
+      ...value,
+      requiredCertificateSignatureAlgorithms:
+        algorithms.length > 0 ? algorithms : undefined,
+    });
+  };
+
+  const handleHiddenKeysChange = (text: string) => {
+    const keys = text
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s);
+    onChange({
+      ...value,
+      hiddenConfigurationKeys: keys.length > 0 ? keys : undefined,
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      <TextField
+        label="Label"
+        value={(value.label as string | undefined) ?? ""}
+        onChange={(label) => onChange({ ...value, label })}
+      />
+      <SelectField
+        label="Mode"
+        value={currentMode}
+        onChange={handleModeChange}
+        options={modeOptions}
+      />
+      {currentMode === "set" && (
+        <>
+          <SelectField
+            label="Preset (optional)"
+            value={currentPreset}
+            onChange={handlePresetChange}
+            options={presetOptions}
+          />
+          <SelectField
+            label="CSR Key Algorithm (optional)"
+            value={currentCsrKeyAlgorithm}
+            onChange={handleCsrKeyChange}
+            options={[{ value: "", label: "(none)" }, ...csrKeyOptions]}
+          />
+          <SelectField
+            label="CSR PEM Line Endings (optional)"
+            value={currentLineEndings}
+            onChange={handleLineEndingsChange}
+            options={[{ value: "", label: "(none)" }, ...lineEndingsOptions]}
+          />
+          <div>
+            <label className="block text-xs font-semibold text-primary mb-1">
+              Required Signature Algorithms (optional, comma-separated)
+            </label>
+            <input
+              type="text"
+              className="input-base w-full text-xs"
+              placeholder="e.g., RSASSA-PKCS1-v1_5, ECDSA"
+              value={currentAlgorithms.join(", ")}
+              onChange={(e) => handleAlgorithmsChange(e.target.value)}
+            />
+            <div className="text-xs text-gray-500 mt-1">
+              Valid: {algorithmOptions.map((o) => o.value).join(", ")}
+            </div>
+          </div>
+          <div>
+            <label className="block text-xs font-semibold text-primary mb-1">
+              Hidden Configuration Keys (optional, comma-separated)
+            </label>
+            <input
+              type="text"
+              className="input-base w-full text-xs"
+              placeholder="e.g., CpoName, SomeOtherKey"
+              value={currentHiddenKeys.join(", ")}
+              onChange={(e) => handleHiddenKeysChange(e.target.value)}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/scenario/forms/nodeFormRegistry.ts
+++ b/src/components/scenario/forms/nodeFormRegistry.ts
@@ -1,6 +1,7 @@
 import {
   type BaseNodeData,
   type CancelReservationNodeData,
+  CERT_SIGNATURE_ALGORITHMS,
   type CertQuirksNodeData,
   type ConfigSetNodeData,
   type ConnectorPlugNodeData,
@@ -137,6 +138,9 @@ function asResponseOverrideStatus(
 }
 
 const INBOUND_POLICY_ACTIONS_SET = new Set<string>(INBOUND_POLICY_ACTIONS);
+const CERT_SIGNATURE_ALGORITHMS_SET = new Set<string>(
+  CERT_SIGNATURE_ALGORITHMS,
+);
 const INBOUND_POLICY_ERROR_CODES_SET = new Set<string>(
   INBOUND_POLICY_ERROR_CODES,
 );
@@ -705,9 +709,18 @@ function asCertLineEndings(value: unknown): "lf" | "crlf" | undefined {
   return value === "lf" || value === "crlf" ? value : undefined;
 }
 
+/** Free-text entries reach this parser, and the CertificateSigned handler
+ *  compares them verbatim against the leaf certificate's algorithm name —
+ *  a typo would silently make the acceptance policy reject everything.
+ *  Only the advertised algorithm names survive; an all-invalid list drops
+ *  to undefined (no policy) rather than persisting as reject-everything. */
 function parseCertAlgorithmArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
-  return value.filter((v) => typeof v === "string");
+  const valid = value.filter(
+    (v): v is string =>
+      typeof v === "string" && CERT_SIGNATURE_ALGORITHMS_SET.has(v),
+  );
+  return valid.length > 0 ? valid : undefined;
 }
 
 function parseStringArray(value: unknown): string[] | undefined {

--- a/src/components/scenario/forms/nodeFormRegistry.ts
+++ b/src/components/scenario/forms/nodeFormRegistry.ts
@@ -1,6 +1,7 @@
 import {
   type BaseNodeData,
   type CancelReservationNodeData,
+  type CertQuirksNodeData,
   type ConfigSetNodeData,
   type ConnectorPlugNodeData,
   CSMS_CALL_TRIGGER_ACTIONS,
@@ -31,6 +32,7 @@ import {
 import { OCPPStatus } from "../../../cp/domain/types/OcppTypes";
 import type { CurvePoint } from "../../../cp/domain/connector/MeterValueCurve";
 import CancelReservationForm from "./CancelReservationForm";
+import CertQuirksForm from "./CertQuirksForm";
 import ConfigSetForm from "./ConfigSetForm";
 import ConnectorPlugForm from "./ConnectorPlugForm";
 import CsmsCallTriggerForm from "./CsmsCallTriggerForm";
@@ -687,6 +689,67 @@ function inboundPolicyFormToNodeData(
   }) as InboundPolicyNodeData;
 }
 
+function asCertQuirksMode(value: unknown): "set" | "clear" {
+  return value === "clear" ? "clear" : "set";
+}
+
+function asCertQuirksPreset(value: unknown): "octt" | undefined {
+  return value === "octt" ? "octt" : undefined;
+}
+
+function asCertKeyAlgorithm(value: unknown): "ECDSA" | "RSA" | undefined {
+  return value === "ECDSA" || value === "RSA" ? value : undefined;
+}
+
+function asCertLineEndings(value: unknown): "lf" | "crlf" | undefined {
+  return value === "lf" || value === "crlf" ? value : undefined;
+}
+
+function parseCertAlgorithmArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((v) => typeof v === "string");
+}
+
+function parseStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((v) => typeof v === "string");
+}
+
+function certQuirksNodeDataToForm(nodeData: ScenarioNodeData): NodeFormData {
+  const data = nodeData as Partial<CertQuirksNodeData>;
+  return compactDefined({
+    ...baseToForm(nodeData),
+    mode: asCertQuirksMode(data.mode),
+    preset: asCertQuirksPreset(data.preset),
+    csrKeyAlgorithm: asCertKeyAlgorithm(data.csrKeyAlgorithm),
+    csrPemLineEndings: asCertLineEndings(data.csrPemLineEndings),
+    requiredCertificateSignatureAlgorithms:
+      data.requiredCertificateSignatureAlgorithms,
+    hiddenConfigurationKeys: data.hiddenConfigurationKeys,
+  });
+}
+
+function certQuirksFormToNodeData(formData: NodeFormData): CertQuirksNodeData {
+  const mode = asCertQuirksMode(formData.mode);
+  return compactDefined({
+    ...baseFromForm(formData),
+    mode,
+    ...(mode === "set"
+      ? {
+          preset: asCertQuirksPreset(formData.preset),
+          csrKeyAlgorithm: asCertKeyAlgorithm(formData.csrKeyAlgorithm),
+          csrPemLineEndings: asCertLineEndings(formData.csrPemLineEndings),
+          requiredCertificateSignatureAlgorithms: parseCertAlgorithmArray(
+            formData.requiredCertificateSignatureAlgorithms,
+          ),
+          hiddenConfigurationKeys: parseStringArray(
+            formData.hiddenConfigurationKeys,
+          ),
+        }
+      : {}),
+  }) as CertQuirksNodeData;
+}
+
 export const NODE_FORM_REGISTRY = {
   [ScenarioNodeType.STATUS_CHANGE]: {
     title: "Status Change",
@@ -801,6 +864,12 @@ export const NODE_FORM_REGISTRY = {
     Component: InboundPolicyForm,
     nodeDataToForm: inboundPolicyNodeDataToForm,
     formToNodeData: inboundPolicyFormToNodeData,
+  },
+  [ScenarioNodeType.CERT_QUIRKS]: {
+    title: "Certificate Quirks",
+    Component: CertQuirksForm,
+    nodeDataToForm: certQuirksNodeDataToForm,
+    formToNodeData: certQuirksFormToNodeData,
   },
   [ScenarioNodeType.CONFIG_SET]: {
     title: "Config Set",

--- a/src/components/scenario/nodes/CertQuirksNode.tsx
+++ b/src/components/scenario/nodes/CertQuirksNode.tsx
@@ -1,0 +1,49 @@
+import React, { memo } from "react";
+import { Handle, Position, NodeProps, type Node } from "@xyflow/react";
+import { CertQuirksNodeData } from "../../../cp/application/scenario/ScenarioTypes";
+
+// Mapped type (not `extends`) so the result is a fresh object type that
+// satisfies xyflow v12's `Node<Record<string, unknown>>` constraint — a
+// plain interface does not.
+type CertQuirksNodeDataMapped = {
+  [K in keyof CertQuirksNodeData]: CertQuirksNodeData[K];
+};
+
+type CertQuirksFlowNode = Node<CertQuirksNodeDataMapped>;
+
+const CertQuirksNode: React.FC<NodeProps<CertQuirksFlowNode>> = ({
+  data,
+  selected,
+}) => {
+  // Compact summary of mode and key quirks for the node display
+  const summary = (() => {
+    if (data.mode === "clear") {
+      return "clear all";
+    }
+    const parts: string[] = [];
+    if (data.preset) parts.push(`${data.preset} preset`);
+    if (data.csrKeyAlgorithm) parts.push(`CSR: ${data.csrKeyAlgorithm}`);
+    if (data.csrPemLineEndings)
+      parts.push(`PEM: ${data.csrPemLineEndings.toUpperCase()}`);
+    return parts.length > 0 ? parts.join(", ") : "set";
+  })();
+
+  return (
+    <div
+      className={`px-4 py-3 rounded-lg border-2 bg-white dark:bg-gray-800 min-w-[200px] ${
+        selected ? "border-blue-500" : "border-gray-300 dark:border-gray-600"
+      }`}
+    >
+      <Handle type="target" position={Position.Top} className="w-3 h-3" />
+      <div className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">
+        Certificate Quirks
+      </div>
+      <div className="text-sm font-bold text-amber-700 dark:text-amber-300">
+        {summary}
+      </div>
+      <Handle type="source" position={Position.Bottom} className="w-3 h-3" />
+    </div>
+  );
+};
+
+export default memo(CertQuirksNode);

--- a/src/console/lib/scenarioSteps.ts
+++ b/src/console/lib/scenarioSteps.ts
@@ -2,6 +2,7 @@ import type { Edge } from "@xyflow/react";
 
 import {
   type CancelReservationNodeData,
+  type CertQuirksNodeData,
   type ConfigSetNodeData,
   type ConnectorPlugNodeData,
   type CsmsCallTriggerNodeData,
@@ -456,6 +457,16 @@ export function createDefaultNode(type: ScenarioNodeType): ScenarioNode {
           errorDescription: "",
         } satisfies InboundPolicyNodeData,
       };
+    case ScenarioNodeType.CERT_QUIRKS:
+      return {
+        id,
+        type,
+        position,
+        data: {
+          label: "Certificate Quirks",
+          mode: "set",
+        } satisfies CertQuirksNodeData,
+      };
     case ScenarioNodeType.START:
       return {
         id,
@@ -586,6 +597,19 @@ export function stepSummary(node: ScenarioNode): string {
         return `${d.action} → ignore`;
       }
     }
+    case ScenarioNodeType.CERT_QUIRKS: {
+      const d = node.data as CertQuirksNodeData;
+      if (d.mode === "clear") {
+        return "clear all quirks";
+      } else {
+        const parts: string[] = [];
+        if (d.preset) parts.push(`preset: ${d.preset}`);
+        if (d.csrKeyAlgorithm) parts.push(`CSR: ${d.csrKeyAlgorithm}`);
+        if (d.csrPemLineEndings)
+          parts.push(`PEM: ${d.csrPemLineEndings.toUpperCase()}`);
+        return parts.length > 0 ? parts.join(" · ") : "set quirks";
+      }
+    }
     case ScenarioNodeType.CONFIG_SET: {
       const d = node.data as ConfigSetNodeData;
       return `${d.key} = ${d.value}`;
@@ -643,6 +667,7 @@ export const STEP_CATEGORIES: ReadonlyArray<{
     types: [
       ScenarioNodeType.RESPONSE_OVERRIDE,
       ScenarioNodeType.INBOUND_POLICY,
+      ScenarioNodeType.CERT_QUIRKS,
       ScenarioNodeType.CONFIG_SET,
       ScenarioNodeType.DATA_TRANSFER,
       ScenarioNodeType.NOTIFICATION,

--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -24,6 +24,7 @@ import {
   UnlockOutcomeNodeData,
   ResponseOverrideNodeData,
   InboundPolicyNodeData,
+  CertQuirksNodeData,
   ConfigSetNodeData,
   DataTransferNodeData,
   StartTransactionOptions,
@@ -115,6 +116,9 @@ export class ScenarioExecutor {
   // Issue #247: track which inbound policies were armed during this run,
   // so they can be cleared when the run ends (both normal completion and stop()).
   private armedInboundPolicyActions: string[] = [];
+  // Issue #247 Phase 3: track whether certificate quirks were armed during this
+  // run, so they can be cleared when the run ends (both normal completion and stop()).
+  private armedCertificateQuirks = false;
 
   constructor(
     scenario: ScenarioDefinition,
@@ -278,6 +282,12 @@ export class ScenarioExecutor {
         this.callbacks.onClearInboundPolicy?.(action);
       }
       this.armedInboundPolicyActions = [];
+
+      // Issue #247 Phase 3: clear any certificate quirks armed during this run.
+      if (this.armedCertificateQuirks) {
+        this.callbacks.onClearCertificateQuirks?.();
+        this.armedCertificateQuirks = false;
+      }
 
       this.notifyStateChange();
     }
@@ -649,6 +659,10 @@ export class ScenarioExecutor {
         await this.executeInboundPolicy(node.data as InboundPolicyNodeData);
         break;
 
+      case ScenarioNodeType.CERT_QUIRKS:
+        await this.executeCertQuirks(node.data as CertQuirksNodeData);
+        break;
+
       case ScenarioNodeType.CONFIG_SET:
         await this.executeConfigSet(node.data as ConfigSetNodeData);
         break;
@@ -763,6 +777,69 @@ export class ScenarioExecutor {
           : "ignore";
       this.callbacks.log?.(
         `Armed inbound policy: ${data.action} → ${policyDesc}`,
+        "info",
+      );
+    }
+  }
+
+  /** Issue #247 Phase 3: set or clear certificate quirks. */
+  private async executeCertQuirks(data: CertQuirksNodeData): Promise<void> {
+    if (data.mode === "clear") {
+      // Clear all quirks.
+      if (!this.callbacks.onClearCertificateQuirks) {
+        this.callbacks.log?.(
+          "CertQuirks: no onClearCertificateQuirks callback wired",
+          "warn",
+        );
+        return;
+      }
+      this.callbacks.onClearCertificateQuirks();
+      this.callbacks.log?.("Cleared certificate quirks", "info");
+    } else if (data.mode === "set") {
+      // Build quirks from preset (if any) + explicit overrides.
+      const quirks: Record<string, unknown> = {};
+
+      // Start with preset if specified
+      if (data.preset === "octt") {
+        quirks.csrKeyAlgorithm = "RSA";
+        quirks.csrPemLineEndings = "crlf";
+        quirks.requiredCertificateSignatureAlgorithms = ["RSASSA-PKCS1-v1_5"];
+        quirks.hiddenConfigurationKeys = ["CpoName"];
+      }
+
+      // Apply explicit field overrides
+      if (data.csrKeyAlgorithm !== undefined) {
+        quirks.csrKeyAlgorithm = data.csrKeyAlgorithm;
+      }
+      if (data.csrPemLineEndings !== undefined) {
+        quirks.csrPemLineEndings = data.csrPemLineEndings;
+      }
+      if (data.requiredCertificateSignatureAlgorithms !== undefined) {
+        quirks.requiredCertificateSignatureAlgorithms =
+          data.requiredCertificateSignatureAlgorithms;
+      }
+      if (data.hiddenConfigurationKeys !== undefined) {
+        quirks.hiddenConfigurationKeys = data.hiddenConfigurationKeys;
+      }
+
+      if (!this.callbacks.onSetCertificateQuirks) {
+        this.callbacks.log?.(
+          "CertQuirks: no onSetCertificateQuirks callback wired",
+          "warn",
+        );
+        return;
+      }
+
+      this.callbacks.onSetCertificateQuirks(
+        quirks as Parameters<
+          NonNullable<typeof this.callbacks.onSetCertificateQuirks>
+        >[0],
+      );
+      this.armedCertificateQuirks = true;
+
+      const presetDesc = data.preset ? ` (preset: ${data.preset})` : "";
+      this.callbacks.log?.(
+        `Armed certificate quirks${presetDesc}: ${JSON.stringify(quirks)}`,
         "info",
       );
     }

--- a/src/cp/application/scenario/ScenarioRuntime.ts
+++ b/src/cp/application/scenario/ScenarioRuntime.ts
@@ -639,6 +639,12 @@ export const createScenarioExecutorCallbacks = (
     onClearInboundPolicy: (action) => {
       chargePoint.clearInboundCallPolicy(action);
     },
+    onSetCertificateQuirks: (quirks) => {
+      chargePoint.setCertificateQuirks(quirks);
+    },
+    onClearCertificateQuirks: () => {
+      chargePoint.clearCertificateQuirks();
+    },
     onConfigSet: (key, value) => {
       chargePoint.configuration.applyChange(key, value);
     },

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -72,6 +72,11 @@ export enum ScenarioNodeType {
   // (callerror or ignore). Policies survive reconnects until explicitly
   // cleared, unlike responseOverride which is one-shot.
   INBOUND_POLICY = "inboundPolicy",
+  // Issue #247 Phase 3: set or clear certificate quirks (ChargePoint
+  // domain-specific behaviors like CSR key algorithm, PEM line endings,
+  // signature algorithm requirements, hidden configuration keys). Used to
+  // emulate certification-tool behaviors (e.g., OCTT strictness).
+  CERT_QUIRKS = "certQuirks",
 }
 
 /**
@@ -332,6 +337,34 @@ export interface InboundPolicyNodeData extends BaseNodeData {
 }
 
 /**
+ * Certificate Quirks Node Data — sets or clears ChargePoint domain-specific
+ * certificate behaviors (CSR key algorithm, PEM line endings, required
+ * signature algorithms, hidden configuration keys). Issue #247 Phase 3.
+ *
+ * Two modes:
+ * - "set": apply quirks from an optional preset and/or explicit fields.
+ * - "clear": clear all quirks (resume normal behavior).
+ *
+ * Presets (e.g., "octt") encode certification-tool behaviors. Explicit
+ * fields override preset values. Quirks are tracked and cleared when the
+ * scenario completes or stops (same lifecycle as inboundPolicy).
+ */
+export interface CertQuirksNodeData extends BaseNodeData {
+  /** Mode: "set" to apply quirks, "clear" to remove them. */
+  mode: "set" | "clear";
+  /** Optional preset name; only meaningful when mode === "set". */
+  preset?: "octt";
+  /** CSR key algorithm (only for mode="set" and optional). */
+  csrKeyAlgorithm?: "ECDSA" | "RSA";
+  /** CSR PEM line endings (only for mode="set" and optional). */
+  csrPemLineEndings?: "lf" | "crlf";
+  /** Required certificate signature algorithms (only for mode="set" and optional). */
+  requiredCertificateSignatureAlgorithms?: string[];
+  /** Hidden configuration keys (only for mode="set" and optional). */
+  hiddenConfigurationKeys?: string[];
+}
+
+/**
  * Config Set Node Data — applies a ChangeConfiguration locally (without
  * round-tripping through CSMS). Useful for tightening
  * MeterValueSampleInterval / changing MeterValuesSampledData mid-scenario.
@@ -372,6 +405,7 @@ export type ScenarioNodeData =
   | UnlockOutcomeNodeData
   | ResponseOverrideNodeData
   | InboundPolicyNodeData
+  | CertQuirksNodeData
   | ConfigSetNodeData
   | DataTransferNodeData
   | StartNodeData
@@ -713,6 +747,18 @@ export interface ScenarioExecutorCallbacks {
   /** Issue #247: clear the inbound call policy for the given action (or all
    *  if action is omitted). Called when a scenario run ends to clean up. */
   onClearInboundPolicy?: (action?: string) => void;
+  /** Issue #247 Phase 3: set certificate quirks (merge with existing). */
+  onSetCertificateQuirks?: (
+    quirks: Partial<{
+      csrKeyAlgorithm?: "ECDSA" | "RSA";
+      csrPemLineEndings?: "lf" | "crlf";
+      requiredCertificateSignatureAlgorithms?: string[];
+      hiddenConfigurationKeys?: string[];
+    }>,
+  ) => void;
+  /** Issue #247 Phase 3: clear all certificate quirks. Called when a scenario
+   *  run ends to clean up any quirks armed during the run. */
+  onClearCertificateQuirks?: () => void;
   /** §5.3: apply a Configuration key change locally. */
   onConfigSet?: (key: string, value: string) => void;
   /** §4.3: send CP-initiated DataTransfer.req. */
@@ -942,4 +988,25 @@ export const INBOUND_POLICY_ERROR_CODES = [
   "OccurenceConstraintViolation",
   "TypeConstraintViolation",
   "GenericError",
+] as const;
+
+/** Presets for certQuirks node; currently "octt" encodes legacy OCTT
+ *  strictness (RSA CSR, CRLF PEM, RSASSA-PKCS1-v1_5 only, hide CpoName). */
+export const CERT_QUIRKS_PRESETS = ["octt"] as const;
+
+/** The OCTT preset expansion: legacy SHA256withRSA-only acceptance
+ *  (reject RSA-PSS), RSA CSR, CRLF PEM, no CpoName reference.
+ *  See steve-community/steve#2093. */
+export const OCTT_PRESET_QUIRKS = {
+  csrKeyAlgorithm: "RSA",
+  csrPemLineEndings: "crlf",
+  requiredCertificateSignatureAlgorithms: ["RSASSA-PKCS1-v1_5"],
+  hiddenConfigurationKeys: ["CpoName"],
+} as const;
+
+/** Valid certificate signature algorithm names for certQuirks validation. */
+export const CERT_SIGNATURE_ALGORITHMS = [
+  "ECDSA",
+  "RSASSA-PKCS1-v1_5",
+  "RSA-PSS",
 ] as const;

--- a/src/cp/application/scenario/__tests__/certQuirks.test.ts
+++ b/src/cp/application/scenario/__tests__/certQuirks.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it } from "vitest";
+
+import { ScenarioExecutor } from "../ScenarioExecutor";
+import { createScenarioExecutorCallbacks } from "../ScenarioRuntime";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+import { ScenarioDefinition, ScenarioNodeType } from "../ScenarioTypes";
+
+function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+async function waitUntil(predicate: () => boolean, ms = 500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > ms) {
+      throw new Error("Timed out waiting for predicate");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function newChargePoint(id: string): ChargePoint {
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    "ws://127.0.0.1:9/",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  return cp;
+}
+
+describe("certQuirks node (issue #247)", () => {
+  it("mode=set arms quirks and clears on scenario completion", async () => {
+    const cp = newChargePoint("CP-CERT-QUIRKS-SET");
+    const connector = cp.getConnector(1)!;
+    const now = new Date().toISOString();
+    const scenario: ScenarioDefinition = {
+      id: "test-cert-quirks-set",
+      name: "certQuirks mode set",
+      targetType: "connector",
+      targetId: 1,
+      trigger: { type: "manual" },
+      defaultExecutionMode: "oneshot",
+      enabled: true,
+      createdAt: now,
+      updatedAt: now,
+      nodes: [
+        {
+          id: "start-1",
+          type: ScenarioNodeType.START,
+          position: { x: 0, y: 0 },
+          data: { label: "Start", triggerOn: "connect" },
+        },
+        {
+          id: "arm-quirks",
+          type: ScenarioNodeType.CERT_QUIRKS,
+          position: { x: 0, y: 100 },
+          data: {
+            label: "Set explicit quirks",
+            mode: "set",
+            csrKeyAlgorithm: "RSA",
+            csrPemLineEndings: "crlf",
+            requiredCertificateSignatureAlgorithms: ["RSASSA-PKCS1-v1_5"],
+            hiddenConfigurationKeys: ["CpoName"],
+          },
+        },
+        {
+          id: "end-1",
+          type: ScenarioNodeType.END,
+          position: { x: 0, y: 200 },
+          data: { label: "End" },
+        },
+      ],
+      edges: [
+        { id: "e1", source: "start-1", target: "arm-quirks" },
+        { id: "e2", source: "arm-quirks", target: "end-1" },
+      ],
+    };
+
+    const executor = new ScenarioExecutor(
+      scenario,
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+    );
+
+    await timeout(executor.start(), 1000);
+
+    // After completion, the quirks should be cleared
+    expect(cp.certificateQuirks).toEqual({});
+  });
+
+  it("preset octt expands to documented object; explicit fields override", async () => {
+    const cp = newChargePoint("CP-CERT-QUIRKS-PRESET");
+    const connector = cp.getConnector(1)!;
+    const now = new Date().toISOString();
+
+    const scenario: ScenarioDefinition = {
+      id: "test-cert-quirks-octt-override",
+      name: "certQuirks preset octt with override",
+      targetType: "connector",
+      targetId: 1,
+      trigger: { type: "manual" },
+      defaultExecutionMode: "oneshot",
+      enabled: true,
+      createdAt: now,
+      updatedAt: now,
+      nodes: [
+        {
+          id: "start-1",
+          type: ScenarioNodeType.START,
+          position: { x: 0, y: 0 },
+          data: { label: "Start", triggerOn: "connect" },
+        },
+        {
+          id: "arm-preset",
+          type: ScenarioNodeType.CERT_QUIRKS,
+          position: { x: 0, y: 100 },
+          data: {
+            label: "OCTT preset with override",
+            mode: "set",
+            preset: "octt",
+            csrPemLineEndings: "lf", // Override the preset's "crlf"
+          },
+        },
+        {
+          id: "end-1",
+          type: ScenarioNodeType.END,
+          position: { x: 0, y: 200 },
+          data: { label: "End" },
+        },
+      ],
+      edges: [
+        { id: "e1", source: "start-1", target: "arm-preset" },
+        { id: "e2", source: "arm-preset", target: "end-1" },
+      ],
+    };
+
+    const executor = new ScenarioExecutor(
+      scenario,
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+    );
+
+    await timeout(executor.start(), 1000);
+
+    // After completion, the quirks should be cleared
+    expect(cp.certificateQuirks).toEqual({});
+  });
+
+  it("mode=clear clears immediately", async () => {
+    const cp = newChargePoint("CP-CERT-QUIRKS-CLEAR");
+    const connector = cp.getConnector(1)!;
+    const now = new Date().toISOString();
+
+    // First, manually set some quirks
+    cp.setCertificateQuirks({
+      csrKeyAlgorithm: "ECDSA",
+      csrPemLineEndings: "lf",
+    });
+    expect(cp.certificateQuirks.csrKeyAlgorithm).toBe("ECDSA");
+
+    const scenario: ScenarioDefinition = {
+      id: "test-cert-quirks-clear",
+      name: "certQuirks mode clear",
+      targetType: "connector",
+      targetId: 1,
+      trigger: { type: "manual" },
+      defaultExecutionMode: "oneshot",
+      enabled: true,
+      createdAt: now,
+      updatedAt: now,
+      nodes: [
+        {
+          id: "start-1",
+          type: ScenarioNodeType.START,
+          position: { x: 0, y: 0 },
+          data: { label: "Start", triggerOn: "connect" },
+        },
+        {
+          id: "clear-quirks",
+          type: ScenarioNodeType.CERT_QUIRKS,
+          position: { x: 0, y: 100 },
+          data: {
+            label: "Clear quirks",
+            mode: "clear",
+          },
+        },
+        {
+          id: "end-1",
+          type: ScenarioNodeType.END,
+          position: { x: 0, y: 200 },
+          data: { label: "End" },
+        },
+      ],
+      edges: [
+        { id: "e1", source: "start-1", target: "clear-quirks" },
+        { id: "e2", source: "clear-quirks", target: "end-1" },
+      ],
+    };
+
+    const executor = new ScenarioExecutor(
+      scenario,
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+    );
+
+    await timeout(executor.start(), 1000);
+
+    // After the clear node executes, quirks should be cleared
+    expect(cp.certificateQuirks).toEqual({});
+  });
+
+  it("clears armed quirks on stop() mid-run", async () => {
+    const cp = newChargePoint("CP-CERT-QUIRKS-STOP");
+    const connector = cp.getConnector(1)!;
+    const now = new Date().toISOString();
+
+    const parkedScenario: ScenarioDefinition = {
+      id: "test-cert-quirks-parked",
+      name: "certQuirks armed, then parked",
+      targetType: "connector",
+      targetId: 1,
+      trigger: { type: "manual" },
+      defaultExecutionMode: "oneshot",
+      enabled: true,
+      createdAt: now,
+      updatedAt: now,
+      nodes: [
+        {
+          id: "start-1",
+          type: ScenarioNodeType.START,
+          position: { x: 0, y: 0 },
+          data: { label: "Start", triggerOn: "connect" },
+        },
+        {
+          id: "arm-quirks",
+          type: ScenarioNodeType.CERT_QUIRKS,
+          position: { x: 0, y: 100 },
+          data: {
+            label: "Arm quirks",
+            mode: "set",
+            csrKeyAlgorithm: "RSA",
+          },
+        },
+        {
+          id: "park",
+          type: ScenarioNodeType.CSMS_CALL_TRIGGER,
+          position: { x: 0, y: 200 },
+          data: {
+            label: "Wait for GetConfiguration",
+            action: "GetConfiguration",
+            timeout: 30,
+          },
+        },
+        {
+          id: "end-1",
+          type: ScenarioNodeType.END,
+          position: { x: 0, y: 300 },
+          data: { label: "End" },
+        },
+      ],
+      edges: [
+        { id: "e1", source: "start-1", target: "arm-quirks" },
+        { id: "e2", source: "arm-quirks", target: "park" },
+        { id: "e3", source: "park", target: "end-1" },
+      ],
+    };
+
+    const executor = new ScenarioExecutor(
+      parkedScenario,
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+    );
+
+    const startPromise = executor.start();
+
+    // Wait for the csmsCallTrigger node to attach its listener — that's
+    // when the executor has armed the quirks and reached the parked state.
+    await waitUntil(() => cp.events.listenerCount("incomingCallReceived") > 0);
+
+    // Stop the scenario while parked (the quirks are armed)
+    executor.stop();
+
+    // Wait for the start promise to resolve
+    await timeout(startPromise, 1000);
+
+    // After stop, the executor's finally block should have cleared the armed quirks
+    expect(cp.certificateQuirks).toEqual({});
+  });
+});

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -91,6 +91,30 @@ export type InboundCallPolicy =
   | { kind: "callerror"; errorCode: string; errorDescription: string }
   | { kind: "ignore" };
 
+/**
+ * Certificate quirks for CSR generation and acceptance (issue #247).
+ * Used to emulate OCPP conformance tool behavior and test edge cases.
+ * All fields are optional; unset fields revert to default behavior.
+ */
+export interface CertificateQuirks {
+  /** Key algorithm for generated CSRs. Default (unset): ECDSA P-256. */
+  csrKeyAlgorithm?: "ECDSA" | "RSA";
+  /** Line endings for emitted CSR PEM. Default (unset): "lf". */
+  csrPemLineEndings?: "lf" | "crlf";
+  /** Accepted signature algorithms for certificates received via CertificateSigned.
+   *  Unset/empty = accept anything (default behavior). The handler checks the leaf
+   *  certificate's signature algorithm name (via X509Certificate.signatureAlgorithm.name)
+   *  and rejects the chain if its name is not in this list. Matchable algorithm names
+   *  include "ECDSA" (P-256, P-384, P-521), "RSASSA-PKCS1-v1_5" (RSA PKCS#1),
+   *  and "RSA-PSS" (RSA-PSS). */
+  requiredCertificateSignatureAlgorithms?: string[];
+  /** OCPP 1.6 configuration keys to omit from GetConfiguration responses.
+   *  When a hidden key is requested by name, it appears in the response's
+   *  unknownKey array instead of the configurationKey list. Unset/empty =
+   *  no keys are hidden (default behavior). */
+  hiddenConfigurationKeys?: string[];
+}
+
 export type ChargePointResetType = "Hard" | "Soft";
 type ChargePointResetSource = "ocpp-call" | "ocpp15-soap";
 
@@ -144,6 +168,9 @@ export class ChargePoint {
    *  CALL arrives for an action with a policy, reply with CALLERROR or stay silent
    *  instead of processing normally. Survive reconnects until explicitly cleared. */
   private readonly _inboundCallPolicies = new Map<string, InboundCallPolicy>();
+  /** Certificate quirks for CSR generation and acceptance (issue #247).
+   *  Used to emulate OCPP conformance tool behavior. Sticky until cleared. */
+  private _certificateQuirks: CertificateQuirks = {};
   // §4.9 B6: per-connector ConnectionTimeOut watchdog. Started when a
   // connector enters Preparing, cleared on any other transition. If the
   // timer fires we auto-transition the connector to Finishing.
@@ -784,6 +811,23 @@ export class ChargePoint {
     } else {
       this._inboundCallPolicies.delete(action);
     }
+  }
+
+  /** Set certificate quirks (CSR generation options, acceptance policies, etc.).
+   *  Shallow-merges into current quirks; unset fields inherit prior values.
+   *  Sticky until explicitly cleared. */
+  setCertificateQuirks(quirks: Partial<CertificateQuirks>): void {
+    this._certificateQuirks = { ...this._certificateQuirks, ...quirks };
+  }
+
+  /** Reset all certificate quirks to empty state. */
+  clearCertificateQuirks(): void {
+    this._certificateQuirks = {};
+  }
+
+  /** Read-only access to current certificate quirks. */
+  get certificateQuirks(): CertificateQuirks {
+    return this._certificateQuirks;
   }
 
   set loggingCallback(callback: (entry: LogEntry) => void) {

--- a/src/cp/domain/charge-point/__tests__/AuthorizationKey.redaction.test.ts
+++ b/src/cp/domain/charge-point/__tests__/AuthorizationKey.redaction.test.ts
@@ -31,7 +31,7 @@ function contextFor(
   logger: Logger = { info: vi.fn() } as unknown as Logger,
 ): HandlerContext {
   return {
-    chargePoint: { configuration: store } as ChargePoint,
+    chargePoint: { configuration: store, certificateQuirks: {} } as ChargePoint,
     logger,
   };
 }

--- a/src/cp/domain/security/CertificateStore.ts
+++ b/src/cp/domain/security/CertificateStore.ts
@@ -1,4 +1,4 @@
-import { generateCsr } from "./csr";
+import { generateCsr, type CsrGenerationOptions } from "./csr";
 
 export type RootCertificateType =
   "CentralSystemRootCertificate" | "ManufacturerRootCertificate";
@@ -23,8 +23,12 @@ export class CertificateStore {
   #signedChains: string[][] = [];
   #rootCerts: InstalledRootCertificate[] = [];
 
-  async generateNewCsr(serial: string, cpoName: string): Promise<string> {
-    const generated = await generateCsr(serial, cpoName);
+  async generateNewCsr(
+    serial: string,
+    cpoName: string,
+    options?: CsrGenerationOptions,
+  ): Promise<string> {
+    const generated = await generateCsr(serial, cpoName, options);
 
     this.#keyPair = {
       privateKey: generated.privateKey,

--- a/src/cp/domain/security/__tests__/csr.test.ts
+++ b/src/cp/domain/security/__tests__/csr.test.ts
@@ -1,0 +1,147 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import * as x509 from "@peculiar/x509";
+import { generateCsr } from "../csr";
+
+x509.cryptoProvider.set(globalThis.crypto as Crypto);
+
+describe("generateCsr", () => {
+  it("default: CSR is ECDSA P-256 with SHA-256", async () => {
+    const generated = await generateCsr("TEST-SERIAL", "TestCPO");
+
+    expect(generated.pem).toContain("-----BEGIN CERTIFICATE REQUEST-----");
+    expect(generated.csr).toBeInstanceOf(x509.Pkcs10CertificateRequest);
+
+    // Verify the CSR signature
+    const isValid = await generated.csr.verify();
+    expect(isValid).toBe(true);
+
+    // Parse and check the public key algorithm is ECDSA
+    const publicKey = generated.csr.publicKey;
+    expect(publicKey.algorithm.name).toBe("ECDSA");
+    expect((publicKey.algorithm as EcKeyAlgorithm).namedCurve).toBe("P-256");
+
+    // Check signature algorithm is ECDSA with SHA-256
+    const sigAlg = generated.csr.signatureAlgorithm;
+    expect(sigAlg.name).toBe("ECDSA");
+  });
+
+  it("keyAlgorithm 'RSA': CSR public key and signature are RSA", async () => {
+    const generated = await generateCsr("TEST-SERIAL-RSA", "TestCPO", {
+      keyAlgorithm: "RSA",
+    });
+
+    expect(generated.pem).toContain("-----BEGIN CERTIFICATE REQUEST-----");
+    const isValid = await generated.csr.verify();
+    expect(isValid).toBe(true);
+
+    // Parse and check the public key algorithm is RSA
+    const publicKey = generated.csr.publicKey;
+    expect(publicKey.algorithm.name).toBe("RSASSA-PKCS1-v1_5");
+    expect((publicKey.algorithm as RsaKeyAlgorithm).modulusLength).toBe(2048);
+
+    // Check signature algorithm name (x509 returns "RSASSA-PKCS1-v1_5" for RSA CSRs)
+    const sigAlg = generated.csr.signatureAlgorithm;
+    expect(sigAlg.name).toBe("RSASSA-PKCS1-v1_5");
+  });
+
+  it("pemLineEndings 'crlf': converts LF to CRLF", async () => {
+    const generated = await generateCsr("TEST-SERIAL-CRLF", "TestCPO", {
+      pemLineEndings: "crlf",
+    });
+
+    // Should have CRLF line endings
+    expect(generated.pem).toContain("\r\n");
+    // Should NOT have isolated LF (which would be CRLF converted to CRCRLF)
+    const lines = generated.pem.split("\r\n");
+    for (const line of lines) {
+      expect(line).not.toContain("\r");
+      expect(line).not.toContain("\n");
+    }
+
+    // Verify the PEM is still valid by parsing it
+    const csr = new x509.Pkcs10CertificateRequest(generated.pem);
+    expect(csr.subject).toContain("CN=TEST-SERIAL-CRLF");
+  });
+
+  it("pemLineEndings 'crlf': idempotently converts, no double conversion", async () => {
+    const generated = await generateCsr("TEST-SERIAL-CRLF-2", "TestCPO", {
+      pemLineEndings: "crlf",
+    });
+
+    // Count CRLF sequences
+    const crlfCount = (generated.pem.match(/\r\n/g) || []).length;
+    // Count isolated CR (would indicate double conversion)
+    const isolatedCrCount = (
+      generated.pem.replace(/\r\n/g, "").match(/\r/g) || []
+    ).length;
+
+    expect(crlfCount).toBeGreaterThan(0);
+    expect(isolatedCrCount).toBe(0); // No isolated CR
+  });
+
+  it("keyAlgorithm 'RSA' + pemLineEndings 'crlf': both options work together", async () => {
+    const generated = await generateCsr("TEST-SERIAL-RSA-CRLF", "TestCPO", {
+      keyAlgorithm: "RSA",
+      pemLineEndings: "crlf",
+    });
+
+    // Check RSA
+    const publicKey = generated.csr.publicKey;
+    expect(publicKey.algorithm.name).toBe("RSASSA-PKCS1-v1_5");
+
+    // Check CRLF
+    expect(generated.pem).toContain("\r\n");
+    const lines = generated.pem.split("\r\n");
+    for (const line of lines) {
+      expect(line).not.toContain("\r");
+      expect(line).not.toContain("\n");
+    }
+
+    // Verify signature
+    const isValid = await generated.csr.verify();
+    expect(isValid).toBe(true);
+  });
+
+  it("pemLineEndings 'lf': keeps LF line endings (default)", async () => {
+    const generated = await generateCsr("TEST-SERIAL-LF", "TestCPO", {
+      pemLineEndings: "lf",
+    });
+
+    // Should have LF but not CRLF
+    expect(generated.pem).toContain("\n");
+    expect(generated.pem).not.toContain("\r\n");
+  });
+
+  it("no options: defaults to ECDSA + LF", async () => {
+    const generated = await generateCsr("TEST-SERIAL-DEFAULTS", "TestCPO");
+
+    // Check ECDSA
+    const publicKey = generated.csr.publicKey;
+    expect(publicKey.algorithm.name).toBe("ECDSA");
+
+    // Check LF (no CRLF)
+    expect(generated.pem).not.toContain("\r\n");
+    expect(generated.pem).toContain("\n");
+  });
+
+  it("CSR subject includes serial and CPO name", async () => {
+    const generated = await generateCsr("MY-SERIAL-123", "My CPO Inc");
+
+    expect(generated.csr.subject).toContain("CN=MY-SERIAL-123");
+    expect(generated.csr.subject).toContain("O=My CPO Inc");
+  });
+
+  it("RSA: uses 2048-bit modulus and SHA-256 hash", async () => {
+    const generated = await generateCsr("TEST-RSA-PARAMS", "TestCPO", {
+      keyAlgorithm: "RSA",
+    });
+
+    const publicKey = generated.csr.publicKey;
+    const rsaAlg = publicKey.algorithm as RsaKeyAlgorithm;
+    expect(rsaAlg.modulusLength).toBe(2048);
+
+    const sigAlg = generated.csr.signatureAlgorithm;
+    expect(sigAlg.name).toBe("RSASSA-PKCS1-v1_5");
+  });
+});

--- a/src/cp/domain/security/csr.ts
+++ b/src/cp/domain/security/csr.ts
@@ -3,7 +3,12 @@ import * as x509 from "@peculiar/x509";
 
 x509.cryptoProvider.set(globalThis.crypto as Crypto);
 
-const alg = { name: "ECDSA", namedCurve: "P-256", hash: "SHA-256" } as const;
+export interface CsrGenerationOptions {
+  /** Key algorithm for the CSR. Default: "ECDSA" (P-256, SHA-256) */
+  keyAlgorithm?: "ECDSA" | "RSA";
+  /** Line endings for the emitted PEM. Default: "lf" */
+  pemLineEndings?: "lf" | "crlf";
+}
 
 export interface GeneratedCsr {
   csr: x509.Pkcs10CertificateRequest;
@@ -15,14 +20,61 @@ export interface GeneratedCsr {
 export async function generateCsr(
   serial: string,
   cpoName: string,
+  options?: CsrGenerationOptions,
 ): Promise<GeneratedCsr> {
-  const keys = await crypto.subtle.generateKey(alg, true, ["sign", "verify"]);
+  const keyAlgorithm = options?.keyAlgorithm ?? "ECDSA";
+  const pemLineEndings = options?.pemLineEndings ?? "lf";
+
+  let alg:
+    | {
+        name: "ECDSA";
+        namedCurve: "P-256";
+        hash: "SHA-256";
+      }
+    | {
+        name: "RSASSA-PKCS1-v1_5";
+        modulusLength: 2048;
+        publicExponent: Uint8Array;
+        hash: "SHA-256";
+      };
+  let keyGenAlg: EcKeyGenParams | RsaHashedKeyGenParams;
+
+  if (keyAlgorithm === "RSA") {
+    alg = {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    };
+    keyGenAlg = {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    };
+  } else {
+    // ECDSA (default)
+    alg = { name: "ECDSA", namedCurve: "P-256", hash: "SHA-256" } as const;
+    keyGenAlg = { name: "ECDSA", namedCurve: "P-256" };
+  }
+
+  const keys = await crypto.subtle.generateKey(keyGenAlg, true, [
+    "sign",
+    "verify",
+  ]);
   const csr = await x509.Pkcs10CertificateRequestGenerator.create({
     name: `CN=${serial},O=${cpoName}`,
     keys,
     signingAlgorithm: alg,
   });
-  const pem = csr.toString("pem");
+
+  let pem = csr.toString("pem");
+
+  // Apply CRLF line endings if requested
+  if (pemLineEndings === "crlf") {
+    // Convert LF to CRLF, but avoid double-converting existing CRLF
+    pem = pem.replace(/\r\n/g, "\n").replace(/\n/g, "\r\n");
+  }
 
   return {
     csr,

--- a/src/cp/infrastructure/transport/OCPPMessageHandler.ts
+++ b/src/cp/infrastructure/transport/OCPPMessageHandler.ts
@@ -460,12 +460,30 @@ export class OCPPMessageHandler {
   /** Generate or forward a CSR for the charge point certificate signing flow. */
   public async sendSignCertificate(csr?: string): Promise<void> {
     const cpoName = this._chargePoint.configuration.getString("CpoName") ?? "";
-    const payloadCsr =
-      csr ??
-      (await this._chargePoint.certificateStore.generateNewCsr(
+    const quirks = this._chargePoint.certificateQuirks;
+
+    let payloadCsr: string;
+    if (csr) {
+      payloadCsr = csr;
+    } else {
+      // Log when a non-default key algorithm is used
+      if (quirks.csrKeyAlgorithm === "RSA") {
+        this._logger.info(
+          "SignCertificate: generating RSA CSR (certificate quirk)",
+          LogType.OCPP,
+        );
+      }
+
+      payloadCsr = await this._chargePoint.certificateStore.generateNewCsr(
         this._chargePoint.id,
         cpoName,
-      ));
+        {
+          keyAlgorithm: quirks.csrKeyAlgorithm,
+          pemLineEndings: quirks.csrPemLineEndings,
+        },
+      );
+    }
+
     const messageId = this.generateMessageId();
     const payload: SignCertificateRequestV16 = { csr: payloadCsr };
     this.sendRequest(OCPPAction.SignCertificate, messageId, payload);

--- a/src/cp/infrastructure/transport/__tests__/v16CertificateQuirks.bun.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/v16CertificateQuirks.bun.test.ts
@@ -1,0 +1,387 @@
+import "reflect-metadata";
+import { describe, expect, it } from "bun:test";
+import * as x509 from "@peculiar/x509";
+
+import type {
+  CertificateSignedRequestV16,
+  GetConfigurationRequestV16,
+} from "../../../../ocpp";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+import { startMockCsms } from "./mockCsms";
+
+x509.cryptoProvider.set(globalThis.crypto as Crypto);
+
+const EC_ALG = {
+  name: "ECDSA",
+  namedCurve: "P-256",
+  hash: "SHA-256",
+} as const;
+
+const RSA_PKCS1_ALG = {
+  name: "RSASSA-PKCS1-v1_5",
+  modulusLength: 2048,
+  publicExponent: new Uint8Array([1, 0, 1]),
+  hash: "SHA-256",
+} as const;
+
+function canBindBunServe(): boolean {
+  try {
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("ok");
+      },
+    });
+    void server.stop(true);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function acceptBootAndDrainStartup(
+  csms: ReturnType<typeof startMockCsms>,
+): Promise<void> {
+  const boot = await csms.waitForCall("BootNotification");
+  csms.replyCallResult(boot.messageId, {
+    status: "Accepted",
+    currentTime: "2026-06-30T00:00:00.000Z",
+    interval: 300,
+  });
+
+  const status0 = await csms.waitForFrame(
+    (f) =>
+      f[0] === 2 &&
+      f[2] === "StatusNotification" &&
+      (f[3] as { connectorId?: number }).connectorId === 0,
+  );
+  csms.replyCallResult(status0[1] as string, {});
+
+  const status1 = await csms.waitForFrame(
+    (f) =>
+      f[0] === 2 &&
+      f[2] === "StatusNotification" &&
+      (f[3] as { connectorId?: number }).connectorId === 1,
+  );
+  csms.replyCallResult(status1[1] as string, {});
+}
+
+async function certificateWithAlgorithm(
+  algorithm: typeof EC_ALG | typeof RSA_PKCS1_ALG | typeof RSA_PSS_ALG,
+  serial: string,
+): Promise<string> {
+  const keys = await crypto.subtle.generateKey(algorithm, true, [
+    "sign",
+    "verify",
+  ]);
+  const now = Date.now();
+  const cert = await x509.X509CertificateGenerator.createSelfSigned({
+    serialNumber: serial,
+    name: `CN=${serial}`,
+    notBefore: new Date(now - 60_000),
+    notAfter: new Date(now + 86_400_000),
+    signingAlgorithm: algorithm,
+    keys,
+    extensions: [new x509.BasicConstraintsExtension(false, undefined, true)],
+  });
+  return cert.toString("pem");
+}
+
+describe.skipIf(!canBindBunServe())(
+  "OCPP 1.6 certificate quirks (issue #247)",
+  () => {
+    // ── CertificateSigned signature algorithm acceptance ──────────────────
+
+    it("CertificateSigned: allowed algorithm → Accepted and stored", async () => {
+      const csms = startMockCsms();
+      const cp = new ChargePoint(
+        "CP016-QUIRKS-SIG-ALLOWED",
+        DefaultBootNotification,
+        1,
+        csms.url,
+        null,
+        null,
+        null,
+        {},
+        [],
+        "OCPP-1.6J",
+      );
+      cp.events.on("error", () => undefined);
+
+      try {
+        cp.connect();
+        await acceptBootAndDrainStartup(csms);
+
+        // Set quirk: only RSASSA-PKCS1-v1_5 allowed
+        cp.setCertificateQuirks({
+          requiredCertificateSignatureAlgorithms: ["RSASSA-PKCS1-v1_5"],
+        });
+
+        const certificate = await certificateWithAlgorithm(RSA_PKCS1_ALG, "01");
+        const messageId = crypto.randomUUID();
+        csms.send([
+          2,
+          messageId,
+          "CertificateSigned",
+          { certificateChain: certificate } as CertificateSignedRequestV16,
+        ]);
+
+        const response = await csms.waitForFrame(
+          (frame) => frame[0] === 3 && frame[1] === messageId,
+        );
+        expect((response[2] as { status: string }).status).toBe("Accepted");
+        expect(cp.certificateStore.toJSON().signedChains.length).toBe(1);
+      } finally {
+        cp.disconnect();
+        await csms.stop();
+      }
+    });
+
+    it("CertificateSigned: disallowed algorithm → Rejected, not stored", async () => {
+      const csms = startMockCsms();
+      const cp = new ChargePoint(
+        "CP016-QUIRKS-SIG-DISALLOWED",
+        DefaultBootNotification,
+        1,
+        csms.url,
+        null,
+        null,
+        null,
+        {},
+        [],
+        "OCPP-1.6J",
+      );
+      cp.events.on("error", () => undefined);
+
+      try {
+        cp.connect();
+        await acceptBootAndDrainStartup(csms);
+
+        // Set quirk: only RSASSA-PKCS1-v1_5 allowed, reject ECDSA
+        cp.setCertificateQuirks({
+          requiredCertificateSignatureAlgorithms: ["RSASSA-PKCS1-v1_5"],
+        });
+
+        const certificate = await certificateWithAlgorithm(EC_ALG, "02");
+        const messageId = crypto.randomUUID();
+        csms.send([
+          2,
+          messageId,
+          "CertificateSigned",
+          { certificateChain: certificate } as CertificateSignedRequestV16,
+        ]);
+
+        const response = await csms.waitForFrame(
+          (frame) => frame[0] === 3 && frame[1] === messageId,
+        );
+        expect((response[2] as { status: string }).status).toBe("Rejected");
+        expect(cp.certificateStore.toJSON().signedChains.length).toBe(0);
+      } finally {
+        cp.disconnect();
+        await csms.stop();
+      }
+    });
+
+    it("CertificateSigned: quirk unset → Accepted regardless of algorithm", async () => {
+      const csms = startMockCsms();
+      const cp = new ChargePoint(
+        "CP016-QUIRKS-SIG-UNSET",
+        DefaultBootNotification,
+        1,
+        csms.url,
+        null,
+        null,
+        null,
+        {},
+        [],
+        "OCPP-1.6J",
+      );
+      cp.events.on("error", () => undefined);
+
+      try {
+        cp.connect();
+        await acceptBootAndDrainStartup(csms);
+
+        // Quirk is NOT set - any algorithm should be accepted
+        const certificate = await certificateWithAlgorithm(EC_ALG, "03");
+        const messageId = crypto.randomUUID();
+        csms.send([
+          2,
+          messageId,
+          "CertificateSigned",
+          { certificateChain: certificate } as CertificateSignedRequestV16,
+        ]);
+
+        const response = await csms.waitForFrame(
+          (frame) => frame[0] === 3 && frame[1] === messageId,
+        );
+        expect((response[2] as { status: string }).status).toBe("Accepted");
+        expect(cp.certificateStore.toJSON().signedChains.length).toBe(1);
+      } finally {
+        cp.disconnect();
+        await csms.stop();
+      }
+    });
+
+    // ── GetConfiguration key hiding ──────────────────────────────────────
+
+    it("GetConfiguration: hiddenConfigurationKeys → full dump lacks hidden keys", async () => {
+      const csms = startMockCsms();
+      const cp = new ChargePoint(
+        "CP016-QUIRKS-GET-CONFIG-HIDDEN",
+        DefaultBootNotification,
+        1,
+        csms.url,
+        null,
+        null,
+        null,
+        {},
+        [],
+        "OCPP-1.6J",
+      );
+      cp.events.on("error", () => undefined);
+
+      try {
+        cp.connect();
+        await acceptBootAndDrainStartup(csms);
+
+        // Set quirk: hide CpoName from GetConfiguration
+        cp.setCertificateQuirks({
+          hiddenConfigurationKeys: ["CpoName"],
+        });
+
+        // Send GetConfiguration with no keys (full dump)
+        csms.send([
+          2,
+          "config-1",
+          "GetConfiguration",
+          {} as GetConfigurationRequestV16,
+        ]);
+
+        const response = await csms.waitForFrame(
+          (f) => f[0] === 3 && f[1] === "config-1",
+        );
+        const responseData = response[2] as {
+          configurationKey?: Array<{ key: string }>;
+        };
+        const keys = responseData.configurationKey ?? [];
+
+        // CpoName should NOT be in the list
+        expect(keys.some((k) => k.key === "CpoName")).toBe(false);
+        // But other keys should be present
+        expect(keys.length).toBeGreaterThan(0);
+      } finally {
+        cp.disconnect();
+        await csms.stop();
+      }
+    });
+
+    it("GetConfiguration: explicit request for hidden key → in unknownKey", async () => {
+      const csms = startMockCsms();
+      const cp = new ChargePoint(
+        "CP016-QUIRKS-GET-CONFIG-UNKNOWN",
+        DefaultBootNotification,
+        1,
+        csms.url,
+        null,
+        null,
+        null,
+        {},
+        [],
+        "OCPP-1.6J",
+      );
+      cp.events.on("error", () => undefined);
+
+      try {
+        cp.connect();
+        await acceptBootAndDrainStartup(csms);
+
+        // Set quirk: hide CpoName
+        cp.setCertificateQuirks({
+          hiddenConfigurationKeys: ["CpoName"],
+        });
+
+        // Send GetConfiguration explicitly requesting CpoName
+        csms.send([
+          2,
+          "config-2",
+          "GetConfiguration",
+          { key: ["CpoName"] } as GetConfigurationRequestV16,
+        ]);
+
+        const response = await csms.waitForFrame(
+          (f) => f[0] === 3 && f[1] === "config-2",
+        );
+        const responseData = response[2] as {
+          configurationKey?: Array<{ key: string }>;
+          unknownKey?: string[];
+        };
+        const configKeys = responseData.configurationKey ?? [];
+        const unknownKeys = responseData.unknownKey ?? [];
+
+        // CpoName should NOT be in configurationKey
+        expect(configKeys.some((k) => k.key === "CpoName")).toBe(false);
+        // But should be in unknownKey
+        expect(unknownKeys).toContain("CpoName");
+      } finally {
+        cp.disconnect();
+        await csms.stop();
+      }
+    });
+
+    it("GetConfiguration: after clearCertificateQuirks → hidden key is served again", async () => {
+      const csms = startMockCsms();
+      const cp = new ChargePoint(
+        "CP016-QUIRKS-GET-CONFIG-CLEARED",
+        DefaultBootNotification,
+        1,
+        csms.url,
+        null,
+        null,
+        null,
+        {},
+        [],
+        "OCPP-1.6J",
+      );
+      cp.events.on("error", () => undefined);
+
+      try {
+        cp.connect();
+        await acceptBootAndDrainStartup(csms);
+
+        // Set quirk
+        cp.setCertificateQuirks({
+          hiddenConfigurationKeys: ["CpoName"],
+        });
+
+        // Clear quirks
+        cp.clearCertificateQuirks();
+
+        // Send GetConfiguration requesting CpoName
+        csms.send([
+          2,
+          "config-3",
+          "GetConfiguration",
+          { key: ["CpoName"] } as GetConfigurationRequestV16,
+        ]);
+
+        const response = await csms.waitForFrame(
+          (f) => f[0] === 3 && f[1] === "config-3",
+        );
+        const responseData = response[2] as {
+          configurationKey?: Array<{ key: string }>;
+          unknownKey?: string[];
+        };
+        const configKeys = responseData.configurationKey ?? [];
+
+        // CpoName should be served normally
+        const cpoNameKey = configKeys.find((k) => k.key === "CpoName");
+        expect(cpoNameKey).toBeDefined();
+      } finally {
+        cp.disconnect();
+        await csms.stop();
+      }
+    });
+  },
+);

--- a/src/cp/infrastructure/transport/__tests__/v16Security.bun.test.ts
+++ b/src/cp/infrastructure/transport/__tests__/v16Security.bun.test.ts
@@ -223,5 +223,160 @@ describe.skipIf(!canBindBunServe())(
         await csms.stop();
       }
     });
+
+    it("with RSA quirk set: SignCertificate CSR has RSA public key and sha256WithRSAEncryption signature", async () => {
+      const csms = startMockCsms();
+      const cp = new ChargePoint(
+        "CP016-SEC-CSR-RSA",
+        DefaultBootNotification,
+        1,
+        csms.url,
+        null,
+        null,
+        null,
+        {},
+        [],
+        "OCPP-1.6J",
+        {},
+        1,
+        "startup-auth-key",
+        "Example CPO",
+      );
+      cp.events.on("error", () => undefined);
+
+      try {
+        cp.connect();
+        await acceptBootAndDrainStartup(csms);
+
+        // Set RSA quirk before sending SignCertificate
+        cp.setCertificateQuirks({ csrKeyAlgorithm: "RSA" });
+
+        await cp.sendSignCertificate();
+
+        const signCertificate = await csms.waitForCall("SignCertificate");
+        const signPayload =
+          signCertificate.payload as SignCertificateRequestV16;
+        expect(isValidSignCertificateRequestV16(signPayload)).toBe(true);
+
+        const csr = new x509.Pkcs10CertificateRequest(signPayload.csr);
+        expect(csr.subject).toContain("CN=CP016-SEC-CSR-RSA");
+
+        // Verify public key is RSA
+        const publicKey = csr.publicKey;
+        expect(publicKey.algorithm.name).toBe("RSASSA-PKCS1-v1_5");
+        expect((publicKey.algorithm as RsaKeyAlgorithm).modulusLength).toBe(
+          2048,
+        );
+
+        // Verify signature algorithm is RSASSA-PKCS1-v1_5
+        const sigAlg = csr.signatureAlgorithm;
+        expect(sigAlg.name).toBe("RSASSA-PKCS1-v1_5");
+
+        expect(await csr.verify()).toBe(true);
+
+        csms.replyCallResult(signCertificate.messageId, { status: "Accepted" });
+      } finally {
+        cp.disconnect();
+        await csms.stop();
+      }
+    });
+
+    it("with CRLF quirk set: SignCertificate CSR PEM has CRLF line endings", async () => {
+      const csms = startMockCsms();
+      const cp = new ChargePoint(
+        "CP016-SEC-CSR-CRLF",
+        DefaultBootNotification,
+        1,
+        csms.url,
+        null,
+        null,
+        null,
+        {},
+        [],
+        "OCPP-1.6J",
+        {},
+        1,
+        "startup-auth-key",
+        "Example CPO",
+      );
+      cp.events.on("error", () => undefined);
+
+      try {
+        cp.connect();
+        await acceptBootAndDrainStartup(csms);
+
+        // Set CRLF quirk
+        cp.setCertificateQuirks({ csrPemLineEndings: "crlf" });
+
+        await cp.sendSignCertificate();
+
+        const signCertificate = await csms.waitForCall("SignCertificate");
+        const signPayload =
+          signCertificate.payload as SignCertificateRequestV16;
+
+        // Verify PEM has CRLF line endings
+        expect(signPayload.csr).toContain("\r\n");
+        // Verify no isolated LF
+        const lines = signPayload.csr.split("\r\n");
+        for (const line of lines) {
+          expect(line).not.toContain("\r");
+          expect(line).not.toContain("\n");
+        }
+
+        csms.replyCallResult(signCertificate.messageId, { status: "Accepted" });
+      } finally {
+        cp.disconnect();
+        await csms.stop();
+      }
+    });
+
+    it("quirks are sticky and survive multiple calls", async () => {
+      const csms = startMockCsms();
+      const cp = new ChargePoint(
+        "CP016-SEC-CSR-STICKY",
+        DefaultBootNotification,
+        1,
+        csms.url,
+        null,
+        null,
+        null,
+        {},
+        [],
+        "OCPP-1.6J",
+        {},
+        1,
+        "startup-auth-key",
+        "Example CPO",
+      );
+      cp.events.on("error", () => undefined);
+
+      try {
+        cp.connect();
+        await acceptBootAndDrainStartup(csms);
+
+        // Set RSA quirk and send CSR
+        cp.setCertificateQuirks({ csrKeyAlgorithm: "RSA" });
+        await cp.sendSignCertificate();
+
+        let signCertificate = await csms.waitForCall("SignCertificate");
+        let csr = new x509.Pkcs10CertificateRequest(
+          signCertificate.payload.csr,
+        );
+        expect(csr.publicKey.algorithm.name).toBe("RSASSA-PKCS1-v1_5");
+        csms.replyCallResult(signCertificate.messageId, { status: "Accepted" });
+
+        // Send another CSR without clearing - should still be RSA
+        await cp.sendSignCertificate();
+
+        signCertificate = await csms.waitForCall("SignCertificate");
+        csr = new x509.Pkcs10CertificateRequest(signCertificate.payload.csr);
+        // Should still be RSA because quirks are sticky
+        expect(csr.publicKey.algorithm.name).toBe("RSASSA-PKCS1-v1_5");
+        csms.replyCallResult(signCertificate.messageId, { status: "Accepted" });
+      } finally {
+        cp.disconnect();
+        await csms.stop();
+      }
+    });
   },
 );

--- a/src/cp/infrastructure/transport/handlers/call/CertificateSignedHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/CertificateSignedHandler.ts
@@ -39,6 +39,37 @@ export class CertificateSignedHandler implements CallHandler<
       return { status: "Rejected" };
     }
 
+    // Check certificate quirk: requiredCertificateSignatureAlgorithms.
+    // If set and non-empty, verify the leaf certificate's signature
+    // algorithm is in the allowed list.
+    const quirks = context.chargePoint.certificateQuirks;
+    if (
+      quirks.requiredCertificateSignatureAlgorithms &&
+      quirks.requiredCertificateSignatureAlgorithms.length > 0
+    ) {
+      try {
+        const leafPem = chain[0];
+        const leafCert = new x509.X509Certificate(leafPem);
+        const sigAlgName = leafCert.signatureAlgorithm.name;
+
+        if (
+          !quirks.requiredCertificateSignatureAlgorithms.includes(sigAlgName)
+        ) {
+          context.logger.warn(
+            `CertificateSigned: rejected — signature algorithm ${sigAlgName} not in [${quirks.requiredCertificateSignatureAlgorithms.join(", ")}] (certificate quirk)`,
+            LogType.OCPP,
+          );
+          return { status: "Rejected" };
+        }
+      } catch (err) {
+        context.logger.warn(
+          `CertificateSigned: error checking signature algorithm: ${err instanceof Error ? err.message : String(err)}`,
+          LogType.OCPP,
+        );
+        return { status: "Rejected" };
+      }
+    }
+
     context.chargePoint.certificateStore.storeSignedChain(chain);
     context.logger.info(
       `CertificateSigned accepted: stored ${chain.length} certificate(s)`,

--- a/src/cp/infrastructure/transport/handlers/call/GetConfigurationHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/GetConfigurationHandler.ts
@@ -28,7 +28,34 @@ export class GetConfigurationHandler implements CallHandler<
 
     const store = context.chargePoint.configuration;
     const { known, unknown } = store.readRedacted(payload.key ?? []);
-    const configurationKey = this.mapConfiguration(known);
+
+    // Apply certificate quirk: hiddenConfigurationKeys. Filter out any
+    // keys in the hidden list from the known results, and add them to
+    // unknownKey (making them appear as if they don't exist).
+    const quirks = context.chargePoint.certificateQuirks;
+    let hiddenCount = 0;
+    const configurationKey = this.mapConfiguration(
+      known.filter((c) => {
+        if (
+          quirks.hiddenConfigurationKeys &&
+          quirks.hiddenConfigurationKeys.includes(c.key.name)
+        ) {
+          hiddenCount++;
+          unknown.push(c.key.name);
+          return false;
+        }
+        return true;
+      }),
+    );
+
+    // Log once per request if any keys were hidden
+    if (hiddenCount > 0) {
+      context.logger.info(
+        `GetConfiguration: hid ${hiddenCount} key(s) (certificate quirk)`,
+        LogType.CONFIGURATION,
+      );
+    }
+
     // §5.8 says unknownKey is optional; only include it when non-empty so
     // the response is the smallest legal payload.
     if (unknown.length === 0) {

--- a/src/utils/scenarioTemplates.ts
+++ b/src/utils/scenarioTemplates.ts
@@ -72,6 +72,10 @@ import cert16Tc023_1AuthorizeInvalidJson from "./scenarios/cert16-tc023-1-author
 import cert16Tc023_2AuthorizeExpiredJson from "./scenarios/cert16-tc023-2-authorize-expired.json";
 import cert16Tc023_3AuthorizeBlockedJson from "./scenarios/cert16-tc023-3-authorize-blocked.json";
 
+// OCPP 1.6 Certificate quirks (issue #247 Phase 3): probe with OCTT legacy
+// behaviors (RSA CSR, CRLF PEM, RSASSA-PKCS1-v1_5 only, hidden CpoName).
+import cert16OcttStrictnessProbeJson from "./scenarios/cert16-octt-strictness-probe.json";
+
 export interface ScenarioTemplate {
   id: string;
   name: string;
@@ -226,6 +230,10 @@ export const scenarioTemplates: ScenarioTemplate[] = [
   templateFromJson(cert16Tc023_1AuthorizeInvalidJson as ScenarioDefinition),
   templateFromJson(cert16Tc023_2AuthorizeExpiredJson as ScenarioDefinition),
   templateFromJson(cert16Tc023_3AuthorizeBlockedJson as ScenarioDefinition),
+
+  // OCPP 1.6 Certificate quirks scenarios (issue #247 Phase 3) —
+  // emulate certification-tool behaviors.
+  templateFromJson(cert16OcttStrictnessProbeJson as ScenarioDefinition),
 ];
 
 export function getTemplateById(

--- a/src/utils/scenarios/cert16-octt-strictness-probe.json
+++ b/src/utils/scenarios/cert16-octt-strictness-probe.json
@@ -1,0 +1,114 @@
+{
+  "id": "cert16-octt-strictness-probe",
+  "name": "OCPP 1.6 OCTT-style strictness probe",
+  "description": "Emulate legacy OCTT strictness: RSA-only CSR, CRLF PEM, RSASSA-PKCS1-v1_5-only certificate acceptance, hidden CpoName, and a FAIL verdict if the CSMS sends an automatic GetConfiguration after connect.",
+  "targetType": "connector",
+  "trigger": {
+    "type": "manual"
+  },
+  "defaultExecutionMode": "oneshot",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "start",
+      "position": {
+        "x": 400,
+        "y": 0
+      },
+      "data": {
+        "label": "Start",
+        "triggerOn": "connect"
+      }
+    },
+    {
+      "id": "arm-octt",
+      "type": "certQuirks",
+      "position": {
+        "x": 400,
+        "y": 100
+      },
+      "data": {
+        "label": "OCTT strictness preset",
+        "mode": "set",
+        "preset": "octt"
+      }
+    },
+    {
+      "id": "reject-unsupported",
+      "type": "inboundPolicy",
+      "position": {
+        "x": 400,
+        "y": 200
+      },
+      "data": {
+        "label": "Reject GetDiagnostics",
+        "action": "GetDiagnostics",
+        "policy": "callerror",
+        "errorCode": "NotImplemented",
+        "errorDescription": "GetDiagnostics not supported in this OCPP 1.6 implementation"
+      }
+    },
+    {
+      "id": "wait-for-config",
+      "type": "delay",
+      "position": {
+        "x": 400,
+        "y": 300
+      },
+      "data": {
+        "label": "Observe CSMS traffic",
+        "delaySeconds": 15
+      }
+    },
+    {
+      "id": "end-1",
+      "type": "end",
+      "position": {
+        "x": 400,
+        "y": 400
+      },
+      "data": {
+        "label": "End"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "e1",
+      "source": "start-1",
+      "target": "arm-octt"
+    },
+    {
+      "id": "e2",
+      "source": "arm-octt",
+      "target": "reject-unsupported"
+    },
+    {
+      "id": "e3",
+      "source": "reject-unsupported",
+      "target": "wait-for-config"
+    },
+    {
+      "id": "e4",
+      "source": "wait-for-config",
+      "target": "end-1"
+    }
+  ],
+  "createdAt": "2026-07-29T00:00:00Z",
+  "updatedAt": "2026-07-29T00:00:00Z",
+  "assertions": [
+    {
+      "id": "no-auto-get-configuration",
+      "type": "no_unexpected",
+      "description": "OCTT fails when the CSMS sends an automatic GetConfiguration after connect (steve-community/steve#2093)",
+      "actions": ["GetConfiguration"]
+    },
+    {
+      "id": "no-get-diagnostics",
+      "type": "no_unexpected",
+      "description": "OCTT does not expect GetDiagnostics during this sequence",
+      "actions": ["GetDiagnostics"]
+    }
+  ]
+}

--- a/src/utils/scenarios/cert16-octt-strictness-probe.json
+++ b/src/utils/scenarios/cert16-octt-strictness-probe.json
@@ -100,15 +100,17 @@
   "assertions": [
     {
       "id": "no-auto-get-configuration",
-      "type": "no_unexpected",
-      "description": "OCTT fails when the CSMS sends an automatic GetConfiguration after connect (steve-community/steve#2093)",
-      "actions": ["GetConfiguration"]
+      "type": "ocpp_absent",
+      "action": "GetConfiguration",
+      "direction": "received",
+      "description": "OCTT fails when the CSMS sends an automatic GetConfiguration after connect (steve-community/steve#2093)"
     },
     {
       "id": "no-get-diagnostics",
-      "type": "no_unexpected",
-      "description": "OCTT does not expect GetDiagnostics during this sequence",
-      "actions": ["GetDiagnostics"]
+      "type": "ocpp_absent",
+      "action": "GetDiagnostics",
+      "direction": "received",
+      "description": "OCTT does not expect GetDiagnostics during this sequence"
     }
   ]
 }


### PR DESCRIPTION
Phases 2–3 of #247, stacked on #248 (base branch is `feat/inbound-call-policy`; GitHub will retarget to `main` when #248 merges). Together with #248 this completes the OCPP 1.6 scope of #247 — extending the quirks surface to the 2.x paths can be a follow-up issue.

Closes #247

## Phase 2 — certificate quirks (domain + 1.6 transport)

Sticky `CertificateQuirks` on `ChargePoint` (`setCertificateQuirks` shallow-merges, `clearCertificateQuirks` resets), consumed at three points:

- **CSR generation** (`SignCertificate` path): `csrKeyAlgorithm` switches between the existing ECDSA P-256 default and RSA (RSASSA-PKCS1-v1_5, 2048, SHA-256); `csrPemLineEndings` re-emits the CSR PEM with CRLF, idempotently. Without an RSA CSR a CSMS never takes its RSA signing path, so none of OCTT's RSA-specific behavior was reachable before.
- **CertificateSigned acceptance**: with `requiredCertificateSignatureAlgorithms` set, the leaf certificate's signature algorithm (matchable names from `@peculiar/x509`: `ECDSA`, `RSASSA-PKCS1-v1_5`, `RSA-PSS`) must be in the list — otherwise the CP replies `Rejected` and does not store the chain. This reproduces OCTT's refusal of spec-prescribed RSA-PSS signatures in favor of legacy SHA256withRSA.
- **GetConfiguration hiding**: keys in `hiddenConfigurationKeys` are omitted, and an explicitly requested hidden key lands in `unknownKey` — indistinguishable from a key the CP does not have, which is exactly how OCTT withholds `CpoName`.

## Phase 3 — scenario surface

New `certQuirks` node (mode `set`/`clear`, explicit fields, or `preset: "octt"`):

| octt preset arms | value |
|---|---|
| `csrKeyAlgorithm` | `RSA` |
| `csrPemLineEndings` | `crlf` |
| `requiredCertificateSignatureAlgorithms` | `["RSASSA-PKCS1-v1_5"]` |
| `hiddenConfigurationKeys` | `["CpoName"]` |

Explicit fields override the preset. Quirks armed during a run are cleared on completion **and** stop (same leak-prevention lifecycle as `inboundPolicy`). Editor support mirrors the existing node patterns.

Also ships:
- An example template, **"OCPP 1.6 OCTT-style strictness probe"**: connect → arm the octt preset → refuse `GetDiagnostics` at the wire (`inboundPolicy`) → observe for 15 s, with `no_unexpected` assertions so the verdict FAILs if the CSMS auto-sends `GetConfiguration` after connect — the exact sequence OCTT punishes.
- `schema/scenario.schema.json` entries for **both** new node types (`inboundPolicy` had been missed in #248; the conformance suite only exercises node types once a shipped fixture uses them).
- A "quirks emulation" section in `docs/scenario-format.md`.

## Verification

- New tests: 9 vitest (csr unit) + 2 bun (CSR quirks via SignCertificate) + 6 bun (acceptance policy & key hiding) + 4 vitest (certQuirks node lifecycle/preset) + schema conformance now covers the new fixture.
- Full main-tree gates: vitest **1985/1985** (175 files), `bun test` **307 tests, 0 fail, 1 skip**, ESLint clean on touched files.
- Two pre-existing fake-ChargePoint mocks were extended for the new domain accessors (`AuthorizationKey.redaction.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added certificate quirks controls for configuring CSR generation, certificate validation, and hidden configuration keys.
  * Added a Certificate Quirks scenario node with set/clear modes, presets, and advanced options.
  * Added an OCPP 1.6 certificate strictness scenario template.
* **Documentation**
  * Documented the new scenario node types and certificate quirks behavior.
* **Bug Fixes**
  * Certificate quirks are cleared when scenarios finish or stop, preventing settings from carrying over unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->