### PR TITLE
feat(scenario): assertion severity and a two-axis verdict (conformance vs compatibility) with strict mode

### DIFF
--- a/docs/scenario-format.md
+++ b/docs/scenario-format.md
@@ -43,22 +43,23 @@ Mirrors the [OCPP trace format](./trace-format.md#versioning)'s rules:
 
 ## Top-level fields
 
-| Field                   | Type                                                                            | Required | Notes                                                                               |
-| ----------------------- | ------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------- |
-| `schemaVersion`         | string                                                                          | No       | e.g. `"1.0"`. Absent on files predating issue #214 — still valid.                   |
-| `id`                    | string                                                                          | Yes      | Stable scenario identifier.                                                         |
-| `name`                  | string                                                                          | Yes      |                                                                                     |
-| `description`           | string                                                                          | No       |                                                                                     |
-| `targetType`            | `"chargePoint"` \| `"connector"`                                                | Yes      |                                                                                     |
-| `targetId`              | number                                                                          | No       | Connector id if `targetType` is `"connector"`.                                      |
-| `nodes`                 | [Node](#node-shape)`[]`                                                         | Yes      |                                                                                     |
-| `edges`                 | [Edge](#edge-shape)`[]`                                                         | Yes      |                                                                                     |
-| `createdAt`/`updatedAt` | string (ISO-8601)                                                               | No       | Most shipped templates omit these — kept optional so they still validate.           |
-| `trigger`               | `{ type: "manual" \| "statusChange", conditions?: { fromStatus?, toStatus? } }` | No       | Auto-execution trigger (default: manual).                                           |
-| `defaultExecutionMode`  | `"oneshot"` \| `"step"`                                                         | No       | Default: `oneshot`.                                                                 |
-| `enabled`               | boolean                                                                         | No       | Default: `true`.                                                                    |
-| `evSettings`            | `Partial<EVSettings>`                                                           | No       | `modelName`, `batteryCapacityKwh`, `maxChargingPowerKw`, `initialSoc`, `targetSoc`. |
-| `assertions`            | [Assertion](#assertions)`[]`                                                    | No       | Declarative pass/fail checks against the run's OCPP transcript.                     |
+| Field                   | Type                                                                            | Required | Notes                                                                                                              |
+| ----------------------- | ------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| `schemaVersion`         | string                                                                          | No       | e.g. `"1.0"`. Absent on files predating issue #214 — still valid.                                                  |
+| `id`                    | string                                                                          | Yes      | Stable scenario identifier.                                                                                        |
+| `name`                  | string                                                                          | Yes      |                                                                                                                    |
+| `description`           | string                                                                          | No       |                                                                                                                    |
+| `targetType`            | `"chargePoint"` \| `"connector"`                                                | Yes      |                                                                                                                    |
+| `targetId`              | number                                                                          | No       | Connector id if `targetType` is `"connector"`.                                                                     |
+| `nodes`                 | [Node](#node-shape)`[]`                                                         | Yes      |                                                                                                                    |
+| `edges`                 | [Edge](#edge-shape)`[]`                                                         | Yes      |                                                                                                                    |
+| `createdAt`/`updatedAt` | string (ISO-8601)                                                               | No       | Most shipped templates omit these — kept optional so they still validate.                                          |
+| `trigger`               | `{ type: "manual" \| "statusChange", conditions?: { fromStatus?, toStatus? } }` | No       | Auto-execution trigger (default: manual).                                                                          |
+| `defaultExecutionMode`  | `"oneshot"` \| `"step"`                                                         | No       | Default: `oneshot`.                                                                                                |
+| `enabled`               | boolean                                                                         | No       | Default: `true`.                                                                                                   |
+| `evSettings`            | `Partial<EVSettings>`                                                           | No       | `modelName`, `batteryCapacityKwh`, `maxChargingPowerKw`, `initialSoc`, `targetSoc`.                                |
+| `strictCompatibility`   | boolean                                                                         | No       | Promote warning-severity assertion failures to run failures (default: `false`). Per-run `strict` option overrides. |
+| `assertions`            | [Assertion](#assertions)`[]`                                                    | No       | Declarative pass/fail checks against the run's OCPP transcript.                                                    |
 
 ## Node shape
 
@@ -147,7 +148,7 @@ conformance.
 (`sourceHandle`, `targetHandle`, `type`, `animated`, ...) which the schema
 allows but does not require.
 
-## Assertions
+## Assertions & verdicts
 
 An optional array of declarative pass/fail checks evaluated against the
 run's captured OCPP transcript once a scenario finishes (see
@@ -157,8 +158,35 @@ Each entry has `id` and `type` (one of `ocpp_sent`, `ocpp_received`,
 `ocpp_absent`, `response_status`, `idtag_info_status`, `payload_match`,
 `message_order`, `message_after`, `state_transition`, `no_unexpected`), plus
 type-dependent fields (`action`, `direction`, `status`, `occurrence`,
-`payload`, `targetStatus`, `actions`, `before`, `after`). A scenario with no
-`assertions` produces a `SKIPPED` verdict and runs exactly as before.
+`payload`, `targetStatus`, `actions`, `before`, `after`).
+
+### Severity: conformance vs. compatibility
+
+Each assertion optionally carries a `severity` field (`"failure"` or `"warning"`; default: `"failure"`):
+
+- **`"failure"` (default)**: A normative OCPP conformance check. If it fails, the run's `conformanceVerdict` is `FAIL` and the overall scenario verdict fails.
+- **`"warning"`**: A compatibility observation (e.g., an OCTT certification quirk): behavior that is legal per the OCPP specification but has been observed to trip a particular peer. If it fails, the run's `compatibilityVerdict` is `WARNING` and the run does **not** fail. Strict mode promotes such warnings to failures when either:
+  - the scenario sets `strictCompatibility: true`, or
+  - the run is started with `strict: true` (accepted by the `run_scenario`, `run_scenario_file`, and `run_scenario_template` RPCs; overrides the scenario-level setting).
+
+The run report carries both axes alongside the overall `verdict`: `conformanceVerdict` (`PASS`/`FAIL`/`BLOCKED`/`SKIPPED`, from failure-severity assertions only) and `compatibilityVerdict` (`PASS`/`WARNING`/`FAIL`/`SKIPPED`, from warning-severity assertions only), plus the effective `strict` flag.
+
+**Example run report**:
+
+```json
+{
+  "conformanceVerdict": "PASS",
+  "compatibilityVerdict": "WARNING",
+  "strict": false,
+  "verdict": "PASS"
+}
+```
+
+A scenario with no `assertions` produces a `SKIPPED` verdict and runs exactly as before.
+
+### OCTT strictness probe
+
+The bundled `cert16-octt-strictness-probe.json` scenario uses warning-severity `ocpp_absent` assertions for two CSMS behaviors that are valid per OCPP 1.6 but have been observed to break OCTT certification scenarios: an automatic `GetConfiguration` right after connect, and a `GetDiagnostics` during the sequence. By default such a run reports `OCPP conformance: PASS / compatibility: WARNING`; enable strict mode (`strictCompatibility: true` or per-run `strict: true`) to promote those warnings to failures when rehearsing for an official certification run.
 
 ## Validating a scenario file
 

--- a/docs/scenario-format.md
+++ b/docs/scenario-format.md
@@ -59,7 +59,7 @@ Mirrors the [OCPP trace format](./trace-format.md#versioning)'s rules:
 | `enabled`               | boolean                                                                         | No       | Default: `true`.                                                                                                   |
 | `evSettings`            | `Partial<EVSettings>`                                                           | No       | `modelName`, `batteryCapacityKwh`, `maxChargingPowerKw`, `initialSoc`, `targetSoc`.                                |
 | `strictCompatibility`   | boolean                                                                         | No       | Promote warning-severity assertion failures to run failures (default: `false`). Per-run `strict` option overrides. |
-| `assertions`            | [Assertion](#assertions)`[]`                                                    | No       | Declarative pass/fail checks against the run's OCPP transcript.                                                    |
+| `assertions`            | [Assertion](#assertions--verdicts)`[]`                                          | No       | Declarative pass/fail checks against the run's OCPP transcript.                                                    |
 
 ## Node shape
 

--- a/schema/scenario.schema.json
+++ b/schema/scenario.schema.json
@@ -11,6 +11,10 @@
       "type": "string",
       "description": "Scenario schema version, e.g. \"1.0\". Optional: absent on files predating issue #214."
     },
+    "strictCompatibility": {
+      "type": "boolean",
+      "description": "Promote warning-severity assertion failures to run failures (default false). A per-run strict option overrides this."
+    },
     "id": { "type": "string" },
     "name": { "type": "string" },
     "description": { "type": "string" },
@@ -126,6 +130,11 @@
             "state_transition",
             "no_unexpected"
           ]
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["failure", "warning"],
+          "description": "How a failed assertion affects the verdict. \"failure\" (default): normative OCPP conformance check; failing it fails the run. \"warning\": compatibility observation (e.g. OCTT quirks); failing it yields a compatibility WARNING unless strict mode promotes it."
         },
         "action": { "type": "string" },
         "direction": { "type": "string", "enum": ["sent", "received"] },

--- a/src/cli/__tests__/service.scenarioVerdict.bun.test.ts
+++ b/src/cli/__tests__/service.scenarioVerdict.bun.test.ts
@@ -205,3 +205,120 @@ describe("#179 Phase 4: scenario_reset", () => {
     expect(connector1(svc).status).toBe("Available");
   });
 });
+
+describe("Verdict severity axes + strict mode", () => {
+  it("a failing warning-severity assertion in non-strict mode produces PASS verdict + WARNING compatibilityVerdict", async () => {
+    const svc = newService();
+    // A scenario with a warning-severity assertion that will fail (no BootNotification sent).
+    const id = svc.loadScenario(
+      1,
+      completingScenario("warning-fails-nonstrict", [
+        {
+          id: "boot-warning",
+          type: "ocpp_sent",
+          action: "BootNotification",
+          severity: "warning",
+        },
+      ]),
+    );
+    svc.runScenario(1, id);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const result = svc.getScenarioRunResult(id);
+    expect(result).not.toBeNull();
+    expect(result!.verdict).toBe("PASS");
+    expect(result!.conformanceVerdict).toBe("SKIPPED");
+    expect(result!.compatibilityVerdict).toBe("WARNING");
+    expect(result!.strict).toBe(false);
+    expect(result!.assertions).toHaveLength(1);
+    expect(result!.assertions[0]).toMatchObject({
+      id: "boot-warning",
+      severity: "warning",
+      status: "failed",
+    });
+  });
+
+  it("a failing warning-severity assertion with strict: true produces FAIL verdict + FAIL compatibilityVerdict", async () => {
+    const svc = newService();
+    const id = svc.loadScenario(
+      1,
+      completingScenario("warning-fails-strict", [
+        {
+          id: "boot-warning",
+          type: "ocpp_sent",
+          action: "BootNotification",
+          severity: "warning",
+        },
+      ]),
+    );
+    svc.runScenario(1, id, { strict: true });
+    await new Promise((r) => setTimeout(r, 200));
+
+    const result = svc.getScenarioRunResult(id);
+    expect(result).not.toBeNull();
+    expect(result!.verdict).toBe("FAIL");
+    expect(result!.conformanceVerdict).toBe("SKIPPED");
+    expect(result!.compatibilityVerdict).toBe("FAIL");
+    expect(result!.strict).toBe(true);
+  });
+
+  it("a scenario definition with strictCompatibility: true applies the strict mode default", async () => {
+    const svc = newService();
+    const scenario = completingScenario("with-strict-def", [
+      {
+        id: "boot-warning",
+        type: "ocpp_sent",
+        action: "BootNotification",
+        severity: "warning",
+      },
+    ]);
+    scenario.strictCompatibility = true;
+    const id = svc.loadScenario(1, scenario);
+    // Run without explicit options -- should use the definition's strictCompatibility default.
+    svc.runScenario(1, id);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const result = svc.getScenarioRunResult(id);
+    expect(result).not.toBeNull();
+    expect(result!.verdict).toBe("FAIL");
+    expect(result!.compatibilityVerdict).toBe("FAIL");
+    expect(result!.strict).toBe(true);
+  });
+
+  it("per-run strict option overrides the scenario definition's strictCompatibility", async () => {
+    const svc = newService();
+    const scenario = completingScenario("override-def-strict", [
+      {
+        id: "boot-warning",
+        type: "ocpp_sent",
+        action: "BootNotification",
+        severity: "warning",
+      },
+    ]);
+    scenario.strictCompatibility = true;
+    const id = svc.loadScenario(1, scenario);
+    // Run with explicit strict: false, overriding the definition's strictCompatibility: true.
+    svc.runScenario(1, id, { strict: false });
+    await new Promise((r) => setTimeout(r, 200));
+
+    const result = svc.getScenarioRunResult(id);
+    expect(result).not.toBeNull();
+    expect(result!.verdict).toBe("PASS");
+    expect(result!.compatibilityVerdict).toBe("WARNING");
+    expect(result!.strict).toBe(false);
+  });
+
+  it("existing tests still include the new verdict fields in the result shape", async () => {
+    const svc = newService();
+    const id = svc.loadScenario(1, completingScenario("include-verdicts"));
+    svc.runScenario(1, id);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const result = svc.getScenarioRunResult(id);
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty("verdict");
+    expect(result).toHaveProperty("conformanceVerdict");
+    expect(result).toHaveProperty("compatibilityVerdict");
+    expect(result).toHaveProperty("strict");
+  });
+});

--- a/src/cli/server/RegistryChargePointService.ts
+++ b/src/cli/server/RegistryChargePointService.ts
@@ -521,8 +521,9 @@ export class RegistryChargePointService implements ChargePointService {
     id: string,
     connectorId: number,
     scenarioId: string,
+    options?: { strict?: boolean },
   ): Promise<void> {
-    this.requireService(id).runScenario(connectorId, scenarioId);
+    this.requireService(id).runScenario(connectorId, scenarioId, options);
   }
 
   async runScenarioFile(
@@ -544,7 +545,11 @@ export class RegistryChargePointService implements ChargePointService {
       );
     }
     const scenarioId = service.loadScenario(connectorId, parsed);
-    service.runScenario(connectorId, scenarioId);
+    if (opts.strict === undefined) {
+      service.runScenario(connectorId, scenarioId);
+    } else {
+      service.runScenario(connectorId, scenarioId, { strict: opts.strict });
+    }
     return { scenarioId };
   }
 
@@ -560,7 +565,11 @@ export class RegistryChargePointService implements ChargePointService {
       connectorId,
       opts.evSettings,
     );
-    service.runScenario(connectorId, scenarioId);
+    if (opts.strict === undefined) {
+      service.runScenario(connectorId, scenarioId);
+    } else {
+      service.runScenario(connectorId, scenarioId, { strict: opts.strict });
+    }
     return { scenarioId };
   }
 

--- a/src/cli/server/__tests__/harnessScenarioVerdict.bun.test.ts
+++ b/src/cli/server/__tests__/harnessScenarioVerdict.bun.test.ts
@@ -166,4 +166,214 @@ describe("issue #111: drive a scenario verdict over the Socket.IO control plane"
       socket.disconnect();
     }
   });
