### PR TITLE
fix(soap): drive the SOAP ChargePointService from SteVe — 1.5 + DataTransfer dispatch, optional wsa:From (#256, #257)

### DIFF
--- a/src/cli/server/__tests__/httpServer.soap.bun.test.ts
+++ b/src/cli/server/__tests__/httpServer.soap.bun.test.ts
@@ -14,6 +14,7 @@ import type {
   ParsedSoapEnvelope,
   SoapDialect,
   SoapOperation,
+  SoapOperationMetadata,
   SoapPayload,
 } from "../../../cp/infrastructure/transport/soap";
 import { CPRegistry } from "../CPRegistry";
@@ -933,6 +934,160 @@ describe("httpServer OCPP 1.6 SOAP ChargePointService", () => {
       expect(["Unlocked", "UnlockFailed", "NotSupported"]).not.toContain(
         status,
       );
+    } finally {
+      registry.shutdownAll();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression corpus (issues #256, #257): every CS→CP operation each dialect
+// declares must actually be dispatched, not answered with a not-implemented
+// Fault. Driven off the dialects' own operationMetadata so the matrix can't
+// silently drift when a dialect gains/loses an operation. This is the
+// systematic form of the spot tests above — it would have caught "1.5 = 1/15"
+// across the whole surface, not just the two ops probed by hand.
+// ---------------------------------------------------------------------------
+
+const NOT_IMPLEMENTED_FAULT =
+  "is not implemented by the SOAP ChargePointService";
+
+/** Minimal payloads so a routed op runs its handler cleanly instead of a
+ *  payload-validation fault. Ops absent here send an empty body — the corpus
+ *  only asserts the route was reached (not the not-implemented Fault), which
+ *  is exactly how #257 measured coverage. */
+const MINIMAL_CS_TO_CP_PAYLOAD: Partial<Record<SoapOperation, SoapPayload>> = {
+  ChangeAvailability: { connectorId: 0, type: "Operative" },
+  ChangeConfiguration: { key: "HeartbeatInterval", value: "60" },
+  ClearCache: {},
+  GetConfiguration: {},
+  GetDiagnostics: { location: "ftp://example.test/diag" },
+  GetLocalListVersion: {},
+  RemoteStartTransaction: { idTag: "TAG" },
+  RemoteStopTransaction: { transactionId: 1 },
+  Reset: { type: "Hard" },
+  UnlockConnector: { connectorId: 1 },
+  UpdateFirmware: {
+    location: "ftp://example.test/fw",
+    retrieveDate: "2026-01-01T00:00:00Z",
+  },
+  CancelReservation: { reservationId: 1 },
+  ReserveNow: {
+    connectorId: 1,
+    expiryDate: "2026-01-01T00:00:00Z",
+    idTag: "TAG",
+    reservationId: 1,
+  },
+  SendLocalList: { listVersion: 1, updateType: "Full" },
+  TriggerMessage: { requestedMessage: "StatusNotification" },
+  ClearChargingProfile: {},
+  GetCompositeSchedule: { connectorId: 1, duration: 60 },
+  SetChargingProfile: { connectorId: 1 },
+  DataTransfer: { vendorId: "V", messageId: "m", data: "d" },
+};
+
+const DISPATCH_COVERAGE_DIALECTS = [
+  { name: "1.2", version: "OCPP-1.2", dialect: OCPP12_DIALECT },
+  { name: "1.5", version: "OCPP-1.5", dialect: OCPP15_DIALECT },
+  { name: "1.6S", version: "OCPP-1.6S", dialect: OCPP16_DIALECT },
+] as const;
+
+for (const { name, version, dialect } of DISPATCH_COVERAGE_DIALECTS) {
+  const csToCpOps = (
+    Object.entries(dialect.operationMetadata) as [
+      SoapOperation,
+      SoapOperationMetadata,
+    ][]
+  )
+    .filter(([, meta]) => meta.target === "cp" || meta.bidirectional)
+    .map(([op]) => op);
+
+  describe(`httpServer SOAP CS→CP dispatch corpus — OCPP ${name} (${csToCpOps.length} ops, #257)`, () => {
+    for (const op of csToCpOps) {
+      it(`dispatches ${op} (not the not-implemented Fault)`, async () => {
+        await withGlobalFetch(async () => {
+          const registry = createRegistry();
+          const handlers = createHandlers(registry);
+          // A fake CSMS absorbs any CP→CS callback an op triggers
+          // (TriggerMessage, RemoteStart, Reset reboot, …).
+          const restoreFetch = installFakeCentralSystemFetch([], dialect);
+          const id = `CP-${name}-${op}`;
+          registry.create(
+            { ...soapCpInit(id), ocppVersion: version },
+            { seedDefault: false },
+          );
+
+          try {
+            const meta = dialect.operationMetadata[op];
+            const res = await postSoap(
+              handlers,
+              `/ocpp/soap/${id}/ChargePointService`,
+              buildSoapEnvelope({
+                operation: op,
+                chargeBoxIdentity: id,
+                messageId: `uuid:${name}-${op}`,
+                from: centralSystemUrl,
+                to: `http://127.0.0.1:9700/ocpp/soap/${id}/ChargePointService`,
+                payload: MINIMAL_CS_TO_CP_PAYLOAD[op] ?? {},
+                dialect,
+                ...(meta.bidirectional ? { service: "cp" as const } : {}),
+              }),
+            );
+            const body = await res.text();
+            expect(
+              body.includes(NOT_IMPLEMENTED_FAULT),
+              `OCPP ${name} ${op} should be routed, got: ${body.slice(0, 200)}`,
+            ).toBe(false);
+          } finally {
+            registry.shutdownAll();
+            restoreFetch();
+          }
+        });
+      });
+    }
+  });
+}
+
+describe("httpServer SOAP no-From leniency reaches dispatched ops too (#256)", () => {
+  // The other no-From test covers Reset (the legacy-registry path). This one
+  // proves From-less requests also flow through the v16 dispatch path.
+  it("dispatches a 1.6S GetConfiguration with no From/ReplyTo header", async () => {
+    const registry = createRegistry();
+    const handlers = createHandlers(registry);
+    const id = "CP16-NOFROM";
+    registry.create(
+      { ...soapCpInit(id), ocppVersion: "OCPP-1.6S" },
+      { seedDefault: false },
+    );
+
+    try {
+      const ns = OCPP16_SOAP_NAMESPACES.CP;
+      const envelope = [
+        '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">',
+        "<soap:Header>",
+        '<Action xmlns="http://www.w3.org/2005/08/addressing">/GetConfiguration</Action>',
+        '<MessageID xmlns="http://www.w3.org/2005/08/addressing">uuid:getcfg-nofrom</MessageID>',
+        `<To xmlns="http://www.w3.org/2005/08/addressing">http://127.0.0.1:9700/ocpp/soap/${id}/ChargePointService</To>`,
+        `<chargeBoxIdentity xmlns="${ns}">${id}</chargeBoxIdentity>`,
+        "</soap:Header>",
+        `<soap:Body><getConfigurationRequest xmlns="${ns}"/></soap:Body>`,
+        "</soap:Envelope>",
+      ].join("");
+      const res = await postSoap(
+        handlers,
+        `/ocpp/soap/${id}/ChargePointService`,
+        envelope,
+      );
+      const body = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(body).not.toContain("<s:Fault>");
+      const parsed = parseSoapEnvelope(body, OCPP16_DIALECT);
+      expect(parsed).toMatchObject({
+        operation: "GetConfiguration",
+        kind: "response",
+        relatesTo: "uuid:getcfg-nofrom",
+      });
     } finally {
       registry.shutdownAll();
     }

--- a/src/cli/server/__tests__/httpServer.soap.bun.test.ts
+++ b/src/cli/server/__tests__/httpServer.soap.bun.test.ts
@@ -4,6 +4,8 @@ import {
   buildSoapEnvelope,
   OCPP12_DIALECT,
   OCPP12_SOAP_NAMESPACES,
+  OCPP15_DIALECT,
+  OCPP15_SOAP_NAMESPACES,
   OCPP16_DIALECT,
   OCPP16_SOAP_NAMESPACES,
   parseSoapEnvelope,
@@ -414,6 +416,28 @@ function resetEnvelope(
   });
 }
 
+/** A 1.5 Reset request envelope with NO wsa:From and NO wsa:ReplyTo — the
+ *  shape Apache CXF / SteVe put on the wire (issue #256). Hand-built because
+ *  buildSoapEnvelope always emits From. */
+function noFromResetEnvelope(
+  chargeBoxIdentity: string,
+  messageId: string,
+  to: string,
+): string {
+  const ns = OCPP15_SOAP_NAMESPACES.CP;
+  return [
+    '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">',
+    "<soap:Header>",
+    '<Action xmlns="http://www.w3.org/2005/08/addressing">/Reset</Action>',
+    `<MessageID xmlns="http://www.w3.org/2005/08/addressing">${messageId}</MessageID>`,
+    `<To xmlns="http://www.w3.org/2005/08/addressing">${to}</To>`,
+    `<chargeBoxIdentity xmlns="${ns}">${chargeBoxIdentity}</chargeBoxIdentity>`,
+    "</soap:Header>",
+    `<soap:Body><resetRequest xmlns="${ns}"><type>Hard</type></resetRequest></soap:Body>`,
+    "</soap:Envelope>",
+  ].join("");
+}
+
 function installFakeCentralSystemFetch(
   received: ParsedSoapEnvelope[],
   dialect?: SoapDialect,
@@ -516,6 +540,169 @@ describe("httpServer OCPP 1.6-SOAP + 1.2 CS→CP dispatch (v16 registry)", () =>
         kind: "response",
         relatesTo: "uuid:ca-12-1",
         chargeBoxIdentity: cp12Id,
+        payload: { status: "Accepted" },
+      });
+    } finally {
+      registry.shutdownAll();
+    }
+  });
+});
+
+describe("httpServer OCPP 1.5 CS→CP dispatch (issue #257)", () => {
+  const cp15Id = "CP15";
+
+  // Before #257 a 1.5 CP dispatched only Reset (the legacy registry); every
+  // other CS→CP op fell through to a not-implemented Fault. It now reaches the
+  // shared v16 registry like 1.2/1.6, answering in the 1.5 CP namespace.
+  it("accepts GetConfiguration for a 1.5 CP and answers in the 1.5 namespace", async () => {
+    const registry = createRegistry();
+    const handlers = createHandlers(registry);
+    registry.create(
+      { ...soapCpInit(cp15Id), ocppVersion: "OCPP-1.5" },
+      { seedDefault: false },
+    );
+
+    try {
+      const res = await postSoap(
+        handlers,
+        `/ocpp/soap/${cp15Id}/ChargePointService`,
+        buildSoapEnvelope({
+          operation: "GetConfiguration",
+          chargeBoxIdentity: cp15Id,
+          messageId: "uuid:getcfg-15-1",
+          from: centralSystemUrl,
+          to: `http://127.0.0.1:9700/ocpp/soap/${cp15Id}/ChargePointService`,
+          payload: {},
+          dialect: OCPP15_DIALECT,
+        }),
+      );
+      const body = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(body).toContain(OCPP15_SOAP_NAMESPACES.CP);
+      const parsed = parseSoapEnvelope(body, OCPP15_DIALECT);
+      expect(parsed).toMatchObject({
+        operation: "GetConfiguration",
+        kind: "response",
+        relatesTo: "uuid:getcfg-15-1",
+        chargeBoxIdentity: cp15Id,
+        namespace: OCPP15_SOAP_NAMESPACES.CP,
+      });
+    } finally {
+      registry.shutdownAll();
+    }
+  });
+
+  it("accepts ChangeAvailability for a 1.5 CP", async () => {
+    const registry = createRegistry();
+    const handlers = createHandlers(registry);
+    registry.create(
+      { ...soapCpInit(cp15Id), ocppVersion: "OCPP-1.5" },
+      { seedDefault: false },
+    );
+
+    try {
+      const res = await postSoap(
+        handlers,
+        `/ocpp/soap/${cp15Id}/ChargePointService`,
+        buildSoapEnvelope({
+          operation: "ChangeAvailability",
+          chargeBoxIdentity: cp15Id,
+          messageId: "uuid:ca-15-1",
+          from: centralSystemUrl,
+          to: `http://127.0.0.1:9700/ocpp/soap/${cp15Id}/ChargePointService`,
+          payload: { connectorId: "1", type: "Operative" },
+          dialect: OCPP15_DIALECT,
+        }),
+      );
+      const parsed = parseSoapEnvelope(await res.text(), OCPP15_DIALECT);
+
+      expect(res.status).toBe(200);
+      expect(parsed).toMatchObject({
+        operation: "ChangeAvailability",
+        kind: "response",
+        relatesTo: "uuid:ca-15-1",
+        payload: { status: "Accepted" },
+      });
+    } finally {
+      registry.shutdownAll();
+    }
+  });
+});
+
+describe("httpServer SOAP DataTransfer CS→CP (issue #257)", () => {
+  // DataTransfer's metadata target is "cs" (bidirectional), so it used to be
+  // rejected as not-implemented even though its handler exists. It now
+  // dispatches, and its response serializes in the CP-service namespace.
+  it("accepts DataTransfer from the CSMS on a 1.6S CP", async () => {
+    const registry = createRegistry();
+    const handlers = createHandlers(registry);
+    const dtId = "CP16-DT";
+    registry.create(
+      { ...soapCpInit(dtId), ocppVersion: "OCPP-1.6S" },
+      { seedDefault: false },
+    );
+
+    try {
+      const res = await postSoap(
+        handlers,
+        `/ocpp/soap/${dtId}/ChargePointService`,
+        buildSoapEnvelope({
+          operation: "DataTransfer",
+          chargeBoxIdentity: dtId,
+          messageId: "uuid:dt-1",
+          from: centralSystemUrl,
+          to: `http://127.0.0.1:9700/ocpp/soap/${dtId}/ChargePointService`,
+          payload: { vendorId: "TestVendor", messageId: "ping", data: "x" },
+          dialect: OCPP16_DIALECT,
+          service: "cp",
+        }),
+      );
+      const body = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(body).toContain(OCPP16_SOAP_NAMESPACES.CP);
+      const parsed = parseSoapEnvelope(body, OCPP16_DIALECT);
+      expect(parsed).toMatchObject({
+        operation: "DataTransfer",
+        kind: "response",
+        relatesTo: "uuid:dt-1",
+        chargeBoxIdentity: dtId,
+      });
+      expect(parsed.payload).toHaveProperty("status");
+    } finally {
+      registry.shutdownAll();
+    }
+  });
+});
+
+describe("httpServer SOAP accepts CS→CP without wsa:From / ReplyTo (issue #256)", () => {
+  // Apache CXF (and therefore SteVe) omit wsa:From and wsa:ReplyTo on CS→CP
+  // calls. The server used to Fault with "missing From"; it now accepts them.
+  it("dispatches a Reset whose envelope carries no From or ReplyTo header", async () => {
+    const registry = createRegistry();
+    const handlers = createHandlers(registry);
+    registry.create(soapCpInit(cpId), { seedDefault: false });
+
+    try {
+      const res = await postSoap(
+        handlers,
+        "/ocpp/soap/CP/ChargePointService",
+        noFromResetEnvelope(
+          "CP",
+          "uuid:reset-nofrom",
+          "http://127.0.0.1:9700/ocpp/soap/CP/ChargePointService",
+        ),
+      );
+      const body = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(body).not.toContain("<s:Fault>");
+      const parsed = parseSoapEnvelope(body, OCPP15_DIALECT);
+      expect(parsed).toMatchObject({
+        operation: "Reset",
+        kind: "response",
+        relatesTo: "uuid:reset-nofrom",
         payload: { status: "Accepted" },
       });
     } finally {

--- a/src/cp/infrastructure/transport/soap/OCPPSoapServer.ts
+++ b/src/cp/infrastructure/transport/soap/OCPPSoapServer.ts
@@ -17,7 +17,11 @@ import {
 } from "./soapEnvelope";
 import type { SoapDialect } from "./dialect";
 import { OCPP15_DIALECT } from "./dialect";
-import { OCPP_1_6_SOAP, OCPP_1_2 } from "../../../domain/types/OcppVersion";
+import {
+  OCPP_1_6_SOAP,
+  OCPP_1_5,
+  OCPP_1_2,
+} from "../../../domain/types/OcppVersion";
 import {
   dispatchSoapCallViaV16Registry,
   transformResponseForOcpp12,
@@ -90,7 +94,8 @@ export class OCPPSoapServer {
 
       // Dispatch order:
       // (1) Legacy inbound registry (Reset) — unchanged for all dialects
-      // (2) If 1.6S or 1.2 with v16 registry support — dispatch CS→CP through handlers
+      // (2) 1.2 / 1.5 / 1.6S with v16 registry support — dispatch CS→CP
+      //     through the shared handlers (filtered by each dialect's metadata)
       // (3) Else not-implemented Fault
 
       let responsePayload: SoapPayload;
@@ -99,7 +104,15 @@ export class OCPPSoapServer {
       const operationMetadata =
         this.dialect.operationMetadata[envelope.operation];
       const isV16Supported = this.dialect.version === OCPP_1_6_SOAP;
+      const isV15Supported = this.dialect.version === OCPP_1_5;
       const isV12Supported = this.dialect.version === OCPP_1_2;
+
+      // A bidirectional op (DataTransfer) arriving at the ChargePointService is
+      // a CS→CP call, so it is dispatchable here even though its metadata
+      // target is "cs" (issue #257).
+      const isDispatchable =
+        !!operationMetadata &&
+        (operationMetadata.target === "cp" || operationMetadata.bidirectional);
 
       // First try legacy registry (Reset for all dialects)
       const legacyHandler = this.registry.get(envelope.operation);
@@ -111,13 +124,13 @@ export class OCPPSoapServer {
         responsePayload = result.payload;
         afterResponse = result.afterResponse;
       } else if (
-        (isV16Supported || isV12Supported) &&
-        operationMetadata &&
-        operationMetadata.target === "cp" &&
+        (isV16Supported || isV15Supported || isV12Supported) &&
+        isDispatchable &&
         this.target.chargePoint &&
         this.target.logger
       ) {
-        // Dispatch through v16 registry for full 1.6S or filtered 1.2
+        // Dispatch through the shared v16 registry. 1.2 narrows a few enum
+        // tokens afterwards; 1.5 shares 1.6's enums so needs no transform.
         try {
           responsePayload = await dispatchSoapCallViaV16Registry({
             operation: envelope.operation,
@@ -156,6 +169,10 @@ export class OCPPSoapServer {
         relatesTo: envelope.messageId,
         payload: responsePayload,
         dialect: this.dialect,
+        // A bidirectional op answered here is a CS→CP call, so its response
+        // serializes in the ChargePointService (CP) namespace, not the CS one
+        // that metadata.target would otherwise select.
+        service: operationMetadata?.bidirectional ? "cp" : undefined,
       });
       afterResponse?.();
       return new Response(responseXml, {

--- a/src/cp/infrastructure/transport/soap/soapEnvelope.ts
+++ b/src/cp/infrastructure/transport/soap/soapEnvelope.ts
@@ -585,16 +585,6 @@ function optionalTextElement(
   return { key, value, text: textValue(value, name) };
 }
 
-function requireAddressHeader(
-  header: Record<string, unknown>,
-  name: string,
-): { readonly key: string; readonly value: unknown; readonly address: string } {
-  const [key, value] = requireElement(header, name);
-  const addressParent = requireRecord(value, name);
-  const [, addressValue] = requireElement(addressParent, "Address");
-  return { key, value, address: textValue(addressValue, `${name}.Address`) };
-}
-
 function optionalAddressHeader(
   header: Record<string, unknown>,
   name: string,
@@ -706,8 +696,21 @@ function findMetadataByWrapper(
       expectedNamespaceForWrapper = metadata.namespace;
     }
     if (metadata.responseWrapper === wrapper) {
-      // Responses should use the metadata's namespace; bidirectional doesn't affect responses.
-      if (!namespace || namespace === metadata.namespace) {
+      // For bidirectional operations, a response can arrive in either service's
+      // namespace depending on the call direction: a CS→CP DataTransfer answers
+      // in the CP (ChargePointService) namespace, a CP→CS one in the CS
+      // namespace. Mirror the request allowance above (issue #257).
+      if (metadata.bidirectional && namespace) {
+        const isCorrectNamespace = namespace === metadata.namespace;
+        const isOppositeNamespace =
+          namespace ===
+          (metadata.target === "cs"
+            ? dialect.namespaces.CP
+            : dialect.namespaces.CS);
+        if (isCorrectNamespace || isOppositeNamespace) {
+          return { operation, kind: "response", metadata, namespace };
+        }
+      } else if (!namespace || namespace === metadata.namespace) {
         return {
           operation,
           kind: "response",
@@ -811,14 +814,13 @@ export function parseSoapEnvelope(
   }
 
   const messageId = requireTextElement(header, "MessageID");
-  const from =
-    kind === "request"
-      ? requireAddressHeader(header, "From")
-      : optionalAddressHeader(header, "From");
-  const replyTo =
-    kind === "request"
-      ? requireAddressHeader(header, "ReplyTo")
-      : optionalAddressHeader(header, "ReplyTo");
+  // OCPP-S marks wsa:From "Required: Yes", but Apache CXF — and therefore
+  // SteVe, the reference CSMS — omits From (and ReplyTo) on CS→CP calls. Both
+  // are only used here for response routing (responseToAddress falls back
+  // From → ReplyTo → wsa:anonymous), so accept their absence rather than
+  // rejecting every real CSMS→CP request (issue #256).
+  const from = optionalAddressHeader(header, "From");
+  const replyTo = optionalAddressHeader(header, "ReplyTo");
   const to = requireTextElement(header, "To");
   const relatesTo = findElement(header, "RelatesTo");
   const relatesToText = relatesTo


### PR DESCRIPTION
## Summary

Fixes #256 and #257. As reported, the daemon's SOAP `ChargePointService` could not receive **any** CS→CP call from SteVe (Apache CXF), and its dispatch coverage was uneven across dialects (1.2 = 9/9, 1.6S = 18/19, 1.5 = 1/15). This makes CS→CP SOAP work against the reference CSMS.

### #256 — accept CS→CP requests without `wsa:From` / `wsa:ReplyTo`

`parseSoapEnvelope` required `From` (and `ReplyTo`) on inbound requests and faulted with `SOAP envelope is missing From`. Apache CXF — and therefore SteVe — omits them on CS→CP calls, so every CSMS→CP operation was rejected. Both headers are only consumed for response routing, and `responseToAddress` already falls back `From → ReplyTo → wsa:anonymous`, so they are now optional. `To`, `MessageID`, and `chargeBoxIdentity` (all of which CXF does send) stay required.

The OCPP-S spec does mark `From` "Required: Yes", but treating a legal, widely-deployed CSMS as unreachable defeats the simulator's purpose; leniency here matches how a real charge point behaves.

### #257 — dispatch the full CS→CP surface for 1.5, and DataTransfer

- **1.5 was 1/15.** `OCPPSoapServer.handleRequest` gated v16-registry dispatch on `isV16Supported || isV12Supported`, so a 1.5 CP fell through to the legacy Reset-only registry. Added a 1.5 version flag; since 1.5 shares 1.6's enum vocabulary it reaches the shared handler registry directly, with no 1.2-style response transform. 1.5 now answers the 14 `target:"cp"` operations in the CP namespace (`urn://Ocpp/Cp/2012/06/`).
- **DataTransfer** (missing on 1.6S and 1.5) is declared with `target:"cs"` + `bidirectional:true`, so it failed the `target === "cp"` dispatch gate even though its handler exists. Dispatch now also admits `bidirectional` operations, and the response serializes in the CP-service namespace. `parseSoapEnvelope` accepts a bidirectional **response** in either service namespace, mirroring the allowance already present for bidirectional requests.

1.2 is unchanged (no DataTransfer in 1.2; its enum-narrowing transform still applies).

## Tests

Because these bugs only surface against a real SOAP CSMS (CXF/SteVe) and not the JSON e2e or hand-written unit envelopes, this adds a **systematic CS→CP dispatch corpus** (`httpServer.soap.bun.test.ts`), data-driven from each dialect's own `operationMetadata`: every operation a dialect declares as CS→CP (`target:"cp"` or bidirectional) must be dispatched, not answered with the not-implemented Fault. It covers the whole 1.2 / 1.5 / 1.6S surface (9 / 15 / 19 ops), so a future dispatch-gate regression is caught across every operation — not just the ones probed by hand. Verified to fail on **18** cases against the pre-fix dispatch, and green after.

Plus focused response-shape tests: 1.5 `GetConfiguration` (asserts the 1.5 CP namespace) and `ChangeAvailability`; 1.6S `DataTransfer`; a `Reset` and a 1.6S `GetConfiguration` each with **no** `From`/`ReplyTo` header (proving #256 leniency reaches both the legacy and the v16 dispatch paths).

Full suites green: `bun test bun.test` (361 pass), full vitest (2117 pass), including the existing SOAP unit + CP→CS client tests that share the modified parser.

## Not included

#178 (a validation warning when `soapCallbackUrl` doesn't end in `/ChargePointService`) ships separately in #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp