### PR TITLE
feat(soap): warn when soapCallbackUrl lacks the /ChargePointService suffix (#178)

### DIFF
--- a/src/cli/__tests__/soapCallbackUrl.test.ts
+++ b/src/cli/__tests__/soapCallbackUrl.test.ts
@@ -3,6 +3,7 @@ import {
   buildSoapCallbackUrl,
   isHttpUrl,
   resolveSoapCallbackUrl,
+  soapCallbackUrlSuffixWarning,
 } from "../soapCallbackUrl";
 
 describe("isHttpUrl", () => {
@@ -143,5 +144,46 @@ describe("resolveSoapCallbackUrl precedence", () => {
         soapPath: "/ocpp/soap",
       }),
     ).toBe("https://abcd.ngrok-free.app/ocpp/soap/CP-1/ChargePointService");
+  });
+});
+
+describe("soapCallbackUrlSuffixWarning", () => {
+  it("returns null when the URL ends in /ChargePointService", () => {
+    expect(
+      soapCallbackUrlSuffixWarning(
+        "http://simulator-ocpp:9700/ocpp/soap/TEST_16S/ChargePointService",
+      ),
+    ).toBeNull();
+  });
+
+  it("tolerates a trailing slash", () => {
+    expect(
+      soapCallbackUrlSuffixWarning(
+        "http://simulator-ocpp:9700/ocpp/soap/TEST_16S/ChargePointService/",
+      ),
+    ).toBeNull();
+  });
+
+  it("warns when the /ChargePointService suffix is missing", () => {
+    const warning = soapCallbackUrlSuffixWarning(
+      "http://simulator-ocpp:9700/ocpp/soap/TEST_16S",
+    );
+    expect(warning).not.toBeNull();
+    expect(warning).toContain("does not end in '/ChargePointService'");
+    expect(warning).toContain("404");
+  });
+
+  it("does not match a bare 'ChargePointService' that isn't a final path segment", () => {
+    expect(
+      soapCallbackUrlSuffixWarning("http://host/ChargePointService/TEST_16S"),
+    ).not.toBeNull();
+  });
+
+  it("URLs the derived builder emits always pass", () => {
+    expect(
+      soapCallbackUrlSuffixWarning(
+        buildSoapCallbackUrl("https://pub.example", "CP-1", "/ocpp/soap"),
+      ),
+    ).toBeNull();
   });
 });

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,7 +6,12 @@ import { CLIChargePointService } from "./service";
 import { startRepl } from "./repl";
 import { startJsonMode } from "./jsonMode";
 import { resolveClientLocation } from "./clientLocation";
-import { isHttpUrl, resolveSoapCallbackUrl } from "./soapCallbackUrl";
+import {
+  isHttpUrl,
+  resolveSoapCallbackUrl,
+  soapCallbackUrlSuffixWarning,
+} from "./soapCallbackUrl";
+import { isSoapVersion } from "../cp/domain/types/OcppVersion";
 import { BunSqliteDatabase } from "../cp/domain/persistence/BunSqliteDatabase";
 import type { Database } from "../cp/domain/persistence/Database";
 import { SqliteScenarioRepository } from "../cp/domain/persistence/SqliteScenarioRepository";
