### PR TITLE
fix(scenario): re-arm connect-triggered scenarios after a reconnect

### DIFF
--- a/docs/scenario-format.md
+++ b/docs/scenario-format.md
@@ -108,6 +108,24 @@ shape depends on `type`).
 `Preparing`, `Charging`, `SuspendedEVSE`, `SuspendedEV`, `Finishing`,
 `Reserved`, `Unavailable`, `Faulted`.
 
+### `start` notes: `triggerOn: "connect"` fires on _every_ connect
+
+A manual-trigger scenario whose start node uses `triggerOn: "connect"` (the
+default) auto-starts once the charge point reaches `Available` after
+BootNotification is accepted. It is armed **per connection**: losing the
+WebSocket disarms it, so the scenario starts again on the next connect — even
+if the previous run had already finished.
+
+This matters for a long-lived simulator whose scenario answers CSMS-initiated
+calls (a `remoteStartTrigger` responder, say). The run dies with
+`Disconnected while waiting for remote start` when the socket drops, and
+re-arming is what makes the simulator answer again after it reconnects rather
+than going quietly unresponsive.
+
+If a scenario must run only once per process, drive it with an explicit
+`run_scenario` instead of `triggerOn: "connect"`. A status oscillation on a
+still-connected charge point does **not** re-fire the scenario.
+
 ### `responseOverride` notes
 
 Which `status` values are valid depends on `action` (e.g. `action:

--- a/src/cli/server/__tests__/scenarioRearmOnReconnect.bun.test.ts
+++ b/src/cli/server/__tests__/scenarioRearmOnReconnect.bun.test.ts
@@ -1,0 +1,197 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- ack payloads are loosely typed in tests */
+import { afterEach, describe, expect, it } from "bun:test";
+import type { Socket } from "socket.io-client";
+
+import {
+  connectTestClient,
+  startTestServer,
+  type TestServer,
+} from "./socketHarness";
+import { startMockCsms } from "../../../cp/infrastructure/transport/__tests__/mockCsms";
+
+/**
+ * A `triggerOn: "connect"` scenario that was killed by a WebSocket drop must
+ * come back on the next connect.
+ *
+ * Field report (v0.7.5, GKE dev): `essential-cp-behavior` bootstrapped over all
+ * connectors and parked on its remoteStartTrigger node died on a network-sim
+ * manual-disconnect with "Disconnected while waiting for remote start". The CP
+ * reconnected and BootNotification was accepted, but no scenario restarted --
+ * so the simulator stopped answering RemoteStartTransaction entirely until an
+ * operator re-fired run_scenario_template on every connector by hand.
+ *
+ * Cause: `tryAutoStartForConnector` dedups on
+ * `Connector.lastAutoStartedScenarioKey`, which used to survive the
+ * disconnect, so the post-reconnect `Available` looked like a scenario that was
+ * already up. `ChargePoint.teardownAfterClose` now clears the arm.
+ *
+ * This drives the real thing end to end -- mock CSMS, boot, disconnect,
+ * reconnect, boot -- and asserts a second run happened by watching
+ * scenario_report's runId change.
+ */
+const CONNECTOR = 1;
+
+const scenario = {
+  id: "rearm-connect-scenario",
+  name: "Connect-triggered scenario that must re-arm",
+  targetType: "connector",
+  targetId: CONNECTOR,
+  trigger: { type: "manual" },
+  enabled: true,
+  nodes: [
+    {
+      id: "start-1",
+      type: "start",
+      position: { x: 0, y: 0 },
+      // triggerOn defaults to "connect"; spelled out because it is the
+      // behaviour under test.
+      data: { label: "Start", triggerOn: "connect" },
+    },
+    {
+      id: "sc-1",
+      type: "statusChange",
+      position: { x: 0, y: 1 },
+      data: { label: "Preparing", status: "Preparing" },
+    },
+    {
+      id: "end-1",
+      type: "end",
+      position: { x: 0, y: 2 },
+      data: { label: "End" },
+    },
+  ],
+  edges: [
+    { id: "e1", source: "start-1", target: "sc-1" },
+    { id: "e2", source: "sc-1", target: "end-1" },
+  ],
+  createdAt: "2026-07-30T00:00:00Z",
+  updatedAt: "2026-07-30T00:00:00Z",
+};
+
+const servers: TestServer[] = [];
+const csmsList: ReturnType<typeof startMockCsms>[] = [];
+
+afterEach(async () => {
+  while (servers.length > 0) await servers.pop()?.close();
+  while (csmsList.length > 0) await csmsList.pop()?.stop();
+});
+
+function emitRpc(socket: Socket, request: unknown): Promise<any> {
+  return socket.timeout(5_000).emitWithAck("rpc", request);
+}
+
+/**
+ * Connect and answer the BootNotification so the CP reaches Available.
+ *
+ * mockCsms.waitForCall resolves against frames it has ALREADY received, so on
+ * the second connect it would hand back the first boot's messageId and we'd
+ * answer a dead request. Watch for a boot frame past the ones already seen.
+ */
+async function connectAndBoot(
+  socket: Socket,
+  cpId: string,
+  csms: ReturnType<typeof startMockCsms>,
+): Promise<void> {
+  const seenBefore = csms.received.length;
+  const connectAck = emitRpc(socket, { cpId, method: "connect", params: {} });
+
+  const deadline = Date.now() + 5_000;
+  let boot: { messageId: string } | null = null;
+  while (Date.now() < deadline && !boot) {
+    const frame = csms.received
+      .slice(seenBefore)
+      .find((f) => f[0] === 2 && f[2] === "BootNotification");
+    if (frame) boot = { messageId: frame[1] as string };
+    else await new Promise((r) => setTimeout(r, 20));
+  }
+  if (!boot) throw new Error("no new BootNotification after connect");
+
+  csms.replyCallResult(boot.messageId, {
+    currentTime: new Date(0).toISOString(),
+    interval: 300,
+    status: "Accepted",
+  });
+  await connectAck;
+}
+
+/** Poll scenario_report until a run whose id isn't `previousRunId` shows up. */
+async function waitForRunAfter(
+  socket: Socket,
+  cpId: string,
+  previousRunId: string | null,
+  timeoutMs = 5_000,
+): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const report = (
+      await emitRpc(socket, {
+        cpId,
+        method: "scenario_report",
+        params: { connector: CONNECTOR, scenarioId: scenario.id },
+      })
+    ).result;
+    const runId = report?.runId ?? null;
+    if (runId && runId !== previousRunId) return runId;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return null;
+}
+
+describe("connect-triggered scenario re-arms after a reconnect", () => {
+  // Two full connect+boot+run cycles over a real socket; the default 5s
+  // budget is not enough.
+  it("runs again once the CP reconnects and boots", async () => {
+    const csms = startMockCsms();
+    csmsList.push(csms);
+    const server = await startTestServer();
+    servers.push(server);
+    const socket = await connectTestClient(server);
+    const cpId = "CPREARM";
+
+    try {
+      // Created through the registry rather than cp.create so the default
+      // `essential-cp-behavior` seed is skipped: it parks on its own
+      // remoteStartTrigger node, and tryAutoStartForConnector allows only one
+      // scenario per connector, so the seed would mask the scenario under test.
+      server.registry.create(
+        {
+          cpId,
+          wsUrl: csms.url,
+          connectors: 1,
+          vendor: "test",
+          model: "test",
+          basicAuth: null,
+        },
+        { seedDefault: false },
+      );
+
+      expect(
+        (
+          await emitRpc(socket, {
+            cpId,
+            method: "load_scenario",
+            params: { connector: CONNECTOR, scenario },
+          })
+        ).ok,
+      ).toBe(true);
+
+      // First connect: the scenario auto-starts and finishes.
+      await connectAndBoot(socket, cpId, csms);
+      const firstRunId = await waitForRunAfter(socket, cpId, null);
+      expect(firstRunId).not.toBeNull();
+
+      // Drop the socket the way the field repro did, then come back up.
+      expect(
+        (await emitRpc(socket, { cpId, method: "disconnect", params: {} })).ok,
+      ).toBe(true);
+      await connectAndBoot(socket, cpId, csms);
+
+      // The regression: this used to stay on firstRunId forever.
+      const secondRunId = await waitForRunAfter(socket, cpId, firstRunId);
+      expect(secondRunId).not.toBeNull();
+      expect(secondRunId).not.toBe(firstRunId);
+    } finally {
+      socket.disconnect();
+    }
+  }, 30_000);
+});

--- a/src/cli/server/__tests__/scenarioRearmPersistsOnDisconnect.bun.test.ts
+++ b/src/cli/server/__tests__/scenarioRearmPersistsOnDisconnect.bun.test.ts
@@ -197,16 +197,28 @@ describe("the cleared connect-trigger arm is persisted for a charging connector"
       );
 
       await emitRpc(socket, { cpId: CP_ID, method: "disconnect", params: {} });
-      await new Promise((r) => setTimeout(r, 200));
 
-      const rows = db.all<{
-        status: string;
-        transaction_json: string | null;
-        last_auto_started_scenario_key: string | null;
-      }>(
-        "SELECT status, transaction_json, last_auto_started_scenario_key FROM connector_runtime WHERE cp_id = ? AND connector_id = ?",
-        [CP_ID, CONNECTOR],
-      );
+      // The disconnect path is asynchronous, so wait on the condition rather
+      // than a fixed sleep — a slow runner would otherwise read the row before
+      // the write lands and fail for the wrong reason. Bounded, so a genuine
+      // regression still fails instead of hanging.
+      const readRow = () =>
+        db.all<{
+          status: string;
+          transaction_json: string | null;
+          last_auto_started_scenario_key: string | null;
+        }>(
+          "SELECT status, transaction_json, last_auto_started_scenario_key FROM connector_runtime WHERE cp_id = ? AND connector_id = ?",
+          [CP_ID, CONNECTOR],
+        );
+
+      const persistDeadline = Date.now() + 10_000;
+      while (Date.now() < persistDeadline) {
+        if (readRow()[0]?.last_auto_started_scenario_key === null) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+
+      const rows = readRow();
       expect(rows).toHaveLength(1);
 
       // Pin the branch under test: the connector kept its charging status and

--- a/src/cli/server/__tests__/scenarioRearmPersistsOnDisconnect.bun.test.ts
+++ b/src/cli/server/__tests__/scenarioRearmPersistsOnDisconnect.bun.test.ts
@@ -1,0 +1,226 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- ack payloads are loosely typed in tests */
+import { afterEach, describe, expect, it } from "bun:test";
+import type { Socket } from "socket.io-client";
+
+import { BunSqliteDatabase } from "../../../cp/domain/persistence/BunSqliteDatabase";
+import {
+  connectTestClient,
+  startTestServer,
+  type TestServer,
+} from "./socketHarness";
+import { startMockCsms } from "../../../cp/infrastructure/transport/__tests__/mockCsms";
+
+/**
+ * Clearing the connect-trigger arm on disconnect has to reach the DB, not just
+ * memory.
+ *
+ * `ChargePoint.teardownAfterClose` clears every connector's
+ * `lastAutoStartedScenarioKey`, and the `status = Unavailable` cascade right
+ * after it is what normally emits the connector statusChange that drives
+ * `persistConnectorRuntime`. But that cascade deliberately SKIPS a connector
+ * mid-transaction (so a restart doesn't resurrect a transaction inside an
+ * Unavailable shell) — so exactly the connectors that were charging when the
+ * socket dropped never persisted the cleared arm, and a daemon restart restored
+ * the stale one from `connector_runtime.last_auto_started_scenario_key`.
+ *
+ * That matters for any scenario whose id is stable across restarts (anything
+ * loaded by id, or rehydrated by `restoreScenariosFromDatabase`): the arm key
+ * embeds the scenario id, so a restored stale key means the connect-triggered
+ * scenario never re-arms after the restart — the same silent failure, reached
+ * through the restart path instead of the reconnect path.
+ *
+ * Caught by CodeRabbit on #253.
+ */
+const CONNECTOR = 1;
+const CP_ID = "CPARMPERSIST";
+const TRANSACTION_ID = 4242;
+
+/** start → StartTransaction → long delay: the run stays alive holding an open
+ *  transaction, which is the state that skips the Unavailable cascade. */
+const scenario = {
+  id: "arm-persist-scenario",
+  name: "Charging when the socket drops",
+  targetType: "connector",
+  targetId: CONNECTOR,
+  trigger: { type: "manual" },
+  enabled: true,
+  nodes: [
+    {
+      id: "s",
+      type: "start",
+      position: { x: 0, y: 0 },
+      data: { label: "S", triggerOn: "connect" },
+    },
+    {
+      id: "tx",
+      type: "transaction",
+      position: { x: 0, y: 1 },
+      data: { label: "Start tx", action: "start", tagId: "TAG-ARM" },
+    },
+    {
+      id: "hold",
+      type: "delay",
+      position: { x: 0, y: 2 },
+      data: { label: "hold", delaySeconds: 600 },
+    },
+    { id: "e", type: "end", position: { x: 0, y: 3 }, data: { label: "E" } },
+  ],
+  edges: [
+    { id: "e1", source: "s", target: "tx" },
+    { id: "e2", source: "tx", target: "hold" },
+    { id: "e3", source: "hold", target: "e" },
+  ],
+  createdAt: "2026-07-30T00:00:00Z",
+  updatedAt: "2026-07-30T00:00:00Z",
+};
+
+const servers: TestServer[] = [];
+const csmsList: ReturnType<typeof startMockCsms>[] = [];
+
+afterEach(async () => {
+  while (servers.length > 0) await servers.pop()?.close();
+  while (csmsList.length > 0) await csmsList.pop()?.stop();
+});
+
+function emitRpc(socket: Socket, request: unknown): Promise<any> {
+  return socket.timeout(5_000).emitWithAck("rpc", request);
+}
+
+/**
+ * Answer every CALL the charge point sends, as it arrives.
+ *
+ * The §4.1.1 serializer sends one CALL at a time and waits for its CALLRESULT,
+ * so leaving any of them unanswered — a StatusNotification, say — stalls
+ * everything queued behind it, and the scenario never reaches its transaction
+ * node. Answering selectively by action does not work here for that reason.
+ */
+function autoRespond(csms: ReturnType<typeof startMockCsms>): () => void {
+  let next = 0;
+  let stopped = false;
+
+  const conf = (action: string): unknown => {
+    switch (action) {
+      case "BootNotification":
+        return {
+          currentTime: new Date(0).toISOString(),
+          interval: 300,
+          status: "Accepted",
+        };
+      case "Authorize":
+        return { idTagInfo: { status: "Accepted" } };
+      case "StartTransaction":
+        return {
+          transactionId: TRANSACTION_ID,
+          idTagInfo: { status: "Accepted" },
+        };
+      case "Heartbeat":
+        return { currentTime: new Date(0).toISOString() };
+      default:
+        // StatusNotification, MeterValues, StopTransaction: empty conf.
+        return {};
+    }
+  };
+
+  void (async () => {
+    while (!stopped) {
+      while (next < csms.received.length) {
+        const frame = csms.received[next++];
+        if (frame[0] !== 2) continue;
+        csms.replyCallResult(frame[1] as string, conf(String(frame[2])));
+      }
+      await new Promise((r) => setTimeout(r, 10));
+    }
+  })();
+
+  return () => {
+    stopped = true;
+  };
+}
+
+describe("the cleared connect-trigger arm is persisted for a charging connector", () => {
+  it("writes a null arm key even though the Unavailable cascade skips the connector", async () => {
+    const csms = startMockCsms();
+    csmsList.push(csms);
+    const db = BunSqliteDatabase.open(":memory:");
+    const server = await startTestServer({ database: db });
+    servers.push(server);
+    const socket = await connectTestClient(server);
+    const stopResponder = autoRespond(csms);
+
+    try {
+      server.registry.create(
+        {
+          cpId: CP_ID,
+          wsUrl: csms.url,
+          connectors: 1,
+          vendor: "test",
+          model: "test",
+          basicAuth: null,
+        },
+        { seedDefault: false },
+      );
+
+      await emitRpc(socket, {
+        cpId: CP_ID,
+        method: "load_scenario",
+        params: { connector: CONNECTOR, scenario },
+      });
+
+      // Connect; the scenario auto-starts on Available and opens a transaction
+      // (via Authorize, which a local start is gated on — issue #181), which is
+      // what sets the arm key we care about.
+      await emitRpc(socket, { cpId: CP_ID, method: "connect", params: {} });
+
+      // Wait for the transaction to land on the connector.
+      let hasTransaction = false;
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline && !hasTransaction) {
+        const status = (
+          await emitRpc(socket, { cpId: CP_ID, method: "status", params: {} })
+        ).result;
+        hasTransaction =
+          status?.connectors?.[0]?.transactionId === TRANSACTION_ID;
+        if (!hasTransaction) await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(hasTransaction).toBe(true);
+
+      const armedRow = db.all<{
+        last_auto_started_scenario_key: string | null;
+      }>(
+        "SELECT last_auto_started_scenario_key FROM connector_runtime WHERE cp_id = ? AND connector_id = ?",
+        [CP_ID, CONNECTOR],
+      );
+      // Pre-condition: the arm really was persisted while running, otherwise
+      // the assertion below would pass for the wrong reason.
+      expect(armedRow[0]?.last_auto_started_scenario_key).toContain(
+        scenario.id,
+      );
+
+      await emitRpc(socket, { cpId: CP_ID, method: "disconnect", params: {} });
+      await new Promise((r) => setTimeout(r, 200));
+
+      const rows = db.all<{
+        status: string;
+        transaction_json: string | null;
+        last_auto_started_scenario_key: string | null;
+      }>(
+        "SELECT status, transaction_json, last_auto_started_scenario_key FROM connector_runtime WHERE cp_id = ? AND connector_id = ?",
+        [CP_ID, CONNECTOR],
+      );
+      expect(rows).toHaveLength(1);
+
+      // Pin the branch under test: the connector kept its charging status and
+      // its transaction, i.e. the Unavailable cascade skipped it. If this ever
+      // changes, the test is no longer covering the reported gap.
+      expect(rows[0].status).not.toBe("Unavailable");
+      expect(rows[0].transaction_json).not.toBeNull();
+
+      // The regression: this used to keep the pre-disconnect arm, so a restart
+      // rehydrated it and the scenario never re-armed.
+      expect(rows[0].last_auto_started_scenario_key).toBeNull();
+    } finally {
+      stopResponder();
+      socket.disconnect();
+    }
+  }, 30_000);
+});

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -1621,6 +1621,18 @@ export class CLIChargePointService {
     this._unsubscribes.push(
       this._chargePoint.events.on("disconnected", ({ code, reason }) => {
         this.emit({ event: "disconnected", data: { code, reason } });
+        // ChargePoint.teardownAfterClose (which has already run by the time
+        // this fires) clears every connector's lastAutoStartedScenarioKey so a
+        // `triggerOn: "connect"` scenario re-arms on the next connect. Getting
+        // that into the DB normally rides on the connector statusChange that
+        // teardown's Unavailable cascade emits — but the cascade deliberately
+        // SKIPS a connector mid-transaction, so precisely the connectors that
+        // were charging when the socket dropped never persisted the clear, and
+        // a restart rehydrated the stale arm. Snapshot every connector here
+        // instead of relying on which ones happened to emit.
+        for (const [connectorId, connector] of this._chargePoint.connectors) {
+          this.persistConnectorRuntime(connector, connectorId);
+        }
       }),
     );
 

--- a/src/cp/application/scenario/ScenarioRuntime.ts
+++ b/src/cp/application/scenario/ScenarioRuntime.ts
@@ -21,11 +21,24 @@ interface ScenarioRuntimeParams {
   hooks?: ScenarioRuntimeHooks;
 }
 
+/**
+ * Scenario log lines are prefixed with the bound connector so a CP running the
+ * same scenario on every connector stays readable. The executor's own prefix is
+ * the scenario NAME, and a template instantiated per connector shares it, so a
+ * disconnect used to emit N byte-identical "Scenario execution failed:
+ * Disconnected while waiting for remote start" lines with nothing to say which
+ * connector each came from.
+ *
+ * The prefix goes on before `hooks.log` too, so the CLI event stream and the
+ * web console see the same disambiguated text as the CP log.
+ */
 const buildLogger = (
   chargePoint: ChargePoint,
+  connector: Connector,
   hooks?: ScenarioRuntimeHooks,
 ): ScenarioExecutorCallbacks["log"] => {
-  return (message, level = "info") => {
+  return (rawMessage, level = "info") => {
+    const message = `[connector ${connector.id}] ${rawMessage}`;
     switch (level) {
       case "debug":
         chargePoint.logger.debug(message, LogType.SCENARIO);
@@ -608,7 +621,7 @@ export const createScenarioExecutorCallbacks = (
     onNodeExecute: hooks?.onNodeExecute,
     onNodeProgress: hooks?.onNodeProgress,
     onError: hooks?.onError,
-    log: buildLogger(chargePoint, hooks),
+    log: buildLogger(chargePoint, connector, hooks),
     // §4.9: connectorId === -1 sentinel means "use the scenario's bound
     // connector"; otherwise the node specified an explicit target (0 for
     // CP main controller, >0 for another connector).

--- a/src/cp/application/scenario/__tests__/scenarioLogConnectorPrefix.bun.test.ts
+++ b/src/cp/application/scenario/__tests__/scenarioLogConnectorPrefix.bun.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+
+import { createScenarioExecutorCallbacks } from "../ScenarioRuntime";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+
+/**
+ * A template instantiated per connector shares one scenario NAME, which is the
+ * only prefix the executor puts on its own log lines. So when a disconnect
+ * killed every connector's run at once, the field report saw 7 byte-identical
+ * "Scenario execution failed: Disconnected while waiting for remote start"
+ * lines with no way to tell them apart. The runtime logger adds the bound
+ * connector.
+ */
+function makeChargePoint(): ChargePoint {
+  return new ChargePoint(
+    "cp-log-prefix",
+    DefaultBootNotification,
+    2,
+    "ws://127.0.0.1:65534/never",
+    null,
+    null,
+  );
+}
+
+describe("scenario log lines carry the bound connector", () => {
+  it("prefixes the connector id, so same-named runs stay distinguishable", () => {
+    const cp = makeChargePoint();
+    const seen: string[] = [];
+
+    for (const connectorId of [1, 2]) {
+      const callbacks = createScenarioExecutorCallbacks({
+        chargePoint: cp,
+        connector: cp.getConnector(connectorId)!,
+        hooks: { log: (message) => seen.push(message) },
+      });
+      callbacks.log?.(
+        "[Essential CP Behavior] Scenario execution failed: Disconnected while waiting for remote start",
+        "error",
+      );
+    }
+
+    expect(seen).toEqual([
+      "[connector 1] [Essential CP Behavior] Scenario execution failed: Disconnected while waiting for remote start",
+      "[connector 2] [Essential CP Behavior] Scenario execution failed: Disconnected while waiting for remote start",
+    ]);
+    expect(new Set(seen).size).toBe(2);
+  });
+
+  it("prefixes the CP log the same way", () => {
+    const cp = makeChargePoint();
+    const logged: string[] = [];
+    cp.events.on("log", ({ message }) => logged.push(message));
+
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector: cp.getConnector(2)!,
+    });
+    callbacks.log?.(
+      "[Demo] Scenario execution started (mode: oneshot)",
+      "info",
+    );
+
+    expect(
+      logged.some((m) =>
+        m.includes("[connector 2] [Demo] Scenario execution started"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -1255,6 +1255,25 @@ export class ChargePoint {
    * a dead socket.
    */
   private teardownAfterClose(): void {
+    // A `triggerOn: "connect"` scenario is armed once per connect, recorded on
+    // `Connector.lastAutoStartedScenarioKey` so re-emitting Available doesn't
+    // restart something already running. That arm must not survive the socket
+    // dying: both auto-start engines (CLIChargePointService.
+    // tryAutoStartForConnector for the daemon, the useEffect in
+    // src/components/Connector.tsx for browser local mode) gate on the key, so
+    // a stale arm means the scenario never re-fires after a reconnect. In the
+    // daemon that silently kills a CLI-bootstrapped RemoteStart responder --
+    // the CP reconnects and boots, but nothing answers RemoteStartTransaction
+    // until an operator re-fires the template by hand.
+    //
+    // Cleared BEFORE the `status` assignment below: that setter cascades
+    // Unavailable onto every connector, whose statusChange event is what
+    // drives persistConnectorRuntime. Clearing afterwards would persist the
+    // stale key into `connector_runtime.last_auto_started_scenario_key` and
+    // outlive a process restart too.
+    this._connectors.forEach((connector) => {
+      connector.lastAutoStartedScenarioKey = null;
+    });
     this.status = OCPPStatus.Unavailable;
     this._heartbeat.cleanup();
     this._connectors.forEach((connector) => connector.cleanup());

--- a/src/cp/domain/charge-point/__tests__/ChargePoint.scenarioRearm.bun.test.ts
+++ b/src/cp/domain/charge-point/__tests__/ChargePoint.scenarioRearm.bun.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+
+import { ChargePoint } from "../ChargePoint";
+import { DefaultBootNotification } from "../../types/OcppTypes";
+import * as ocpp from "../../types/OcppTypes";
+
+/**
+ * A `triggerOn: "connect"` scenario is armed once per connect, and the arm is
+ * recorded on `Connector.lastAutoStartedScenarioKey` so that re-emitting
+ * `Available` (a status oscillation, a re-render, a repeated load) does not
+ * restart a scenario that is already up.
+ *
+ * The arm must NOT survive the socket dying. Both auto-start engines --
+ * `CLIChargePointService.tryAutoStartForConnector` (daemon) and the
+ * `useEffect` in `src/components/Connector.tsx` (browser local mode) -- gate
+ * on that key, so a stale arm means a reconnect never re-fires the scenario.
+ * In the daemon that silently kills the CLI-bootstrapped RemoteStart
+ * responder: the CP reconnects and boots, but nothing answers a
+ * RemoteStartTransaction until an operator re-fires the template by hand.
+ *
+ * The key is also persisted (`connector_runtime.last_auto_started_scenario_key`),
+ * so clearing has to happen before the disconnect's status cascade writes the
+ * snapshot -- otherwise the stale arm outlives a process restart too.
+ */
+function makeChargePoint(connectorCount = 2): ChargePoint {
+  return new ChargePoint(
+    "cp-rearm",
+    DefaultBootNotification,
+    connectorCount,
+    "ws://127.0.0.1:65534/never",
+    null,
+    null,
+  );
+}
+
+describe("ChargePoint disconnect clears the connect-trigger arm", () => {
+  it("clears lastAutoStartedScenarioKey on every connector", () => {
+    const cp = makeChargePoint();
+    cp.getConnector(1)!.lastAutoStartedScenarioKey =
+      "scenario-a:struct:connect:";
+    cp.getConnector(2)!.lastAutoStartedScenarioKey =
+      "scenario-b:struct:connect:";
+
+    cp.disconnect();
+
+    expect(cp.getConnector(1)!.lastAutoStartedScenarioKey).toBeNull();
+    expect(cp.getConnector(2)!.lastAutoStartedScenarioKey).toBeNull();
+  });
+
+  it("clears the arm before the Unavailable cascade, so the persisted snapshot is clean", () => {
+    // persistConnectorRuntime is driven off the connector statusChange the
+    // Unavailable cascade emits. If the arm were cleared after that cascade the
+    // row written on disconnect would still hold the stale key and a daemon
+    // restart would rehydrate it.
+    const cp = makeChargePoint(1);
+    const connector = cp.getConnector(1)!;
+    connector.status = ocpp.OCPPStatus.Available;
+    connector.lastAutoStartedScenarioKey = "scenario-a:struct:connect:";
+
+    const armAtCascade: Array<string | null> = [];
+    connector.events.on("statusChange", () => {
+      armAtCascade.push(connector.lastAutoStartedScenarioKey);
+    });
+
+    cp.disconnect();
+
+    expect(armAtCascade.length).toBeGreaterThan(0);
+    expect(armAtCascade.every((key) => key === null)).toBe(true);
+  });
+
+  it("leaves the arm alone while the CP stays connected", () => {
+    // Only a dead socket re-arms. A status oscillation must not, or a
+    // long-running scenario would be restarted underneath itself.
+    const cp = makeChargePoint(1);
+    const connector = cp.getConnector(1)!;
+    connector.lastAutoStartedScenarioKey = "scenario-a:struct:connect:";
+
+    connector.status = ocpp.OCPPStatus.Preparing;
+    connector.status = ocpp.OCPPStatus.Charging;
+
+    expect(connector.lastAutoStartedScenarioKey).toBe(
+      "scenario-a:struct:connect:",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

A `triggerOn: "connect"` scenario is armed once per connect, recorded on `Connector.lastAutoStartedScenarioKey` so that re-emitting `Available` doesn't restart something already running. That arm survived the socket dying, so the scenario **never re-fired after a reconnect**.

Found running v0.7.5 as a daemon on a dev cluster with `--scenario-template essential-cp-behavior --scenario-connector all` over 7 connectors:

1. All 7 runs park on the `remoteStartTrigger` node.
2. A network-sim `manual-disconnect` (code 1000, clean close) fails every one with `Scenario execution failed: Disconnected while waiting for remote start`.
3. The WebSocket reconnects and BootNotification is accepted — but no scenario restarts.
4. The simulator silently stops answering `RemoteStartTransaction` until an operator re-fires `run_scenario_template` on every connector by hand.

For a deployed simulator that means E2E traffic breaks quietly on every disconnect.

The arm key is also persisted (`connector_runtime.last_auto_started_scenario_key`), so a stale value can outlive a process restart.

## Fix

Clear the arm in `ChargePoint.teardownAfterClose`, **before** the `status = Unavailable` assignment: that setter cascades Unavailable onto every connector, and the resulting `statusChange` is what drives `persistConnectorRuntime`. Clearing afterwards would persist the stale key.

Fixing it in the domain covers both auto-start engines at once — the daemon's `CLIChargePointService.tryAutoStartForConnector` and browser local mode's `useEffect` in `Connector.tsx`, which had the identical bug.

No new flag: the CLI bootstrap is covered automatically.

Also prefixes scenario log lines with the bound connector. The executor's only prefix is the scenario *name*, which a per-connector template instantiation shares, so the disconnect emitted 7 byte-identical failure lines with nothing to tell them apart.

## Behaviour change

A **completed** `triggerOn: "connect"` scenario now runs again on each reconnect. That's the literal reading of the trigger, and it's what keeps a long-lived simulator responsive. A status oscillation on a still-connected CP does **not** re-fire. Documented in `docs/scenario-format.md` with a pointer to explicit `run_scenario` for run-once-per-process cases.

## Tests

- `ChargePoint.scenarioRearm.bun.test.ts` — the arm is cleared on disconnect, cleared *before* the Unavailable cascade (so the persisted snapshot is clean), and left alone while connected.
- `scenarioRearmOnReconnect.bun.test.ts` — end to end over a real socket against a mock CSMS: connect → boot → run → disconnect → reconnect → boot → a **second** run (watched via `scenario_report`'s `runId`). Verified this fails without the fix.
- `scenarioLogConnectorPrefix.bun.test.ts` — same-named runs on different connectors produce distinguishable lines.

Full suites green: 320 bun tests, 2117 vitest tests. `tsc -b --noEmit` error count unchanged at 510 (all pre-existing).

First of three PRs from the same v0.7.5 field-verification pass (P1 → P2 API contract → P3 operational).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connect-triggered scenarios now properly re-arm after disconnect/reconnect and don’t get stuck in an armed state.
  * Auto-start “arm” state is reliably cleared on teardown/disconnect, and persisted correctly when the socket drops.
  * Scenario logs are now prefixed with the connector identifier for clearer troubleshooting.

* **Documentation**
  * Expanded guidance for `triggerOn: "connect"` semantics, including reconnect behavior and when to use `run_scenario`.

* **Tests**
  * Added end-to-end and unit coverage for reconnect re-arming and disconnect-clearing/persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->