+
+  it("run_scenario with strict: true promotes warning to FAIL", async () => {
+    const server = await serverWithDb();
+    const socket = await connectTestClient(server);
+
+    try {
+      const cpId = "CP-STRICT-TEST";
+      const created = await emitRpc(socket, {
+        method: "cp.create",
+        params: {
+          cpId,
+          wsUrl: "ws://127.0.0.1:65534/never",
+          connectors: 1,
+        },
+      });
+      expect(created.ok).toBe(true);
+
+      const subscribed = await emitRpc(socket, {
+        method: "events.subscribe",
+        params: { scope: cpId },
+      });
+      expect(subscribed.ok).toBe(true);
+
+      // Scenario with a warning-severity assertion that will fail.
+      const scenario = {
+        id: "strict-warning-scenario",
+        name: "Strict warning test",
+        targetType: "connector",
+        targetId: 1,
+        nodes: [
+          {
+            id: "s",
+            type: "start",
+            position: { x: 0, y: 0 },
+            data: { label: "S" },
+          },
+          {
+            id: "m",
+            type: "meterValue",
+            position: { x: 0, y: 1 },
+            data: { label: "MV", value: 100, sendMessage: false },
+          },
+          {
+            id: "e",
+            type: "end",
+            position: { x: 0, y: 2 },
+            data: { label: "E" },
+          },
+        ],
+        edges: [
+          { id: "e1", source: "s", target: "m" },
+          { id: "e2", source: "m", target: "e" },
+        ],
+        assertions: [
+          {
+            id: "boot-warning",
+            type: "ocpp_sent",
+            action: "BootNotification",
+            severity: "warning",
+          },
+        ],
+      };
+
+      const loaded = await emitRpc(socket, {
+        cpId,
+        method: "load_scenario",
+        params: { connector: CONNECTOR, scenario },
+      });
+      expect(loaded.ok).toBe(true);
+      const scenarioId: string =
+        typeof loaded.result === "string"
+          ? loaded.result
+          : (loaded.result?.scenarioId ?? scenario.id);
+
+      // Run with strict: true
+      const ran = await emitRpc(socket, {
+        cpId,
+        method: "run_scenario",
+        params: { connector: CONNECTOR, scenarioId, strict: true },
+      });
+      expect(ran.ok).toBe(true);
+
+      // Wait for report with strict: true
+      let report: any = null;
+      for (let i = 0; i < 75 && !report; i++) {
+        const ack = await emitRpc(socket, {
+          cpId,
+          method: "scenario_report",
+          params: { connector: CONNECTOR, scenarioId },
+        });
+        expect(ack.ok).toBe(true);
+        if (ack.result && ack.result.strict !== undefined) {
+          report = ack.result;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 200));
+      }
+
+      expect(report).not.toBeNull();
+      expect(report.verdict).toBe("FAIL");
+      expect(report.compatibilityVerdict).toBe("FAIL");
+      expect(report.strict).toBe(true);
+    } finally {
+      socket.disconnect();
+    }
+  });
+
+  it("run_scenario without strict reports warning without promoting to FAIL", async () => {
+    const server = await serverWithDb();
+    const socket = await connectTestClient(server);
+
+    try {
+      const cpId = "CP-WARNING-TEST";
+      const created = await emitRpc(socket, {
+        method: "cp.create",
+        params: {
+          cpId,
+          wsUrl: "ws://127.0.0.1:65534/never",
+          connectors: 1,
+        },
+      });
+      expect(created.ok).toBe(true);
+
+      const subscribed = await emitRpc(socket, {
+        method: "events.subscribe",
+        params: { scope: cpId },
+      });
+      expect(subscribed.ok).toBe(true);
+
+      const scenario = {
+        id: "warning-scenario",
+        name: "Warning test",
+        targetType: "connector",
+        targetId: 1,
+        nodes: [
+          {
+            id: "s",
+            type: "start",
+            position: { x: 0, y: 0 },
+            data: { label: "S" },
+          },
+          {
+            id: "m",
+            type: "meterValue",
+            position: { x: 0, y: 1 },
+            data: { label: "MV", value: 100, sendMessage: false },
+          },
+          {
+            id: "e",
+            type: "end",
+            position: { x: 0, y: 2 },
+            data: { label: "E" },
+          },
+        ],
+        edges: [
+          { id: "e1", source: "s", target: "m" },
+          { id: "e2", source: "m", target: "e" },
+        ],
+        assertions: [
+          {
+            id: "boot-warning",
+            type: "ocpp_sent",
+            action: "BootNotification",
+            severity: "warning",
+          },
+        ],
+      };
+
+      const loaded = await emitRpc(socket, {
+        cpId,
+        method: "load_scenario",
+        params: { connector: CONNECTOR, scenario },
+      });
+      expect(loaded.ok).toBe(true);
+      const scenarioId: string =
+        typeof loaded.result === "string"
+          ? loaded.result
+          : (loaded.result?.scenarioId ?? scenario.id);
+
+      // Run without strict (defaults to false)
+      const ran = await emitRpc(socket, {
+        cpId,
+        method: "run_scenario",
+        params: { connector: CONNECTOR, scenarioId },
+      });
+      expect(ran.ok).toBe(true);
+
+      let report: any = null;
+      for (let i = 0; i < 75 && !report; i++) {
+        const ack = await emitRpc(socket, {
+          cpId,
+          method: "scenario_report",
+          params: { connector: CONNECTOR, scenarioId },
+        });
+        expect(ack.ok).toBe(true);
+        if (ack.result && ack.result.strict !== undefined) {
+          report = ack.result;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 200));
+      }
+
+      expect(report).not.toBeNull();
+      expect(report.verdict).toBe("PASS");
+      expect(report.compatibilityVerdict).toBe("WARNING");
+      expect(report.strict).toBe(false);
+    } finally {
+      socket.disconnect();
+    }
+  });
 });