@@ -629,6 +634,12 @@ export function parseArgs(argv: string[]): CLIOptions {
     process.stderr.write(
       `SOAP callback URL resolved from --soap-public-base-url: ${resolvedSoapCallbackUrl}\n`,
     );
+  }
+  if (isSoapVersion(ocppVersion) && resolvedSoapCallbackUrl) {
+    const suffixWarning = soapCallbackUrlSuffixWarning(resolvedSoapCallbackUrl);
+    if (suffixWarning) {
+      process.stderr.write(`Warning: ${suffixWarning}\n`);
+    }
   }
 
   return {

--- a/src/cli/server/socketServer.ts
+++ b/src/cli/server/socketServer.ts
@@ -62,6 +62,8 @@ import {
   type StatusNotificationOptions,
 } from "../../cp/domain/types/OcppTypes";
 import { redactSensitiveText } from "../../cp/shared/redaction";
+import { isSoapVersion } from "../../cp/domain/types/OcppVersion";
+import { soapCallbackUrlSuffixWarning } from "../soapCallbackUrl";
 import { OcppSecurityProfileConfigError } from "../../cp/infrastructure/transport/wsUrlWithBasic";
 import type { NetworkSimLayerConfig } from "../../cp/infrastructure/transport/network-sim/config";
 import { SqliteConnectorSettingsRepository } from "../../data/sqlite/SqliteConnectorSettingsRepository";
@@ -484,6 +486,12 @@ async function createCp(
   rawParams: unknown,
 ): Promise<{ cpId: string }> {
   const init = parseCreateInput(rawParams);
+  if (isSoapVersion(init.ocppVersion) && init.soapCallbackUrl) {
+    const suffixWarning = soapCallbackUrlSuffixWarning(init.soapCallbackUrl);
+    if (suffixWarning) {
+      process.stderr.write(`[server] Warning: ${suffixWarning}\n`);
+    }
+  }
   await runFacadeOperation(() =>
     deps.chargePointService.createChargePoint(
       init as unknown as CreateChargePointParams,

--- a/src/cli/soapCallbackUrl.ts
+++ b/src/cli/soapCallbackUrl.ts
@@ -87,3 +87,24 @@ export function resolveSoapCallbackUrl(
   }
   return null;
 }
+
+/**
+ * Advisory check (issue #178): the daemon routes inbound CS→CP calls on
+ * `<soapPath>/<cpId>/ChargePointService`, and the callback URL is advertised
+ * verbatim as the `wsa:From` the CSMS calls back on. An explicit callback URL
+ * that doesn't end in `/ChargePointService` is accepted but matches no route,
+ * so the CSMS gets 404s. Returns a warning string when the suffix is missing,
+ * or null when the URL is fine (a trailing slash is tolerated). `buildSoapCallbackUrl`
+ * always appends the suffix, so only an operator-supplied URL can trip this.
+ */
+export function soapCallbackUrlSuffixWarning(
+  callbackUrl: string,
+): string | null {
+  const trimmed = callbackUrl.replace(/\/+$/, "");
+  if (trimmed.endsWith(`/${SOAP_SERVICE_SUFFIX}`)) return null;
+  return (
+    `SOAP callback URL '${callbackUrl}' does not end in '/${SOAP_SERVICE_SUFFIX}'. ` +
+    `The daemon routes inbound CS→CP calls on '<soapPath>/<cpId>/${SOAP_SERVICE_SUFFIX}', ` +
+    `so the CSMS will get 404s calling back on this address.`
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #178. As @juherr documented while getting SteVe interop working, the daemon routes inbound CS→CP calls on `<soapPath>/<cpId>/ChargePointService`, and `soapCallbackUrl` is advertised **verbatim** as the `wsa:From` address the CSMS stores and calls back on. An explicit callback URL that omits the `/ChargePointService` suffix (e.g. `http://simulator-ocpp:9700/ocpp/soap/TEST_16S`) is accepted at configuration time but matches no route, so the CSMS silently gets 404s on every server-initiated message — a hard-to-diagnose time-sink.

This adds an **advisory** warning (never blocks creation):

- New `soapCallbackUrlSuffixWarning(url)` helper in `soapCallbackUrl.ts`, alongside the existing resolution logic. Returns a message when the URL doesn't end in `/ChargePointService` (a trailing slash is tolerated), else null. The derived builder always appends the suffix, so only an operator-supplied URL can trip it.
- Surfaced to stderr on SOAP-version CP creation from both entry points, mirroring the existing `tlsKeyPermissionWarning` convention: the standalone CLI (`main.ts`, after callback resolution) and the daemon (`cp.create` in `socketServer.ts`).

## Testing

Unit tests for the helper (suffix present / trailing slash / missing → warns with the 404 hint / derived URLs always pass). `bun test` socket RPC and the full `src/cli` vitest dir stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp