### PR TITLE
feat(console): surface active scenario runs on the CP page and dashboard (#240 first iteration)

### DIFF
--- a/src/console/components/ActiveScenarioBadge.tsx
+++ b/src/console/components/ActiveScenarioBadge.tsx
@@ -7,8 +7,9 @@ interface ActiveScenarioBadgeProps {
    */
   isActive: boolean;
   /**
-   * When provided and the first run's state is "waiting", show an amber
-   * badge with the expectation description instead of blue "Scenario".
+   * Expectation description of the first run in "waiting" state among the
+   * active runs (regardless of its position in the array). When provided,
+   * show an amber waiting badge instead of the blue "Scenario" one.
    */
   waitingExpectation?: string | null;
 }

--- a/src/console/components/ActiveScenarioBadge.tsx
+++ b/src/console/components/ActiveScenarioBadge.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+interface ActiveScenarioBadgeProps {
+  /**
+   * When true, show the "Scenario" badge in blue (running).
+   * When false, don't render.
+   */
+  isActive: boolean;
+  /**
+   * When provided and the first run's state is "waiting", show an amber
+   * badge with the expectation description instead of blue "Scenario".
+   */
+  waitingExpectation?: string | null;
+}
+
+const ActiveScenarioBadge: React.FC<ActiveScenarioBadgeProps> = ({
+  isActive,
+  waitingExpectation,
+}) => {
+  if (!isActive) {
+    return null;
+  }
+
+  const isWaiting = !!waitingExpectation;
+
+  return (
+    <span
+      className={
+        isWaiting
+          ? "rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:bg-amber-950 dark:text-amber-300"
+          : "rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+      }
+    >
+      {isWaiting ? `Waiting: ${waitingExpectation}` : "Scenario"}
+    </span>
+  );
+};
+
+export default ActiveScenarioBadge;

--- a/src/console/lib/useActiveScenarioRuns.ts
+++ b/src/console/lib/useActiveScenarioRuns.ts
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { ScenarioExpectation } from "../../cp/application/scenario/ScenarioTypes";
+import { useDataContext } from "../../data/providers/DataProvider";
+
+export interface ActiveScenarioRun {
+  connectorId: number;
+  scenarioId: string;
+  name: string;
+  runId?: string;
+  state: "running" | "paused" | "stepping" | "waiting";
+  currentNodeId: string | null;
+  currentNodeLabel: string | null;
+  nodeCount: number | null;
+  executedCount: number;
+  expectation: ScenarioExpectation | null;
+  currentNodeStartedAt: number | null;
+}
+
+const ACTIVE_STATES = ["running", "paused", "stepping", "waiting"] as const;
+
+/** What we keep per scenario definition so repeat refreshes don't refetch it:
+ *  node id → label, and the node count for the "k/N steps" display. */
+interface CachedDefinition {
+  labelsById: Map<string, string>;
+  nodeCount: number;
+}
+
+/**
+ * Tracks the scenario runs currently executing (or parked waiting) on a
+ * charge point's connectors (#240). Queries listScenarios/getScenarioStatus
+ * on mount and re-queries (debounced) whenever a scenario lifecycle event
+ * arrives on the CP's event stream; live countdowns are the consumer's job
+ * (compute from `currentNodeStartedAt` / `expectation.timeoutMs`).
+ */
+export function useActiveScenarioRuns(
+  cpId: string | null,
+  connectorIds: number[],
+): { runs: ActiveScenarioRun[]; refresh: () => Promise<void> } {
+  const { chargePointService } = useDataContext();
+
+  const [runs, setRuns] = useState<ActiveScenarioRun[]>([]);
+  const definitionCacheRef = useRef<Map<string, CachedDefinition>>(new Map());
+  const isMountedRef = useRef(true);
+  const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Callers typically pass a freshly-mapped array each render; depend on its
+  // content, not its identity, or every render would recreate refresh() and
+  // re-trigger the fetch effect in a loop.
+  const connectorIdsKey = connectorIds.join(",");
+  const ids = useMemo(
+    () =>
+      connectorIdsKey === ""
+        ? []
+        : connectorIdsKey.split(",").map((id) => Number(id)),
+    [connectorIdsKey],
+  );
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!cpId) return;
+
+    const allRuns: ActiveScenarioRun[] = [];
+
+    for (const connectorId of ids) {
+      try {
+        const scenarios = await chargePointService.listScenarios(
+          cpId,
+          connectorId,
+        );
+
+        for (const scenario of scenarios.filter((s) => s.active)) {
+          try {
+            const status = await chargePointService.getScenarioStatus(
+              cpId,
+              connectorId,
+              scenario.scenarioId,
+            );
+            if (
+              !status ||
+              !(ACTIVE_STATES as readonly string[]).includes(status.state)
+            ) {
+              continue;
+            }
+
+            const cacheKey = `${connectorId}:${scenario.scenarioId}`;
+            let cached = definitionCacheRef.current.get(cacheKey);
+            if (!cached) {
+              const definition = await chargePointService.getScenario(
+                cpId,
+                connectorId,
+                scenario.scenarioId,
+              );
+              if (definition) {
+                cached = {
+                  labelsById: new Map(
+                    definition.nodes.map((n) => [n.id, n.data?.label ?? ""]),
+                  ),
+                  nodeCount: definition.nodes.length,
+                };
+                definitionCacheRef.current.set(cacheKey, cached);
+              }
+            }
+
+            const currentNodeId = status.currentNodeId ?? null;
+            allRuns.push({
+              connectorId,
+              scenarioId: scenario.scenarioId,
+              name: scenario.name,
+              runId: status.runId,
+              state: status.state as ActiveScenarioRun["state"],
+              currentNodeId,
+              currentNodeLabel: currentNodeId
+                ? cached?.labelsById.get(currentNodeId) || currentNodeId
+                : null,
+              nodeCount: cached?.nodeCount ?? null,
+              executedCount: status.executedNodes.length,
+              expectation: status.expectation ?? null,
+              currentNodeStartedAt: status.currentNodeStartedAt ?? null,
+            });
+          } catch (err) {
+            console.warn(
+              `Failed to fetch scenario status for ${cpId}/${connectorId}/${scenario.scenarioId}`,
+              err,
+            );
+          }
+        }
+      } catch (err) {
+        console.warn(
+          `Failed to list scenarios for ${cpId}/${connectorId}`,
+          err,
+        );
+      }
+    }
+
+    if (isMountedRef.current) {
+      setRuns(allRuns);
+    }
+  }, [cpId, ids, chargePointService]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!cpId) return undefined;
+
+    const unsubscribe = chargePointService.subscribe(cpId, (event) => {
+      if (!(
+        event.type === "scenario-started" ||
+        event.type === "scenario-node-execute" ||
+        event.type === "scenario-completed" ||
+        event.type === "scenario-error"
+      )) {
+        return;
+      }
+
+      // Collapse bursts of node transitions into one re-query.
+      if (refreshTimeoutRef.current) {
+        clearTimeout(refreshTimeoutRef.current);
+      }
+      refreshTimeoutRef.current = setTimeout(() => {
+        void refresh();
+      }, 200);
+    });
+
+    return () => {
+      unsubscribe();
+      if (refreshTimeoutRef.current) {
+        clearTimeout(refreshTimeoutRef.current);
+      }
+    };
+  }, [cpId, chargePointService, refresh]);
+
+  return { runs, refresh };
+}