--- a/src/cli/server/socketServer.ts
+++ b/src/cli/server/socketServer.ts
@@ -1318,11 +1318,16 @@ async function dispatchFacadeCpCommand(
     }
     case "run_scenario": {
       const id = requireFacadeCpId(cpId);
+      const strict =
+        params.strict === undefined
+          ? undefined
+          : requireBoolean(params, "strict");
       await runFacadeOperation(() =>
         chargePointService.runScenario(
           id,
           requirePositiveInt(params, "connector"),
           requireString(params, "scenarioId"),
+          strict !== undefined ? { strict } : undefined,
         ),
       );
       return handled(undefined);
@@ -1429,18 +1434,26 @@ async function dispatchFacadeCpCommand(
     }
     case "run_scenario_file": {
       const id = requireFacadeCpId(cpId);
+      const strict =
+        params.strict === undefined
+          ? undefined
+          : requireBoolean(params, "strict");
       return handled(
         await runFacadeOperation(() =>
           chargePointService.runScenarioFile(
             id,
             requireString(params, "file"),
-            { connectorId: requirePositiveInt(params, "connector") },
+            { connectorId: requirePositiveInt(params, "connector"), strict },
           ),
         ),
       );
     }
     case "run_scenario_template": {
       const id = requireFacadeCpId(cpId);
+      const strict =
+        params.strict === undefined
+          ? undefined
+          : requireBoolean(params, "strict");
       return handled(
         await runFacadeOperation(() =>
           chargePointService.runScenarioTemplate(
@@ -1449,6 +1462,7 @@ async function dispatchFacadeCpCommand(
             {
               connectorId: requirePositiveInt(params, "connector"),
               evSettings: params.evSettings as Partial<EVSettings> | undefined,
+              strict,
             },
           ),
         ),

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -57,7 +57,7 @@ import { scenarioTemplates, getTemplateById } from "../utils/scenarioTemplates";
 import { TranscriptBuffer } from "../cp/application/verification/TranscriptBuffer";
 import {
   evaluateAssertions,
-  computeVerdict,
+  computeVerdictSummary,
   frameToTranscriptEntry,
   redactTranscriptEntry,
   type ScenarioRunResult,
@@ -283,6 +283,9 @@ export class CLIChargePointService {
     string,
     { readonly startedAt: string; readonly initialState: ScenarioStateSnapshot }
   > = new Map();
+  // Per-run strict flag, keyed like _executors/_runIdByScenario by scenarioId.
+  // Stores the per-run strict option if provided, consulted by finalizeScenarioRun.
+  private readonly _strictByScenario: Map<string, boolean> = new Map();
   // #179 Phase 2b: bounded history of per-run verdicts + assertion results,
   // keyed by runId. Capped so a long-lived daemon doesn't accumulate
   // results forever; recordRunResult evicts the oldest entry past the cap.
@@ -990,7 +993,11 @@ export class CLIChargePointService {
     return result;
   }
 
-  runScenario(connectorId: number, scenarioId: string): void {
+  runScenario(
+    connectorId: number,
+    scenarioId: string,
+    options?: { strict?: boolean },
+  ): void {
     const entry = this._scenarios.get(scenarioId);
     if (!entry) {
       throw new Error(`Scenario ${scenarioId} not found`);
@@ -1014,6 +1021,14 @@ export class CLIChargePointService {
     // correlate a specific run.
     const runId = makeScenarioRunId(scenarioId);
     this._runIdByScenario.set(scenarioId, runId);
+
+    // Record the per-run strict override; clear any leftover from a prior run
+    // of the same scenario that never reached finalizeScenarioRun.
+    if (options?.strict !== undefined) {
+      this._strictByScenario.set(scenarioId, options.strict);
+    } else {
+      this._strictByScenario.delete(scenarioId);
+    }
 
     // #179 Phase 2b: capture the OCPP wire transcript for this run so its
     // declared assertions (if any) can be evaluated once it ends.
@@ -1299,7 +1314,20 @@ export class CLIChargePointService {
     const definition = this._scenarios.get(scenarioId)?.definition;
     const assertionSpecs = definition?.assertions ?? [];
     const assertions = evaluateAssertions(assertionSpecs, transcript.frames);
-    const verdict = computeVerdict(assertions, { executionState, blocked });
+
+    // Effective strict: per-run option, then the scenario definition, then off.
+    const perRunStrict = this._strictByScenario.get(scenarioId);
+    this._strictByScenario.delete(scenarioId);
+    const effectiveStrict =
+      perRunStrict !== undefined
+        ? perRunStrict
+        : (definition?.strictCompatibility ?? false);
+
+    const verdictSummary = computeVerdictSummary(assertions, {
+      executionState,
+      blocked,
+      strict: effectiveStrict,
+    });
 
     // #179 Phase 3: flatten + redact the captured transcript before it can
     // reach a client (payloads carry auth material -- redactTranscriptEntry).
@@ -1328,7 +1356,10 @@ export class CLIChargePointService {
         new Date(endedAt).getTime() - new Date(startedAt).getTime(),
       ),
       executionState,
-      verdict,
+      verdict: verdictSummary.verdict,
+      conformanceVerdict: verdictSummary.conformanceVerdict,
+      compatibilityVerdict: verdictSummary.compatibilityVerdict,
+      strict: verdictSummary.strict,
       assertions,
       transcript: transcriptEntries,
       errors,

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -923,6 +923,7 @@ export class CLIChargePointService {
       this._transcriptByScenario.delete(scenarioId);
     }
     this._runStartByScenario.delete(scenarioId);
+    this._strictByScenario.delete(scenarioId);
   }
 
   /**

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -476,6 +476,12 @@ export interface ScenarioDefinition {
    * before (no behavior change).
    */
   assertions?: AssertionSpec[];
+
+  /**
+   * Promotes warning-severity assertion failures to run failures (strict
+   * mode, #247). Default false; a per-run `strict` option overrides it.
+   */
+  strictCompatibility?: boolean;
 }
 
 /**
@@ -493,6 +499,14 @@ export type AssertionType =
   | "message_after"
   | "state_transition"
   | "no_unexpected";
+
+/**
+ * How an assertion failure affects the run verdict (#247). "failure"
+ * (default): normative OCPP conformance check; failing it fails the run.
+ * "warning": compatibility observation (e.g. OCTT quirks); failing it yields
+ * a compatibility WARNING, promoted to FAIL only in strict mode.
+ */
+export type AssertionSeverity = "failure" | "warning";
 
 /**
  * Declarative assertion attached to a {@link ScenarioDefinition}. Evaluated
@@ -522,6 +536,8 @@ export interface AssertionSpec {
   /** Reference frame matcher for message_order / message_after. */
   before?: { action: string; direction?: "sent" | "received" };
   after?: { action: string; direction?: "sent" | "received" };
+  /** How an assertion failure affects the run verdict. Default "failure". */
+  severity?: AssertionSeverity;
 }
 
 /** Outcome of evaluating one {@link AssertionSpec} against a run's transcript. */
@@ -534,11 +550,16 @@ export interface AssertionResult {
   description: string;
   /** Explanation of what was/wasn't found; set on failure. */
   detail?: string;
+  /** How this assertion failure affects the verdict. */
+  severity: AssertionSeverity;
 }
 
 /** Overall pass/fail verdict for one scenario run, rolled up from its
  *  {@link AssertionResult}s (see `computeVerdict`). */
 export type ScenarioVerdict = "PASS" | "FAIL" | "BLOCKED" | "SKIPPED";
+
+/** Compatibility-only verdict for warning-severity assertions (see `computeVerdictSummary`). */
+export type CompatibilityVerdict = "PASS" | "WARNING" | "FAIL" | "SKIPPED";
 
 /**
  * Minimal runtime shape check for a value read from an operator-supplied

--- a/src/cp/application/verification/ScenarioAssertions.ts
+++ b/src/cp/application/verification/ScenarioAssertions.ts
@@ -608,7 +608,10 @@ function computeSingleAxisVerdict(
   results: AssertionResult[],
   opts: Pick<ComputeVerdictOptions, "executionState" | "blocked">,
 ): ScenarioVerdict {
-  if (results.length === 0 || results.every((r) => r.status === "skipped")) {
+  if (
+    results.length === 0 ||
+    results.every((r) => r.status === "skipped" || r.status === "blocked")
+  ) {
     return "SKIPPED";
   }
   if (opts.executionState === "error" || opts.blocked === true) {

--- a/src/cp/application/verification/ScenarioAssertions.ts
+++ b/src/cp/application/verification/ScenarioAssertions.ts
@@ -24,6 +24,7 @@ import type {
   AssertionSpec,
   AssertionStatus,
   ScenarioVerdict,
+  CompatibilityVerdict,
 } from "../scenario/ScenarioTypes";
 import {
   redactSensitiveText,
@@ -86,6 +87,7 @@ function makeResult(
     status,
     description: spec.description ?? defaultDescription,
     detail,
+    severity: spec.severity ?? "failure",
   };
 }
 
@@ -549,7 +551,14 @@ export interface ScenarioRunResult {
   endedAt: string;
   durationMs: number;
   executionState: "completed" | "error";
+  /** Overall verdict combining conformance and compatibility axes. */
   verdict: ScenarioVerdict;
+  /** Verdict for failure-severity assertions only (conformance). */
+  conformanceVerdict: ScenarioVerdict;
+  /** Verdict for warning-severity assertions only (compatibility). */
+  compatibilityVerdict: CompatibilityVerdict;
+  /** Whether strict mode was enabled (promotes warnings to failures). */
+  strict: boolean;
   assertions: AssertionResult[];
   transcript: TranscriptEntry[];
   errors: string[];
@@ -570,19 +579,34 @@ export interface ComputeVerdictOptions {
 }
 
 /**
- * Rolls a run's per-assertion results up into one {@link ScenarioVerdict}:
+ * Two-axis verdict from {@link computeVerdictSummary}: separates conformance
+ * (failure-severity assertions) from compatibility (warning-severity assertions).
+ */
+export interface VerdictSummary {
+  /** Overall verdict combining both axes. */
+  verdict: ScenarioVerdict;
+  /** Verdict for failure-severity assertions only (conformance). */
+  conformanceVerdict: ScenarioVerdict;
+  /** Verdict for warning-severity assertions only (compatibility). */
+  compatibilityVerdict: CompatibilityVerdict;
+  /** Whether strict mode was enabled (promotes warnings to failures). */
+  strict: boolean;
+}
+
+/**
+ * Rolls one severity axis' results up into a {@link ScenarioVerdict}, with the
+ * same priority order computeVerdict has used since #179 Phase 2b:
  *
- * 1. SKIPPED -- no assertions were declared, or every declared assertion
- *    resolved to "skipped".
+ * 1. SKIPPED -- the axis has no assertions, or every one resolved "skipped".
  * 2. BLOCKED -- the run errored or was blocked (outranks FAIL: a run that
  *    never reached a verifiable state shouldn't be reported as a clean
  *    failure).
  * 3. FAIL -- at least one assertion failed.
  * 4. PASS -- every assertion passed.
  */
-export function computeVerdict(
+function computeSingleAxisVerdict(
   results: AssertionResult[],
-  opts: ComputeVerdictOptions,
+  opts: Pick<ComputeVerdictOptions, "executionState" | "blocked">,
 ): ScenarioVerdict {
   if (results.length === 0 || results.every((r) => r.status === "skipped")) {
     return "SKIPPED";
@@ -594,4 +618,81 @@ export function computeVerdict(
     return "FAIL";
   }
   return "PASS";
+}
+
+/**
+ * Two-axis verdict (#247): partitions results by {@link AssertionSeverity}.
+ *
+ * - conformanceVerdict: failure-severity assertions only, ranked exactly like
+ *   the legacy computeVerdict.
+ * - compatibilityVerdict: warning-severity assertions only. SKIPPED when the
+ *   axis has no assertions or none produced a pass/fail outcome; WARNING when
+ *   one failed (FAIL instead under strict); PASS otherwise. Warnings mark
+ *   behavior that is legal OCPP but observed to trip picky peers (e.g. OCTT),
+ *   so they never fail a non-strict run.
+ * - verdict: overall. Keeps the legacy priority (SKIPPED for an
+ *   assertion-less run outranks BLOCKED), fails on conformance failures, and
+ *   fails on compatibility findings only under strict.
+ */
+export function computeVerdictSummary(
+  results: AssertionResult[],
+  opts: ComputeVerdictOptions & { strict?: boolean },
+): VerdictSummary {
+  const strict = opts.strict ?? false;
+  const conformanceResults = results.filter((r) => r.severity === "failure");
+  const compatibilityResults = results.filter((r) => r.severity === "warning");
+
+  const conformanceVerdict = computeSingleAxisVerdict(conformanceResults, opts);
+
+  let compatibilityVerdict: CompatibilityVerdict;
+  if (
+    compatibilityResults.every(
+      (r) => r.status === "skipped" || r.status === "blocked",
+    )
+  ) {
+    compatibilityVerdict = "SKIPPED";
+  } else if (compatibilityResults.some((r) => r.status === "failed")) {
+    compatibilityVerdict = strict ? "FAIL" : "WARNING";
+  } else {
+    compatibilityVerdict = "PASS";
+  }
+
+  let verdict: ScenarioVerdict;
+  if (results.length === 0 || results.every((r) => r.status === "skipped")) {
+    verdict = "SKIPPED";
+  } else if (opts.executionState === "error" || opts.blocked === true) {
+    verdict = "BLOCKED";
+  } else if (
+    conformanceVerdict === "FAIL" ||
+    (strict && compatibilityVerdict === "FAIL")
+  ) {
+    verdict = "FAIL";
+  } else {
+    verdict = "PASS";
+  }
+
+  return { verdict, conformanceVerdict, compatibilityVerdict, strict };
+}
+
+/**
+ * Rolls a run's per-assertion results up into one {@link ScenarioVerdict}:
+ *
+ * 1. SKIPPED -- no assertions were declared, or every declared assertion
+ *    resolved to "skipped".
+ * 2. BLOCKED -- the run errored or was blocked (outranks FAIL: a run that
+ *    never reached a verifiable state shouldn't be reported as a clean
+ *    failure).
+ * 3. FAIL -- at least one assertion failed.
+ * 4. PASS -- every assertion passed.
+ *
+ * NOTE: This function provides backward compatibility for legacy callers.
+ * It uses strict=true semantics internally, which means warning-severity
+ * assertions are treated as failures. For new code, use computeVerdictSummary
+ * to get the two-axis verdict and control strictness explicitly.
+ */
+export function computeVerdict(
+  results: AssertionResult[],
+  opts: ComputeVerdictOptions,
+): ScenarioVerdict {
+  return computeVerdictSummary(results, { ...opts, strict: true }).verdict;
 }

--- a/src/cp/application/verification/__tests__/ScenarioAssertions.test.ts
+++ b/src/cp/application/verification/__tests__/ScenarioAssertions.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { evaluateAssertions, computeVerdict } from "../ScenarioAssertions";
+import {
+  evaluateAssertions,
+  computeVerdict,
+  computeVerdictSummary,
+} from "../ScenarioAssertions";
 import type { CallFrame, CallResultFrame, Frame } from "../ocpp";
 import type {
   AssertionResult,
   AssertionSpec,
+  AssertionSeverity,
 } from "../../scenario/ScenarioTypes";
 
 /** Builds a synthetic wire transcript covering every assertion type this
@@ -325,6 +330,212 @@ describe("evaluateAssertions", () => {
     });
     expect(r.description).toBe("boot happened");
   });
+
+  it("propagates severity: spec without severity defaults to 'failure'", () => {
+    const r = evalOne({
+      id: "m1",
+      type: "ocpp_sent",
+      action: "BootNotification",
+    });
+    expect(r.severity).toBe("failure");
+  });
+
+  it("propagates severity: spec with severity='warning' yields result severity='warning'", () => {
+    const r = evalOne({
+      id: "m2",
+      type: "ocpp_sent",
+      action: "BootNotification",
+      severity: "warning",
+    });
+    expect(r.severity).toBe("warning");
+  });
+
+  it("propagates severity: on failed assertion with warning severity", () => {
+    const r = evalOne({
+      id: "m3",
+      type: "ocpp_sent",
+      action: "NeverSent",
+      severity: "warning",
+    });
+    expect(r.status).toBe("failed");
+    expect(r.severity).toBe("warning");
+  });
+});
+
+describe("computeVerdictSummary", () => {
+  const makePassed = (
+    severity: AssertionSeverity = "failure",
+  ): AssertionResult => ({
+    id: "p",
+    type: "ocpp_sent",
+    status: "passed",
+    description: "p",
+    severity,
+  });
+
+  const makeFailed = (
+    severity: AssertionSeverity = "failure",
+  ): AssertionResult => ({
+    id: "f",
+    type: "ocpp_sent",
+    status: "failed",
+    description: "f",
+    severity,
+  });
+
+  const makeSkipped = (
+    severity: AssertionSeverity = "failure",
+  ): AssertionResult => ({
+    id: "s",
+    type: "ocpp_sent",
+    status: "skipped",
+    description: "s",
+    severity,
+  });
+
+  const makeBlocked = (
+    severity: AssertionSeverity = "failure",
+  ): AssertionResult => ({
+    id: "b",
+    type: "ocpp_sent",
+    status: "blocked",
+    description: "b",
+    severity,
+  });
+
+  it("non-strict: one failed warning-severity + one passed failure-severity → verdict PASS, conformanceVerdict PASS, compatibilityVerdict WARNING", () => {
+    const results = [makePassed("failure"), makeFailed("warning")];
+    const summary = computeVerdictSummary(results, {
+      executionState: "completed",
+      strict: false,
+    });
+    expect(summary.verdict).toBe("PASS");
+    expect(summary.conformanceVerdict).toBe("PASS");
+    expect(summary.compatibilityVerdict).toBe("WARNING");
+    expect(summary.strict).toBe(false);
+  });
+
+  it("strict: same inputs with strict true → verdict FAIL, compatibilityVerdict FAIL, conformanceVerdict PASS", () => {
+    const results = [makePassed("failure"), makeFailed("warning")];
+    const summary = computeVerdictSummary(results, {
+      executionState: "completed",
+      strict: true,
+    });
+    expect(summary.verdict).toBe("FAIL");
+    expect(summary.conformanceVerdict).toBe("PASS");
+    expect(summary.compatibilityVerdict).toBe("FAIL");
+    expect(summary.strict).toBe(true);
+  });
+
+  it("only warning-severity assertions, all passed, non-strict → verdict PASS, conformanceVerdict SKIPPED, compatibilityVerdict PASS", () => {
+    const results = [makePassed("warning"), makePassed("warning")];
+    const summary = computeVerdictSummary(results, {
+      executionState: "completed",
+      strict: false,
+    });
+    expect(summary.verdict).toBe("PASS");
+    expect(summary.conformanceVerdict).toBe("SKIPPED");
+    expect(summary.compatibilityVerdict).toBe("PASS");
+  });
+
+  it("no warning-severity assertions → compatibilityVerdict SKIPPED; conformance failure still → verdict FAIL", () => {
+    const results = [makeFailed("failure"), makePassed("failure")];
+    const summary = computeVerdictSummary(results, {
+      executionState: "completed",
+      strict: false,
+    });
+    expect(summary.verdict).toBe("FAIL");
+    expect(summary.conformanceVerdict).toBe("FAIL");
+    expect(summary.compatibilityVerdict).toBe("SKIPPED");
+  });
+
+  it("blocked/executionState error → verdict BLOCKED regardless of severities", () => {
+    const results = [makePassed("warning"), makeFailed("warning")];
+    const summary = computeVerdictSummary(results, {
+      executionState: "error",
+      strict: false,
+    });
+    expect(summary.verdict).toBe("BLOCKED");
+  });
+
+  it("blocked option true → verdict BLOCKED regardless of severities", () => {
+    const results = [makePassed("warning"), makeFailed("warning")];
+    const summary = computeVerdictSummary(results, {
+      executionState: "completed",
+      blocked: true,
+      strict: false,
+    });
+    expect(summary.verdict).toBe("BLOCKED");
+  });
+
+  it("all results skipped → all verdicts SKIPPED", () => {
+    const results = [makeSkipped("failure"), makeSkipped("warning")];
+    const summary = computeVerdictSummary(results, {
+      executionState: "completed",
+      strict: false,
+    });
+    expect(summary.verdict).toBe("SKIPPED");
+    expect(summary.conformanceVerdict).toBe("SKIPPED");
+    expect(summary.compatibilityVerdict).toBe("SKIPPED");
+  });
+
+  it("empty results → all verdicts SKIPPED", () => {
+    const results: AssertionResult[] = [];
+    const summary = computeVerdictSummary(results, {
+      executionState: "completed",
+      strict: false,
+    });
+    expect(summary.verdict).toBe("SKIPPED");
+    expect(summary.conformanceVerdict).toBe("SKIPPED");
+    expect(summary.compatibilityVerdict).toBe("SKIPPED");
+  });
+
+  it("conformance FAIL with all-passed compatibility, non-strict → verdict FAIL", () => {
+    const results = [makeFailed("failure"), makePassed("warning")];
+    const summary = computeVerdictSummary(results, {
+      executionState: "completed",
+      strict: false,
+    });
+    expect(summary.verdict).toBe("FAIL");
+    expect(summary.conformanceVerdict).toBe("FAIL");
+    expect(summary.compatibilityVerdict).toBe("PASS");
+  });
+
+  it("compatibility axis with only skipped/blocked results → compatibilityVerdict SKIPPED", () => {
+    const results = [
+      makeSkipped("warning"),
+      makeBlocked("warning"),
+      makePassed("failure"),
+    ];
+    const summary = computeVerdictSummary(results, {
+      executionState: "completed",
+      strict: false,
+    });
+    expect(summary.compatibilityVerdict).toBe("SKIPPED");
+    expect(summary.verdict).toBe("PASS");
+  });
+
+  it("assertion-less errored run → verdict SKIPPED (legacy priority: SKIPPED outranks BLOCKED)", () => {
+    const summary = computeVerdictSummary([], {
+      executionState: "error",
+      strict: false,
+    });
+    expect(summary.verdict).toBe("SKIPPED");
+    expect(summary.conformanceVerdict).toBe("SKIPPED");
+    expect(summary.compatibilityVerdict).toBe("SKIPPED");
+  });
+
+  it("blocked run still reports per-axis outcomes: conformance BLOCKED, compatibility from results", () => {
+    const results = [makePassed("failure"), makeFailed("warning")];
+    const summary = computeVerdictSummary(results, {
+      executionState: "completed",
+      blocked: true,
+      strict: false,
+    });
+    expect(summary.verdict).toBe("BLOCKED");
+    expect(summary.conformanceVerdict).toBe("BLOCKED");
+    expect(summary.compatibilityVerdict).toBe("WARNING");
+  });
 });
 
 describe("computeVerdict", () => {
@@ -333,18 +544,21 @@ describe("computeVerdict", () => {
     type: "ocpp_sent",
     status: "passed",
     description: "p",
+    severity: "failure",
   };
   const failed: AssertionResult = {
     id: "f",
     type: "ocpp_sent",
     status: "failed",
     description: "f",
+    severity: "failure",
   };
   const skipped: AssertionResult = {
     id: "s",
     type: "ocpp_sent",
     status: "skipped",
     description: "s",
+    severity: "failure",
   };
 
   it("SKIPPED when there are no results", () => {
@@ -382,5 +596,19 @@ describe("computeVerdict", () => {
         blocked: true,
       }),
     ).toBe("BLOCKED");
+  });
+
+  it("legacy behavior unchanged: computeVerdict with warning-severity failed assertion still → FAIL", () => {
+    const warningFailed: AssertionResult = {
+      id: "w",
+      type: "ocpp_sent",
+      status: "failed",
+      description: "w",
+      severity: "warning",
+    };
+    // Old behavior: any failed assertion → FAIL; computeVerdict should use strict semantics
+    expect(
+      computeVerdict([passed, warningFailed], { executionState: "completed" }),
+    ).toBe("FAIL");
   });
 });

--- a/src/cp/application/verification/__tests__/ScenarioAssertions.test.ts
+++ b/src/cp/application/verification/__tests__/ScenarioAssertions.test.ts
@@ -515,6 +515,21 @@ describe("computeVerdictSummary", () => {
     expect(summary.verdict).toBe("PASS");
   });
 
+  it("conformance axis with only skipped/blocked results → conformanceVerdict SKIPPED", () => {
+    const results = [
+      makeSkipped("failure"),
+      makeBlocked("failure"),
+      makePassed("warning"),
+    ];
+    const summary = computeVerdictSummary(results, {
+      executionState: "completed",
+      strict: false,
+    });
+    expect(summary.conformanceVerdict).toBe("SKIPPED");
+    expect(summary.compatibilityVerdict).toBe("PASS");
+    expect(summary.verdict).toBe("PASS");
+  });
+
   it("assertion-less errored run → verdict SKIPPED (legacy priority: SKIPPED outranks BLOCKED)", () => {
     const summary = computeVerdictSummary([], {
       executionState: "error",

--- a/src/data/interfaces/ChargePointService.ts
+++ b/src/data/interfaces/ChargePointService.ts
@@ -235,6 +235,7 @@ export interface ScenarioTemplateInfo {
 export interface ScenarioRunOptions {
   connectorId?: number;
   evSettings?: Partial<EVSettings>;
+  strict?: boolean;
 }
 
 export interface ChargePointSummary {

--- a/src/protocol/methods.ts
+++ b/src/protocol/methods.ts
@@ -210,11 +210,19 @@ export const METHODS = {
   },
   list_scenarios: { params: z.object({ connector: CONN_POS }), result: ANY },
   run_scenario: {
-    params: z.object({ connector: CONN_POS, scenarioId: STR_64K }),
+    params: z.object({
+      connector: CONN_POS,
+      scenarioId: STR_64K,
+      strict: z.boolean().optional(),
+    }),
     result: ANY,
   },
   run_scenario_file: {
-    params: z.object({ connector: CONN_POS, file: STR_64K }),
+    params: z.object({
+      connector: CONN_POS,
+      file: STR_64K,
+      strict: z.boolean().optional(),
+    }),
     result: ANY,
   },
   run_scenario_template: {
@@ -222,6 +230,7 @@ export const METHODS = {
       connector: CONN_POS,
       templateId: STR_64K,
       evSettings: OBJ().optional(),
+      strict: z.boolean().optional(),
     }),
     result: ANY,
   },

--- a/src/utils/scenarios/cert16-octt-strictness-probe.json
+++ b/src/utils/scenarios/cert16-octt-strictness-probe.json
@@ -1,7 +1,7 @@
 {
   "id": "cert16-octt-strictness-probe",
   "name": "OCPP 1.6 OCTT-style strictness probe",
-  "description": "Emulate legacy OCTT strictness: RSA-only CSR, CRLF PEM, RSASSA-PKCS1-v1_5-only certificate acceptance, hidden CpoName, and a FAIL verdict if the CSMS sends an automatic GetConfiguration after connect.",
+  "description": "Emulate legacy OCTT strictness: RSA-only CSR, CRLF PEM, RSASSA-PKCS1-v1_5-only certificate acceptance, hidden CpoName, and compatibility warnings for automatic GetConfiguration/GetDiagnostics after connect (promoted to failures in strict mode).",
   "targetType": "connector",
   "trigger": {
     "type": "manual"
@@ -103,14 +103,16 @@
       "type": "ocpp_absent",
       "action": "GetConfiguration",
       "direction": "received",
-      "description": "OCTT fails when the CSMS sends an automatic GetConfiguration after connect (steve-community/steve#2093)"
+      "severity": "warning",
+      "description": "Valid per OCPP, but an automatic GetConfiguration right after connect has been observed to fail OCTT certification scenarios"
     },
     {
       "id": "no-get-diagnostics",
       "type": "ocpp_absent",
       "action": "GetDiagnostics",
       "direction": "received",
-      "description": "OCTT does not expect GetDiagnostics during this sequence"
+      "severity": "warning",
+      "description": "Valid per OCPP, but GetDiagnostics has been observed to break OCTT certification scenarios"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Refs #247 (reopened). The OCTT preset's verdict semantics conflated two different things: normative OCPP conformance failures and observed OCTT compatibility risks. OCTT's behaviors are empirical observations without a public specification or versioning, so a legal OCPP behavior should not fail a scenario solely because it is believed to be incompatible with OCTT.

This PR separates the two axes, as proposed in the issue discussion:

- **`severity` on assertions** — `"failure"` (default, unchanged behavior) or `"warning"`. A warning-severity assertion marks a compatibility observation: behavior that is legal per the OCPP specification but has been observed to trip a particular peer.
- **Two-axis report** — `ScenarioRunResult` now carries `conformanceVerdict` (failure-severity assertions only, legacy ranking) and `compatibilityVerdict` (`PASS`/`WARNING`/`FAIL`/`SKIPPED`, warning-severity assertions only) alongside the overall `verdict`, plus the effective `strict` flag. A failed warning yields `OCPP conformance: PASS / compatibility: WARNING` and does **not** fail the run.
- **Strict mode** — promotes compatibility warnings to failures when rehearsing for an official certification run: scenario-level `strictCompatibility: true`, overridden by a per-run `strict: true` option on the `run_scenario` / `run_scenario_file` / `run_scenario_template` RPCs (reachable from MCP via `call_method`).
- **OCTT probe scenario** — `cert16-octt-strictness-probe`'s two `ocpp_absent` checks (automatic `GetConfiguration` after connect, `GetDiagnostics`) become warning-severity with descriptions stating the behavior is OCPP-valid.

## Backward compatibility

- `severity` defaults to `"failure"`, so existing scenarios keep their exact semantics.
- `computeVerdict` keeps its legacy any-failed-is-FAIL contract (implemented as the strict summary), including the original priority where an assertion-less run reports `SKIPPED` even if it errored.
- The report fields are additive; `schemaVersion` stays `1`.

## Testing

- Vitest: severity propagation and `computeVerdictSummary` axis/strict/priority rules, plus full suite (2006 tests) green.
- Bun: service-level runs covering non-strict WARNING, per-run `strict: true`, definition-level `strictCompatibility`, per-run override of the definition; harness Socket.IO flows asserting the report's new fields end-to-end. Full `bun test bun.test` green.
- Scenario JSON Schema updated (`severity`, `strictCompatibility`); the bundled OCTT probe exercises the new field in the schema conformance tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warning and failure severity levels for scenario assertions.
  * Added separate conformance and compatibility verdicts to scenario reports.
  * Added strict compatibility mode, configurable per scenario or individual run.
  * Added support for strict mode across scenario execution commands.
  * Updated the OCTT strictness probe to report compatibility warnings by default and failures in strict mode.

* **Documentation**
  * Expanded scenario format documentation with severity, verdict, strict mode, and report examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->