### PR TITLE
fix(steve-verify): boot gate independent of BootNotification.conf key order (#262)

### DIFF
--- a/scripts/steve-verify/runner/__tests__/boot-gate.bun.test.ts
+++ b/scripts/steve-verify/runner/__tests__/boot-gate.bun.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { BOOT_ACCEPTED_PATTERN } from "../boot-gate";
+
+const PREFIX =
+  '[2026-07-12T01:17:58.189Z] [INFO] [WebSocket] Received: [3,"102f1228-84cd-449e-9ccf-c1bcd4d5be7d",';
+
+describe("BOOT_ACCEPTED_PATTERN (issue #262)", () => {
+  test("matches SteVe key order (status first)", () => {
+    const line = `${PREFIX}{"status":"Accepted","currentTime":"2026-07-12T01:17:58.182Z","interval":14400}]`;
+    expect(BOOT_ACCEPTED_PATTERN.test(line)).toBe(true);
+  });
+
+  test("matches the reverse key order (currentTime first)", () => {
+    // The shape the non-SteVe CSMS in #262 emits.
+    const line = `${PREFIX}{"currentTime":"2026-07-12T01:17:58.182Z","interval":14400,"status":"Accepted"}]`;
+    expect(BOOT_ACCEPTED_PATTERN.test(line)).toBe(true);
+  });
+
+  test("does not match a Rejected boot", () => {
+    const line = `${PREFIX}{"status":"Rejected","currentTime":"2026-07-12T01:17:58.182Z","interval":14400}]`;
+    expect(BOOT_ACCEPTED_PATTERN.test(line)).toBe(false);
+  });
+
+  test("does not match an Accepted CALLRESULT that has no currentTime (e.g. RemoteStart.conf)", () => {
+    const line = `${PREFIX}{"status":"Accepted"}]`;
+    expect(BOOT_ACCEPTED_PATTERN.test(line)).toBe(false);
+  });
+
+  test("does not match a CALL frame (`[2,`) or a non-frame line", () => {
+    expect(
+      BOOT_ACCEPTED_PATTERN.test(
+        '[..] Received: [2,"id","BootNotification",{"status":"Accepted","currentTime":"x"}]',
+      ),
+    ).toBe(false);
+    expect(
+      BOOT_ACCEPTED_PATTERN.test("[..] [WebSocket] WebSocket connected"),
+    ).toBe(false);
+  });
+});

--- a/scripts/steve-verify/runner/boot-gate.ts
+++ b/scripts/steve-verify/runner/boot-gate.ts
@@ -1,0 +1,14 @@
+/**
+ * Boot gate: matches a BootNotification.conf CALLRESULT — a CALLRESULT (`[3,`)
+ * carrying both `status: "Accepted"` and `currentTime` — in the CLI's
+ * WebSocket log line, regardless of JSON key order.
+ *
+ * JSON key order is not semantically meaningful and varies by CSMS: SteVe
+ * serialises `{status, currentTime, interval}`, others `{currentTime, interval,
+ * status}`. An order-fixed pattern only matches SteVe, so against another CSMS
+ * the event-driven gate silently degrades to the plain `bootWaitSecs` sleep it
+ * exists to replace (issue #262). The two lookaheads scan the frame body (up to
+ * the closing `]`) for each key independently, so any order matches.
+ */
+export const BOOT_ACCEPTED_PATTERN =
+  /Received: \[3,(?=[^\]]*"status":"Accepted")(?=[^\]]*"currentTime")/;

--- a/scripts/steve-verify/runner/main.ts
+++ b/scripts/steve-verify/runner/main.ts
@@ -23,6 +23,7 @@
 import { mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { AssertRecorder } from "./assert";
+import { BOOT_ACCEPTED_PATTERN } from "./boot-gate";
 import { printCapabilityProbe } from "./capability-probe";
 import { parseLog } from "./ocpp";
 import { defaultSimConfig, startSim } from "./sim";
@@ -147,10 +148,8 @@ async function runScenario<D>(
     // timeout like every other soft wait here), THEN apply the spec's
     // bootWaitSecs settle on top, preserving each spec's tuned timing.
     try {
-      await sim.waitForLine(
-        /Received: \[3,.*"status":"Accepted","currentTime"/,
-        30_000,
-      );
+      // Any-key-order BootNotification.conf gate (issue #262 — see boot-gate.ts).
+      await sim.waitForLine(BOOT_ACCEPTED_PATTERN, 30_000);
     } catch (err) {
       process.stderr.write(
         `[runner] WARN: did not see BootNotification.conf within 30s -- continuing anyway (${


### PR DESCRIPTION
## Summary

Addresses the bug in #262 (thanks for the exact diagnosis and the lookahead form). The `steve-verify` runner's boot gate waits for the `BootNotification.conf` CALLRESULT before firing a scenario, but the pattern encoded SteVe's JSON key order:

```
/Received: \[3,.*"status":"Accepted","currentTime"/
```

Key order carries no meaning, and the REST CSMS you tested serialises `{currentTime, interval, status}`, so the wait always timed out. Because it's warn-and-continue, nothing failed loudly — the event-driven gate silently degraded back into the fixed `bootWaitSecs` sleep it exists to replace, at 30s per scenario.

The pattern is now order-independent (two lookaheads over the frame body) and extracted to `boot-gate.ts` so it's documented and testable:

```ts
export const BOOT_ACCEPTED_PATTERN =
  /Received: \[3,(?=[^\]]*"status":"Accepted")(?=[^\]]*"currentTime")/;
```

## Tests

New `boot-gate.bun.test.ts`: matches both key orders (SteVe `status`-first and the reverse), and rejects a `Rejected` boot, an `Accepted` CALLRESULT without `currentTime` (e.g. RemoteStart.conf), and a CALL (`[2,`) / non-frame line. `bun test` steve-verify suite green (68 pass).

The other six friction points in #262 are enhancements rather than bugs — happy to take those as the small independent PRs you offered (a typed operation union, config-driven `sim.ts` argv, the NOT-APPLICABLE/PARTIAL vocabulary, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot verification to recognize accepted BootNotification responses regardless of JSON field order.
  * Prevented valid responses from being rejected when logs include additional message types or non-frame lines.

* **Tests**
  * Added coverage for accepted, rejected, incomplete, differently ordered, and unrelated boot responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->