--- a/src/console/lib/useActiveScenarioRuns.ts
+++ b/src/console/lib/useActiveScenarioRuns.ts
@@ -43,6 +43,9 @@ export function useActiveScenarioRuns(
   const definitionCacheRef = useRef<Map<string, CachedDefinition>>(new Map());
   const isMountedRef = useRef(true);
   const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Generation counter: an older, slower refresh must not overwrite the
+  // results of a newer one that resolved first.
+  const requestIdRef = useRef(0);
 
   // Callers typically pass a freshly-mapped array each render; depend on its
   // content, not its identity, or every render would recreate refresh() and
@@ -65,82 +68,96 @@ export function useActiveScenarioRuns(
 
   const refresh = useCallback(async () => {
     if (!cpId) return;
+    const requestId = ++requestIdRef.current;
 
-    const allRuns: ActiveScenarioRun[] = [];
-
-    for (const connectorId of ids) {
+    const fetchRun = async (
+      connectorId: number,
+      scenario: { scenarioId: string; name: string },
+    ): Promise<ActiveScenarioRun | null> => {
       try {
-        const scenarios = await chargePointService.listScenarios(
+        const status = await chargePointService.getScenarioStatus(
           cpId,
           connectorId,
+          scenario.scenarioId,
         );
+        if (
+          !status ||
+          !(ACTIVE_STATES as readonly string[]).includes(status.state)
+        ) {
+          return null;
+        }
 
-        for (const scenario of scenarios.filter((s) => s.active)) {
-          try {
-            const status = await chargePointService.getScenarioStatus(
-              cpId,
-              connectorId,
-              scenario.scenarioId,
-            );
-            if (
-              !status ||
-              !(ACTIVE_STATES as readonly string[]).includes(status.state)
-            ) {
-              continue;
-            }
-
-            const cacheKey = `${connectorId}:${scenario.scenarioId}`;
-            let cached = definitionCacheRef.current.get(cacheKey);
-            if (!cached) {
-              const definition = await chargePointService.getScenario(
-                cpId,
-                connectorId,
-                scenario.scenarioId,
-              );
-              if (definition) {
-                cached = {
-                  labelsById: new Map(
-                    definition.nodes.map((n) => [n.id, n.data?.label ?? ""]),
-                  ),
-                  nodeCount: definition.nodes.length,
-                };
-                definitionCacheRef.current.set(cacheKey, cached);
-              }
-            }
-
-            const currentNodeId = status.currentNodeId ?? null;
-            allRuns.push({
-              connectorId,
-              scenarioId: scenario.scenarioId,
-              name: scenario.name,
-              runId: status.runId,
-              state: status.state as ActiveScenarioRun["state"],
-              currentNodeId,
-              currentNodeLabel: currentNodeId
-                ? cached?.labelsById.get(currentNodeId) || currentNodeId
-                : null,
-              nodeCount: cached?.nodeCount ?? null,
-              executedCount: status.executedNodes.length,
-              expectation: status.expectation ?? null,
-              currentNodeStartedAt: status.currentNodeStartedAt ?? null,
-            });
-          } catch (err) {
-            console.warn(
-              `Failed to fetch scenario status for ${cpId}/${connectorId}/${scenario.scenarioId}`,
-              err,
-            );
+        const cacheKey = `${connectorId}:${scenario.scenarioId}`;
+        let cached = definitionCacheRef.current.get(cacheKey);
+        if (!cached) {
+          const definition = await chargePointService.getScenario(
+            cpId,
+            connectorId,
+            scenario.scenarioId,
+          );
+          if (definition) {
+            cached = {
+              labelsById: new Map(
+                definition.nodes.map((n) => [n.id, n.data?.label ?? ""]),
+              ),
+              nodeCount: definition.nodes.length,
+            };
+            definitionCacheRef.current.set(cacheKey, cached);
           }
         }
+
+        const currentNodeId = status.currentNodeId ?? null;
+        return {
+          connectorId,
+          scenarioId: scenario.scenarioId,
+          name: scenario.name,
+          runId: status.runId,
+          state: status.state as ActiveScenarioRun["state"],
+          currentNodeId,
+          currentNodeLabel: currentNodeId
+            ? cached?.labelsById.get(currentNodeId) || currentNodeId
+            : null,
+          nodeCount: cached?.nodeCount ?? null,
+          executedCount: status.executedNodes.length,
+          expectation: status.expectation ?? null,
+          currentNodeStartedAt: status.currentNodeStartedAt ?? null,
+        };
       } catch (err) {
         console.warn(
-          `Failed to list scenarios for ${cpId}/${connectorId}`,
+          `Failed to fetch scenario status for ${cpId}/${connectorId}/${scenario.scenarioId}`,
           err,
         );
+        return null;
       }
-    }
+    };
 
-    if (isMountedRef.current) {
-      setRuns(allRuns);
+    const perConnector = await Promise.all(
+      ids.map(async (connectorId) => {
+        try {
+          const scenarios = await chargePointService.listScenarios(
+            cpId,
+            connectorId,
+          );
+          const runsForConnector = await Promise.all(
+            scenarios
+              .filter((s) => s.active)
+              .map((scenario) => fetchRun(connectorId, scenario)),
+          );
+          return runsForConnector.filter(
+            (r): r is ActiveScenarioRun => r !== null,
+          );
+        } catch (err) {
+          console.warn(
+            `Failed to list scenarios for ${cpId}/${connectorId}`,
+            err,
+          );
+          return [];
+        }
+      }),
+    );
+
+    if (isMountedRef.current && requestId === requestIdRef.current) {
+      setRuns(perConnector.flat());
     }
   }, [cpId, ids, chargePointService]);
 

--- a/src/console/pages/CpDetailPage.tsx
+++ b/src/console/pages/CpDetailPage.tsx
@@ -35,6 +35,7 @@ import StatusPill from "../components/StatusPill";
 import NetworkSimBadge from "../components/network-sim/NetworkSimBadge";
 import ManualDisconnectButtons from "../components/network-sim/ManualDisconnectButtons";
 import { consolePath } from "../routes";
+import ActiveScenarioPanel from "./cp/ActiveScenarioPanel";
 import ConnectorCard from "./cp/ConnectorCard";
 import ConfigTab from "./cp/ConfigTab";
 import CpTabs from "./cp/CpTabs";
@@ -398,6 +399,11 @@ const CpDetailPage: React.FC = () => {
           ))}
         </div>
       )}
+
+      <ActiveScenarioPanel
+        cpId={cpId}
+        connectorIds={connectorList.map((c) => c.id)}
+      />
 
       <CpTabs
         value={activeTab}

--- a/src/console/pages/cp/ActiveScenarioPanel.dom.test.tsx
+++ b/src/console/pages/cp/ActiveScenarioPanel.dom.test.tsx
@@ -1,0 +1,432 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  createFakeChargePointService,
+  renderConsole,
+} from "../../test/harness";
+import { OCPPStatus } from "../../../cp/domain/types/OcppTypes";
+import type { ChargePointSnapshot } from "../../../data/interfaces/ChargePointService";
+import type {
+  ScenarioDefinition,
+  ScenarioExecutionContext,
+} from "../../../cp/application/scenario/ScenarioTypes";
+
+async function unmount(root: Root): Promise<void> {
+  await act(async () => {
+    root.unmount();
+  });
+  document.body.innerHTML = "";
+}
+
+async function flush(times = 3): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+function connector(
+  overrides: Partial<ChargePointSnapshot["connectors"][number]> & {
+    id: number;
+  },
+): ChargePointSnapshot["connectors"][number] {
+  return {
+    status: OCPPStatus.Available,
+    availability: "Operative",
+    meterValue: 0,
+    transactionId: null,
+    soc: null,
+    mode: "manual",
+    autoResetToAvailable: false,
+    autoMeterValueConfig: null,
+    evSettings: null,
+    chargingProfile: null,
+    chargingProfiles: [],
+    transactionStartTime: null,
+    transactionTagId: null,
+    transactionBatteryCapacityKwh: null,
+    ...overrides,
+  };
+}
+
+function snapshot(
+  overrides: Partial<ChargePointSnapshot> & { id: string },
+): ChargePointSnapshot {
+  return {
+    status: OCPPStatus.Available,
+    error: "",
+    connectors: [],
+    ...overrides,
+  };
+}
+
+const scenarioDefinitionFixture: ScenarioDefinition = {
+  id: "s1",
+  name: "Cert probe",
+  targetType: "connector",
+  targetId: 1,
+  nodes: [
+    {
+      id: "n1",
+      type: "start",
+      data: { label: "Start" },
+      position: { x: 0, y: 0 },
+    },
+    {
+      id: "n2",
+      type: "remoteStartTrigger",
+      data: { label: "Wait for remote start" },
+      position: { x: 0, y: 100 },
+    },
+  ],
+  edges: [],
+  createdAt: new Date("2026-01-01T00:00:00.000Z").toISOString(),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z").toISOString(),
+};
+
+describe("ActiveScenarioPanel", () => {
+  let cleanup: (() => Promise<void>) | null = null;
+
+  beforeAll(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = null;
+    }
+  });
+
+  it("shows active scenario with waiting state and expectation details", async () => {
+    const cp = snapshot({
+      id: "CP-1",
+      status: OCPPStatus.Available,
+      connectors: [connector({ id: 1 })],
+    });
+
+    const nowTime = Date.now();
+    const startTime = nowTime - 5000; // Started 5 seconds ago
+
+    const listScenarios = vi.fn(async () => [
+      { scenarioId: "s1", name: "Cert probe", active: true },
+    ]);
+
+    const getScenarioStatus = vi.fn(
+      async (): Promise<ScenarioExecutionContext | null> => ({
+        scenarioId: "s1",
+        state: "waiting",
+        mode: "oneshot",
+        currentNodeId: "n2",
+        executedNodes: ["n1"],
+        loopCount: 0,
+        runId: "run-1",
+        expectation: {
+          type: "ocpp_call" as const,
+          action: "RemoteStartTransaction",
+          timeoutMs: 60000,
+          nodeId: "n2",
+        },
+        currentNodeStartedAt: startTime,
+      }),
+    );
+
+    const getScenario = vi.fn(async () => scenarioDefinitionFixture);
+
+    const service = createFakeChargePointService({
+      snapshots: [cp],
+      listScenarios,
+      getScenarioStatus,
+      getScenario,
+      getStateHistory: vi.fn(async () => []),
+    });
+
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+
+    // Panel should exist and show the scenario name
+    expect(container.textContent).toContain("Active scenarios");
+    expect(container.textContent).toContain("Cert probe");
+
+    // Waiting badge should be visible
+    expect(container.textContent).toContain("waiting");
+
+    // Connector info visible
+    expect(container.textContent).toContain("Connector #1");
+
+    // Current step info visible
+    expect(container.textContent).toContain("Wait for remote start");
+    expect(container.textContent).toContain("1/2 steps");
+
+    // Waiting expectation details
+    expect(container.textContent).toContain("Waiting for");
+    expect(container.textContent).toContain("RemoteStartTransaction");
+
+    // Stop button should exist
+    const stopButton = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Stop",
+    );
+    expect(stopButton, "expected a Stop button").toBeTruthy();
+
+    // Open run link should exist
+    const openLink = Array.from(container.querySelectorAll("a")).find((a) =>
+      a.textContent?.includes("Open run"),
+    );
+    expect(openLink, "expected an Open run link").toBeTruthy();
+    expect(openLink?.href).toContain("/scenarios/run?cp=CP-1");
+    expect(openLink?.href).toContain("connector=1");
+    expect(openLink?.href).toContain("id=s1");
+  });
+
+  it("renders nothing when listScenarios returns only inactive items", async () => {
+    const cp = snapshot({
+      id: "CP-1",
+      status: OCPPStatus.Available,
+      connectors: [connector({ id: 1 })],
+    });
+
+    const listScenarios = vi.fn(async () => [
+      { scenarioId: "s1", name: "Inactive scenario", active: false },
+    ]);
+
+    const service = createFakeChargePointService({
+      snapshots: [cp],
+      listScenarios,
+      getStateHistory: vi.fn(async () => []),
+    });
+
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+
+    // Panel should not be visible when there are no active scenarios
+    expect(container.textContent).not.toContain("Active scenarios");
+  });
+
+  it("shows running state badge correctly", async () => {
+    const cp = snapshot({
+      id: "CP-1",
+      status: OCPPStatus.Available,
+      connectors: [connector({ id: 1 })],
+    });
+
+    const listScenarios = vi.fn(async () => [
+      { scenarioId: "s1", name: "Test scenario", active: true },
+    ]);
+
+    const getScenarioStatus = vi.fn(
+      async (): Promise<ScenarioExecutionContext | null> => ({
+        scenarioId: "s1",
+        state: "running" as const,
+        mode: "oneshot" as const,
+        currentNodeId: "n1",
+        executedNodes: ["n1"],
+        loopCount: 0,
+        runId: "run-1",
+        currentNodeStartedAt: Date.now(),
+      }),
+    );
+
+    const getScenario = vi.fn(async () => scenarioDefinitionFixture);
+
+    const service = createFakeChargePointService({
+      snapshots: [cp],
+      listScenarios,
+      getScenarioStatus,
+      getScenario,
+      getStateHistory: vi.fn(async () => []),
+    });
+
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+
+    expect(container.textContent).toContain("running");
+    expect(container.textContent).not.toContain("waiting");
+  });
+
+  it("stopScenario is called when Stop button is clicked", async () => {
+    const cp = snapshot({
+      id: "CP-1",
+      status: OCPPStatus.Available,
+      connectors: [connector({ id: 1 })],
+    });
+
+    const listScenarios = vi.fn(async () => [
+      { scenarioId: "s1", name: "Test scenario", active: true },
+    ]);
+
+    const getScenarioStatus = vi.fn(
+      async (): Promise<ScenarioExecutionContext | null> => ({
+        scenarioId: "s1",
+        state: "running" as const,
+        mode: "oneshot" as const,
+        currentNodeId: "n1",
+        executedNodes: ["n1"],
+        loopCount: 0,
+        runId: "run-1",
+        currentNodeStartedAt: Date.now(),
+      }),
+    );
+
+    const getScenario = vi.fn(async () => scenarioDefinitionFixture);
+    const stopScenario = vi.fn(async () => {});
+
+    const service = createFakeChargePointService({
+      snapshots: [cp],
+      listScenarios,
+      getScenarioStatus,
+      getScenario,
+      stopScenario,
+      getStateHistory: vi.fn(async () => []),
+    });
+
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+
+    const stopButton = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Stop",
+    );
+    expect(stopButton, "expected a Stop button").toBeTruthy();
+
+    await act(async () => {
+      stopButton!.click();
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(stopScenario).toHaveBeenCalledWith("CP-1", 1, "s1");
+  });
+
+  it("handles waiting state with no timeout", async () => {
+    const cp = snapshot({
+      id: "CP-1",
+      status: OCPPStatus.Available,
+      connectors: [connector({ id: 1 })],
+    });
+
+    const listScenarios = vi.fn(async () => [
+      { scenarioId: "s1", name: "Test scenario", active: true },
+    ]);
+
+    const getScenarioStatus = vi.fn(
+      async (): Promise<ScenarioExecutionContext | null> => ({
+        scenarioId: "s1",
+        state: "waiting" as const,
+        mode: "oneshot" as const,
+        currentNodeId: "n2",
+        executedNodes: ["n1"],
+        loopCount: 0,
+        runId: "run-1",
+        expectation: {
+          type: "connector_status" as const,
+          targetStatus: "Charging",
+          nodeId: "n2",
+        },
+        currentNodeStartedAt: Date.now(),
+      }),
+    );
+
+    const getScenario = vi.fn(async () => scenarioDefinitionFixture);
+
+    const service = createFakeChargePointService({
+      snapshots: [cp],
+      listScenarios,
+      getScenarioStatus,
+      getScenario,
+      getStateHistory: vi.fn(async () => []),
+    });
+
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+
+    expect(container.textContent).toContain("Waiting for");
+    expect(container.textContent).toContain("Charging");
+    expect(container.textContent).toContain("No timeout");
+  });
+
+  it("parent re-renders do not retrigger scenario fetches; scenario events do (fetch-loop regression)", async () => {
+    const cp = snapshot({
+      id: "CP-1",
+      status: OCPPStatus.Available,
+      connectors: [connector({ id: 1 })],
+    });
+
+    const listScenarios = vi.fn(async () => [
+      { scenarioId: "s1", name: "Cert probe", active: true },
+    ]);
+
+    const getScenarioStatus = vi.fn(
+      async (): Promise<ScenarioExecutionContext | null> => ({
+        scenarioId: "s1",
+        state: "running" as const,
+        mode: "oneshot" as const,
+        currentNodeId: "n1",
+        executedNodes: ["n1"],
+        loopCount: 0,
+        runId: "run-1",
+        currentNodeStartedAt: Date.now(),
+      }),
+    );
+
+    const getScenario = vi.fn(async () => scenarioDefinitionFixture);
+
+    const service = createFakeChargePointService({
+      snapshots: [cp],
+      listScenarios,
+      getScenarioStatus,
+      getScenario,
+      getStateHistory: vi.fn(async () => []),
+    });
+
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+    expect(container.textContent).toContain("Active scenarios");
+    const settledCalls = listScenarios.mock.calls.length;
+
+    // Force parent page re-renders via status events. CpDetailPage passes a
+    // freshly-mapped connectorIds array on every render; the hook must key
+    // its fetch effect on the array's content, not its identity, or each
+    // re-render refetches (the loop this test pins down).
+    for (const status of [
+      OCPPStatus.Preparing,
+      OCPPStatus.Charging,
+      OCPPStatus.Finishing,
+    ]) {
+      await act(async () => {
+        service.__handlers.subscribe
+          .get("CP-1")
+          ?.forEach((h) => h({ type: "status", status }));
+      });
+    }
+    await flush();
+    expect(listScenarios.mock.calls.length).toBe(settledCalls);
+
+    // A scenario lifecycle event does retrigger exactly one debounced refresh.
+    await act(async () => {
+      service.__handlers.subscribe.get("CP-1")?.forEach((h) =>
+        h({
+          type: "scenario-completed",
+          connectorId: 1,
+          scenarioId: "s1",
+          runId: "run-1",
+        }),
+      );
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+    await flush();
+    expect(listScenarios.mock.calls.length).toBe(settledCalls + 1);
+  });
+});

--- a/src/console/pages/cp/ActiveScenarioPanel.tsx
+++ b/src/console/pages/cp/ActiveScenarioPanel.tsx
@@ -1,0 +1,171 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useActiveScenarioRuns } from "../../lib/useActiveScenarioRuns";
+import { useDataContext } from "../../../data/providers/DataProvider";
+import { consolePath } from "../../routes";
+
+interface ActiveScenarioPanelProps {
+  cpId: string;
+  connectorIds: number[];
+}
+
+const STATE_BADGE_STYLES: Record<
+  "running" | "paused" | "stepping" | "waiting",
+  string
+> = {
+  running: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+  paused: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+  stepping:
+    "bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-300",
+  waiting: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
+};
+
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+const ActiveScenarioPanel: React.FC<ActiveScenarioPanelProps> = ({
+  cpId,
+  connectorIds,
+}) => {
+  const { chargePointService } = useDataContext();
+  const { runs, refresh } = useActiveScenarioRuns(cpId, connectorIds);
+
+  const [now, setNow] = useState<number>(Date.now());
+
+  useEffect(() => {
+    if (runs.length === 0) return;
+
+    const interval = setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [runs.length]);
+
+  const handleStop = useCallback(
+    async (connectorId: number, scenarioId: string) => {
+      try {
+        await chargePointService.stopScenario(cpId, connectorId, scenarioId);
+        await refresh();
+      } catch (err) {
+        console.error(
+          `Failed to stop scenario ${scenarioId} on ${cpId}/${connectorId}`,
+          err,
+        );
+      }
+    },
+    [cpId, chargePointService, refresh],
+  );
+
+  if (runs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-6 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+      <h3 className="mb-3 text-sm font-semibold text-gray-900 dark:text-gray-100">
+        Active scenarios
+      </h3>
+
+      <div className="space-y-2">
+        {runs.map((run) => {
+          const nodeStartedAt = run.currentNodeStartedAt || now;
+          const elapsedMs = now - nodeStartedAt;
+          const elapsed = formatElapsed(elapsedMs);
+
+          let remainingMs: number | null = null;
+          if (run.expectation?.timeoutMs) {
+            remainingMs = Math.max(0, run.expectation.timeoutMs - elapsedMs);
+          }
+          const remaining =
+            remainingMs !== null ? formatElapsed(remainingMs) : null;
+
+          const expectationDescription =
+            run.expectation?.action ??
+            run.expectation?.targetStatus ??
+            run.expectation?.type;
+
+          return (
+            <div
+              key={`${run.connectorId}:${run.scenarioId}`}
+              className="flex flex-col gap-2 rounded-md border border-gray-100 bg-gray-50 p-3 dark:border-gray-800 dark:bg-gray-800"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      "rounded-full px-2 py-0.5 text-xs font-semibold",
+                      STATE_BADGE_STYLES[run.state],
+                    )}
+                  >
+                    {run.state}
+                  </span>
+                  <div className="flex flex-col gap-0.5">
+                    <span className="font-medium text-gray-900 dark:text-gray-100">
+                      {run.name}
+                    </span>
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      Connector #{run.connectorId}
+                    </span>
+                  </div>
+                </div>
+
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleStop(run.connectorId, run.scenarioId)}
+                  className="h-7 text-xs"
+                >
+                  Stop
+                </Button>
+              </div>
+
+              <div className="flex items-center justify-between gap-2 text-xs text-gray-600 dark:text-gray-300">
+                <span>
+                  {run.currentNodeLabel || run.currentNodeId || "—"} (
+                  {run.executedCount}/{run.nodeCount ?? "?"} steps)
+                </span>
+                <span>{elapsed}</span>
+              </div>
+
+              {run.state === "waiting" && run.expectation && (
+                <div className="flex flex-col gap-1 text-xs text-gray-600 dark:text-gray-300">
+                  <div>
+                    Waiting for{" "}
+                    <code className="font-mono text-xs bg-gray-200 px-1 py-0.5 rounded dark:bg-gray-700">
+                      {expectationDescription}
+                    </code>
+                  </div>
+                  {remaining !== null ? (
+                    <div>Timeout in {remaining}</div>
+                  ) : (
+                    <div>No timeout</div>
+                  )}
+                </div>
+              )}
+
+              <Link
+                to={consolePath(
+                  `/scenarios/run?cp=${encodeURIComponent(cpId)}&connector=${run.connectorId}&id=${encodeURIComponent(run.scenarioId)}`,
+                )}
+                className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+              >
+                Open run
+              </Link>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ActiveScenarioPanel;

--- a/src/console/pages/cp/ActiveScenarioPanel.tsx
+++ b/src/console/pages/cp/ActiveScenarioPanel.tsx
@@ -76,7 +76,7 @@ const ActiveScenarioPanel: React.FC<ActiveScenarioPanelProps> = ({
 
       <div className="space-y-2">
         {runs.map((run) => {
-          const nodeStartedAt = run.currentNodeStartedAt || now;
+          const nodeStartedAt = run.currentNodeStartedAt ?? now;
           const elapsedMs = now - nodeStartedAt;
           const elapsed = formatElapsed(elapsedMs);
 

--- a/src/console/pages/dashboard/CpCard.tsx
+++ b/src/console/pages/dashboard/CpCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { cn } from "@/lib/utils";
@@ -6,8 +6,10 @@ import { OCPPStatus } from "../../../cp/domain/types/OcppTypes";
 import type { ChargePointSnapshot } from "../../../data/interfaces/ChargePointService";
 import { useChargePointView } from "../../../data/hooks/useChargePointView";
 import { useDataContext } from "../../../data/providers/DataProvider";
+import { useActiveScenarioRuns } from "../../lib/useActiveScenarioRuns";
 import StatusPill from "../../components/StatusPill";
 import NetworkSimBadge from "../../components/network-sim/NetworkSimBadge";
+import ActiveScenarioBadge from "../../components/ActiveScenarioBadge";
 import { consolePath } from "../../routes";
 
 export interface CpCardProps {
@@ -52,6 +54,21 @@ const CpCard: React.FC<CpCardProps> = ({ cp, ocppVersion }) => {
     (a, b) => a.id - b.id,
   );
 
+  const connectorIds = useMemo(
+    () => connectorList.map((c) => c.id),
+    [connectorList],
+  );
+  const { runs } = useActiveScenarioRuns(cp.id, connectorIds);
+
+  const firstWaitingExpectation = runs
+    .filter((r) => r.state === "waiting" && r.expectation)
+    .map(
+      (r) =>
+        r.expectation?.action ??
+        r.expectation?.targetStatus ??
+        r.expectation?.type,
+    )[0];
+
   const handleToggleConnect = async () => {
     setIsPending(true);
     try {
@@ -85,6 +102,10 @@ const CpCard: React.FC<CpCardProps> = ({ cp, ocppVersion }) => {
         <div className="flex items-center gap-2">
           <StatusPill status={isConnected ? status : "Disconnected"} />
           <NetworkSimBadge summary={cp.networkSim} />
+          <ActiveScenarioBadge
+            isActive={runs.length > 0}
+            waitingExpectation={firstWaitingExpectation}
+          />
         </div>
       </div>
 

--- a/src/console/pages/dashboard/CpCard.tsx
+++ b/src/console/pages/dashboard/CpCard.tsx
@@ -50,8 +50,9 @@ const CpCard: React.FC<CpCardProps> = ({ cp, ocppVersion }) => {
   // is re-Accepted, so fall back to a non-Unavailable status.
   const isConnected = connected || status !== OCPPStatus.Unavailable;
   const resolvedOcppVersion = cp.config?.ocppVersion ?? ocppVersion;
-  const connectorList = Array.from(connectors.values()).sort(
-    (a, b) => a.id - b.id,
+  const connectorList = useMemo(
+    () => Array.from(connectors.values()).sort((a, b) => a.id - b.id),
+    [connectors],
   );
 
   const connectorIds = useMemo(

--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -104,6 +104,10 @@ export class ScenarioExecutor {
   private remoteStopReason: string | null = null;
   private remoteStopOptions: StopTransactionOptions | null = null;
   private currentNodeId: string | null = null;
+  // #240: epoch ms when the current node began executing; null when no
+  // node is active. Lets a client compute time-on-step and, with
+  // expectation.timeoutMs, the remaining wait.
+  private currentNodeStartedAt: number | null = null;
   // #179: the normalized condition the currently-parked node is waiting on
   // (null when no node is parked). The robot3 machine stays "running" while a
   // node awaits an external event (the "waiting" state is never entered), so
@@ -179,6 +183,7 @@ export class ScenarioExecutor {
     // Fresh abort gate for this run.
     this.aborted = false;
     this.currentNodeId = null;
+    this.currentNodeStartedAt = null;
     this.currentExpectation = null;
     this.executedNodes = [];
     this.stepResolve = null;
@@ -322,6 +327,7 @@ export class ScenarioExecutor {
             : [resumeFromNodeId];
         this.executedNodes = seededNodes;
         this.currentNodeId = originNode.id;
+        this.currentNodeStartedAt = Date.now();
         resumed = true;
         this.callbacks.log?.(
           `[${this.scenario.name}] Resuming scenario from node "${
@@ -386,6 +392,7 @@ export class ScenarioExecutor {
 
     // Clear current node
     this.currentNodeId = null;
+    this.currentNodeStartedAt = null;
     this.currentExpectation = null;
   }
 
@@ -499,6 +506,7 @@ export class ScenarioExecutor {
 
     // Update context with current node
     this.currentNodeId = node.id;
+    this.currentNodeStartedAt = Date.now();
     this.executedNodes.push(node.id);
 
     this.notifyStateChange();
@@ -1535,6 +1543,7 @@ export class ScenarioExecutor {
     // walker bails before executing the next node.
     this.aborted = true;
     this.currentNodeId = null;
+    this.currentNodeStartedAt = null;
     this.currentExpectation = null;
     this.abortResolve?.();
     // Stop the connector's auto-meter now; otherwise a pending maxTime/maxValue
@@ -1617,6 +1626,7 @@ export class ScenarioExecutor {
       loopCount: context.loopCount,
       error: context.error,
       expectation: parked ?? null,
+      currentNodeStartedAt: this.currentNodeStartedAt,
     };
   }
 

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -607,6 +607,10 @@ export interface ScenarioExecutionContext {
   /** #179: stable identifier for this execution, set by the service layer so
    *  a poller can tie status to a specific run. */
   runId?: string;
+  /** #240: epoch ms when the current node began executing; null when no
+   *  node is active. Lets a client compute time-on-step and, with
+   *  expectation.timeoutMs, the remaining wait. */
+  currentNodeStartedAt?: number | null;
 }
 
 /**

--- a/src/cp/application/scenario/__tests__/currentNodeStartedAt.test.ts
+++ b/src/cp/application/scenario/__tests__/currentNodeStartedAt.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from "vitest";
+
+import { ScenarioExecutor } from "../ScenarioExecutor";
+import { createScenarioExecutorCallbacks } from "../ScenarioRuntime";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+import { ScenarioDefinition, ScenarioNodeType } from "../ScenarioTypes";
+
+function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+async function waitUntil(predicate: () => boolean, ms = 500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > ms) {
+      throw new Error("Timed out waiting for predicate");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function newChargePoint(id: string): ChargePoint {
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    "ws://127.0.0.1:9/",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  return cp;
+}
+
+function delayScenario(): ScenarioDefinition {
+  const now = new Date().toISOString();
+  return {
+    id: "test-started-at-delay",
+    name: "currentNodeStartedAt with delay",
+    targetType: "connector",
+    targetId: 1,
+    trigger: { type: "manual" },
+    defaultExecutionMode: "oneshot",
+    enabled: true,
+    createdAt: now,
+    updatedAt: now,
+    nodes: [
+      {
+        id: "start-1",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start", triggerOn: "connect" },
+      },
+      {
+        id: "delay-node",
+        type: ScenarioNodeType.DELAY,
+        position: { x: 0, y: 100 },
+        data: { label: "Delay 1s", delaySeconds: 1 },
+      },
+      {
+        id: "end-1",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 200 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "start-1", target: "delay-node" },
+      { id: "e2", source: "delay-node", target: "end-1" },
+    ],
+  };
+}
+
+function csmsCallTriggerScenario(timeoutSec = 10): ScenarioDefinition {
+  const now = new Date().toISOString();
+  return {
+    id: "test-started-at-csms-call",
+    name: "currentNodeStartedAt with CSMS call trigger",
+    targetType: "connector",
+    targetId: 1,
+    trigger: { type: "manual" },
+    defaultExecutionMode: "oneshot",
+    enabled: true,
+    createdAt: now,
+    updatedAt: now,
+    nodes: [
+      {
+        id: "start-1",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start", triggerOn: "connect" },
+      },
+      {
+        id: "wait-call",
+        type: ScenarioNodeType.CSMS_CALL_TRIGGER,
+        position: { x: 0, y: 100 },
+        data: { label: "Wait for Reset", action: "Reset", timeout: timeoutSec },
+      },
+      {
+        id: "end-1",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 200 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "start-1", target: "wait-call" },
+      { id: "e2", source: "wait-call", target: "end-1" },
+    ],
+  };
+}
+
+describe("currentNodeStartedAt field (#240)", () => {
+  it("tracks when a delay node starts and clears on completion", async () => {
+    const cp = newChargePoint("CP-STARTED-AT");
+    const connector = cp.getConnector(1)!;
+    const executor = new ScenarioExecutor(
+      delayScenario(),
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+    );
+
+    const execution = executor.start();
+
+    try {
+      // Wait for the delay node to start executing
+      await waitUntil(() => {
+        const ctx = executor.getContext();
+        return ctx.currentNodeId === "delay-node";
+      }, 1500);
+
+      // While executing the delay, currentNodeStartedAt should be set
+      const ctx = executor.getContext();
+      expect(ctx.currentNodeId).toBe("delay-node");
+      expect(ctx.currentNodeStartedAt).toBeDefined();
+      expect(typeof ctx.currentNodeStartedAt).toBe("number");
+      // currentNodeStartedAt should be within the last 5 seconds (likely within last 100ms)
+      const now = Date.now();
+      expect(now - (ctx.currentNodeStartedAt || 0)).toBeLessThan(5000);
+      expect(now - (ctx.currentNodeStartedAt || 0)).toBeGreaterThanOrEqual(0);
+
+      // Wait for completion
+      await timeout(execution, 3000);
+
+      // After completion, currentNodeStartedAt should be null
+      const finalCtx = executor.getContext();
+      expect(finalCtx.state).toBe("completed");
+      expect(finalCtx.currentNodeId).toBeNull();
+      expect(finalCtx.currentNodeStartedAt).toBeNull();
+    } finally {
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      ).catch(() => undefined);
+    }
+  });
+
+  it("tracks when a waiting node (csmsCallTrigger) starts and clears on stop", async () => {
+    const cp = newChargePoint("CP-STARTED-AT-WAIT");
+    const connector = cp.getConnector(1)!;
+    const executor = new ScenarioExecutor(
+      csmsCallTriggerScenario(),
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+    );
+
+    const execution = executor.start();
+
+    try {
+      // Wait for the csmsCallTrigger node to attach its listener
+      await waitUntil(
+        () => cp.events.listenerCount("incomingCallReceived") > 0,
+        1000,
+      );
+
+      // The scenario should now be waiting on the csmsCallTrigger node
+      const ctx = executor.getContext();
+      expect(ctx.currentNodeId).toBe("wait-call");
+      expect(ctx.state).toBe("waiting");
+      expect(ctx.currentNodeStartedAt).toBeDefined();
+      expect(typeof ctx.currentNodeStartedAt).toBe("number");
+      // currentNodeStartedAt should be recent
+      const now = Date.now();
+      expect(now - (ctx.currentNodeStartedAt || 0)).toBeLessThan(1000);
+      expect(now - (ctx.currentNodeStartedAt || 0)).toBeGreaterThanOrEqual(0);
+
+      // Stop the scenario
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      );
+
+      // After stopping, currentNodeStartedAt should be null
+      const stoppedCtx = executor.getContext();
+      expect(stoppedCtx.currentNodeId).toBeNull();
+      expect(stoppedCtx.currentNodeStartedAt).toBeNull();
+    } finally {
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      ).catch(() => undefined);
+    }
+  });
+
+  it("reports null currentNodeStartedAt when scenario is idle", () => {
+    const executor = new ScenarioExecutor(delayScenario(), {});
+    const ctx = executor.getContext();
+    expect(ctx.state).toBe("idle");
+    expect(ctx.currentNodeId).toBeNull();
+    expect(ctx.currentNodeStartedAt).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Refs #240. A charge point parked on a CSMS-call wait (`RemoteStartTransaction`, `Reset`, ...) looked idle from the charger page even though a scenario run was active. This implements the first iteration proposed in the issue: exposing the active scenario from the charger page, with waiting states and timeouts.

- **Engine**: `ScenarioExecutor` now stamps `currentNodeStartedAt` (epoch ms; mirrors the `currentNodeId` lifecycle at every assignment/reset site) and surfaces it on `ScenarioExecutionContext`. Combined with the existing `expectation` (#179: awaited action / target status / `timeoutMs`), a client can compute time-on-step and the remaining wait without new wire events — the existing `scenario_status` RPC and local-mode context path carry the field automatically in both console modes.
- **CP detail page — "Active scenarios" panel** (between the connector cards and the tabs): per active run it shows a state badge (running / waiting / paused / stepping), scenario name and connector, the current step (`label (k/N steps)`) with elapsed time ticking every second, and — while waiting — the awaited OCPP action or status plus a live remaining-timeout countdown ("No timeout" for unbounded waits). Each row links to the scenario run page and has a Stop button.
- **Dashboard**: each CP card gets a compact pill — amber `Waiting: <action>` when a run is parked, blue `Scenario` when one is executing.
- **Data layer**: new `useActiveScenarioRuns(cpId, connectorIds)` hook — queries `listScenarios` → `getScenarioStatus` (+ `getScenario` for node labels, cached per scenario) on mount and re-queries with a 200 ms debounce on scenario lifecycle events. The fetch effect is keyed on the connector-id *content*, not the array identity, so parent re-renders (which map a fresh array every render) don't refetch — pinned by a regression test that was verified to fail against the identity-keyed variant.

## Testing

- New executor test (`currentNodeStartedAt.test.ts`): stamped while a delay node runs and while a `csmsCallTrigger` is parked waiting; cleared on completion/stop; null when idle.
- New DOM tests (6) for the panel: waiting state with expectation and countdown, running badge, inactive → renders nothing, Stop button wiring, no-timeout wait, and the fetch-loop regression test.
- Full gates: vitest 1999 tests / bun 307 tests green; tsc error count unchanged from main (510 pre-existing); lint clean.

## Out of scope (later iterations of #240)

- New explicit wait node kinds (payload condition, connect/disconnect) — `csmsCallTrigger` / status / reservation / delay waits already exist.
- Controls while waiting beyond Stop (extend timeout, retry step, continue manually).
- Assertion-to-message linking in the run report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an active scenarios panel to charge point details, showing progress, status, elapsed time, waiting expectations, and timeout information.
  - Added controls to stop active scenarios and links to open individual scenario runs.
  - Added active scenario status badges to charge point dashboard cards.
  - Scenario timing now reflects when the current step began.

- **Tests**
  - Added coverage for active scenario display, refresh behavior, controls, and step timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->