### PR TITLE
fix(security): decode a hex AuthorizationKey before the HTTP Basic header (#260)

### DIFF
--- a/src/cp/infrastructure/transport/wsUrlWithBasic.test.ts
+++ b/src/cp/infrastructure/transport/wsUrlWithBasic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  authorizationKeyToBasicPassword,
   buildOcppBasicAuthorization,
   buildOcppWebSocketConnectOptions,
   buildOcppWebSocketUrl,
@@ -79,6 +80,65 @@ describe("OCPP WebSocket Basic auth", () => {
     expect(opts.headers.Authorization).toBe(
       `Basic ${Buffer.from("CP001:001122").toString("base64")}`,
     );
+  });
+
+  it("decodes a 32–40 char hex AuthorizationKey before the Basic header (#260)", () => {
+    // 40 hex chars = 20 bytes -> "ABCDEFGHIJKLMNOPQRST"
+    const opts = buildOcppWebSocketConnectOptions({
+      baseUrl: "wss://csms.example.com/ocpp/",
+      chargePointId: "CP001",
+      basicAuth: null,
+      securityProfile: 2,
+      authorizationKey: "4142434445464748494a4b4c4d4e4f5051525354",
+      tls: { ca: "CA PEM" },
+    });
+
+    expect(opts.headers.Authorization).toBe(
+      `Basic ${Buffer.from("CP001:ABCDEFGHIJKLMNOPQRST").toString("base64")}`,
+    );
+    // The browser query-param path decodes identically (same resolved value).
+    expect(
+      buildOcppWebSocketUrl({
+        baseUrl: "wss://csms.example.com/ocpp/",
+        chargePointId: "CP001",
+        basicAuth: { username: "CP001", password: "ABCDEFGHIJKLMNOPQRST" },
+        securityProfile: 2,
+      }),
+    ).toBe("wss://csms.example.com/ocpp/CP001");
+  });
+
+  describe("authorizationKeyToBasicPassword (#260 / OCTT TC_085_CS)", () => {
+    it("decodes 32-char hex to 16 bytes", () => {
+      expect(
+        authorizationKeyToBasicPassword("4142434445464748494a4b4c4d4e4f50"),
+      ).toBe("ABCDEFGHIJKLMNOP");
+    });
+
+    it("decodes 40-char hex to 20 bytes", () => {
+      expect(
+        authorizationKeyToBasicPassword(
+          "4142434445464748494a4b4c4d4e4f5051525354",
+        ),
+      ).toBe("ABCDEFGHIJKLMNOPQRST");
+    });
+
+    it("passes a 16–20 char plaintext key through unchanged", () => {
+      expect(authorizationKeyToBasicPassword("plain-text-secret")).toBe(
+        "plain-text-secret",
+      );
+    });
+
+    it("passes a short hex key (< 32 chars) through unchanged", () => {
+      expect(authorizationKeyToBasicPassword("AABB")).toBe("AABB");
+      expect(authorizationKeyToBasicPassword("001122AABB")).toBe("001122AABB");
+    });
+
+    it("passes an out-of-range (30-char) or odd-length hex key through unchanged", () => {
+      const hex30 = "0".repeat(30);
+      expect(authorizationKeyToBasicPassword(hex30)).toBe(hex30);
+      const hex33 = "0".repeat(33);
+      expect(authorizationKeyToBasicPassword(hex33)).toBe(hex33);
+    });
   });
 
   it("derives profile 3 as wss mTLS and strips every Authorization header", () => {

--- a/src/cp/infrastructure/transport/wsUrlWithBasic.ts
+++ b/src/cp/infrastructure/transport/wsUrlWithBasic.ts
@@ -76,6 +76,45 @@ export function buildOcppWebSocketUrl(params: {
   return url.toString();
 }
 
+/**
+ * Derive the HTTP Basic Auth password from a configured `AuthorizationKey`
+ * (OCPP 1.6 Security Whitepaper / OCTT TC_085_CS). The whitepaper stores the
+ * key in one of two shapes, and the value that goes on the wire is the
+ * **non-hex** form:
+ *
+ * - **32–40 chars** ⇒ hex representation of a 16–20 byte password. Decode the
+ *   hex to those bytes before base64-ing `cpId:password`.
+ * - **16–20 chars** ⇒ already plaintext UTF-8; use as-is.
+ *
+ * Any other shape is returned unchanged — best effort. The CLI enforces
+ * hex-ness (but not length), while daemon/browser configs are not
+ * length-validated, so a value outside both ranges is passed through rather
+ * than guessed at. Only the AuthorizationKey copy served over OCPP
+ * (Get/ChangeConfiguration) keeps the hex form; this transform applies solely
+ * to the Basic credential.
+ */
+export function authorizationKeyToBasicPassword(
+  authorizationKey: string,
+): string {
+  const isEvenLengthHex =
+    /^[0-9a-fA-F]+$/.test(authorizationKey) &&
+    authorizationKey.length % 2 === 0;
+  if (
+    isEvenLengthHex &&
+    authorizationKey.length >= 32 &&
+    authorizationKey.length <= 40
+  ) {
+    let decoded = "";
+    for (let i = 0; i < authorizationKey.length; i += 2) {
+      decoded += String.fromCharCode(
+        parseInt(authorizationKey.slice(i, i + 2), 16),
+      );
+    }
+    return decoded;
+  }
+  return authorizationKey;
+}
+
 export function buildOcppBasicAuthorization(
   basicAuth: BasicAuthSettings,
 ): string {
@@ -210,7 +249,9 @@ function resolveBasicAuth(params: {
     }
     return {
       username: params.chargePointId,
-      password: params.authorizationKey,
+      // #260: the AuthorizationKey is stored hex; the Basic header carries its
+      // decoded (non-hex) form per TC_085_CS.
+      password: authorizationKeyToBasicPassword(params.authorizationKey),
     };
   }
   return params.basicAuth; // "legacy"


### PR DESCRIPTION
## Summary

Fixes #260 (thanks for the corrected analysis and the TC_085_CS citation). With security profile 1/2, the simulator put the configured `AuthorizationKey` **verbatim** into the HTTP Basic header. Per the OCPP 1.6 Security Whitepaper / OCTT **TC_085_CS**, the value on the wire is the **non-hex** form:

- **32–40 chars** ⇒ hex representation of a 16–20 byte password → decode to those bytes before base64.
- **16–20 chars** ⇒ already plaintext UTF-8 → use as-is.

Because the CLI's `--authorization-key` requires hex, the recommended max-entropy 40-hex-digit key went out un-decoded (40 chars where the tool and a conformant CSMS expect 20 bytes), so authentication failed — or silently succeeded against a CSMS that made the same mistake. This matches the reading in steve-community/steve#1895: hex when the key travels over OCPP, plain when used for HTTP Basic.

## The fix

The decode happens once, in `resolveBasicAuth`, which is the single point that feeds **both** the Node `Authorization` header (`buildOcppBasicAuthorization`) and the browser `ocpp_ws_secret` query param (`buildOcppWebSocketUrl`) — so both stay consistent. A new exported helper `authorizationKeyToBasicPassword` applies the length rule; a value outside the 32–40 hex range (or odd-length, or non-hex) passes through unchanged, so short test/legacy keys are unaffected.

Deliberately **untouched**: the `AuthorizationKey` copy served over OCPP `GetConfiguration`/`ChangeConfiguration` keeps its hex form. The two representations were already cleanly separated in `ChargePoint` (the config store is never read back to build the header), so decoding at the header-derivation site doesn't affect the config value.

## Tests

`wsUrlWithBasic.test.ts`: unit coverage for `authorizationKeyToBasicPassword` (32→16 bytes, 40→20 bytes, plaintext passthrough, short/odd/out-of-range passthrough) plus an end-to-end `buildOcppWebSocketConnectOptions` case asserting the decoded `Authorization` header for a 40-hex key. Verified the integration test fails against the pre-fix (verbatim) code. Existing profile-1/2 tests use short keys and stay green. Full `bun test bun.test` 414 pass; `tsc -b` clean on the touched file.

Note the CLI still accepts any hex length; adding a 16–20 / 32–40 length validation (with a clear error) would be a reasonable follow-up but isn't required for the decode fix and would churn existing short-key fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp