### PR TITLE
feat(scenario): link assertion results to the transcript frames they matched (#240)

### DIFF
--- a/docs/scenario-format.md
+++ b/docs/scenario-format.md
@@ -190,6 +190,8 @@ Each assertion optionally carries a `severity` field (`"failure"` or `"warning"`
 
 The run report carries both axes alongside the overall `verdict`: `conformanceVerdict` (`PASS`/`FAIL`/`BLOCKED`/`SKIPPED`, from failure-severity assertions only) and `compatibilityVerdict` (`PASS`/`WARNING`/`FAIL`/`SKIPPED`, from warning-severity assertions only), plus the effective `strict` flag.
 
+Each entry in the report's `assertions` array also carries `frameRefs` (#240): the `seq` (capture-order index) of the transcript frame(s) the assertion is about — the frame that satisfied it on pass, or the offending frame on failure (e.g. the unexpected CALL for `ocpp_absent`, the call and its response for `response_status`). Join `frameRefs` against the report's `transcript` entries (which share the same `seq`) to point a failed assertion straight at the relevant messages. It is omitted when no frame is relevant (a "never sent" miss, or a malformed spec).
+
 **Example run report**:
 
 ```json

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -563,6 +563,15 @@ export interface AssertionResult {
   detail?: string;
   /** How this assertion failure affects the verdict. */
   severity: AssertionSeverity;
+  /**
+   * #240: transcript frames this result is about — the `seq` (capture-order
+   * index) of each frame that satisfied the check (on pass) or triggered the
+   * failure (e.g. the unexpected CALL for `ocpp_absent`). Join against
+   * {@link ScenarioRunResult.transcript}'s `seq` to point a failed assertion
+   * at the relevant messages. Absent when no frame is relevant (e.g. a
+   * "never sent" miss, or a malformed spec).
+   */
+  frameRefs?: number[];
 }
 
 /** Overall pass/fail verdict for one scenario run, rolled up from its

--- a/src/cp/application/verification/ScenarioAssertions.ts
+++ b/src/cp/application/verification/ScenarioAssertions.ts
@@ -16,6 +16,7 @@ import {
   findAllCalls,
   findCall,
   findResponseFor,
+  type CallFrame,
   type Direction,
   type Frame,
 } from "./ocpp";
@@ -80,6 +81,7 @@ function makeResult(
   status: AssertionStatus,
   defaultDescription: string,
   detail?: string,
+  frameRefs?: number[],
 ): AssertionResult {
   return {
     id: spec.id,
@@ -88,7 +90,26 @@ function makeResult(
     description: spec.description ?? defaultDescription,
     detail,
     severity: spec.severity ?? "failure",
+    // #240: only attach when a frame is actually relevant, so a "never sent"
+    // miss or a malformed spec stays free of an empty array.
+    ...(frameRefs && frameRefs.length > 0 ? { frameRefs } : {}),
   };
+}
+
+/** Capture-order indices (transcript `seq`) of the given frames, skipping any
+ *  that aren't present. #240: lets an assertion result point at the exact
+ *  transcript entries it matched. */
+function frameIndices(
+  frames: readonly Frame[],
+  ...found: ReadonlyArray<Frame | null | undefined>
+): number[] {
+  const out: number[] = [];
+  for (const frame of found) {
+    if (!frame) continue;
+    const i = frames.indexOf(frame);
+    if (i >= 0) out.push(i);
+  }
+  return out;
 }
 
 /** Shared implementation for `response_status` / `idtag_info_status`:
@@ -124,14 +145,17 @@ function evaluateResponseStatus(
       "failed",
       description,
       `no response frame found for uniqueId=${call.uniqueId} (${action})`,
+      frameIndices(frames, call),
     );
   }
+  const refs = frameIndices(frames, call, response);
   if (response.kind === "callerror") {
     return makeResult(
       spec,
       "failed",
       description,
       `expected CALLRESULT, got CALLERROR ${response.errorCode}: ${response.errorDescription}`,
+      refs,
     );
   }
 
@@ -141,13 +165,14 @@ function evaluateResponseStatus(
       : (response.payload as { idTagInfo?: { status?: unknown } } | null)
           ?.idTagInfo?.status;
   if (actualStatus === expectedStatus) {
-    return makeResult(spec, "passed", description);
+    return makeResult(spec, "passed", description, undefined, refs);
   }
   return makeResult(
     spec,
     "failed",
     description,
     `expected ${statusPath}=${expectedStatus}, got ${statusPath}=${String(actualStatus)} (uniqueId=${call.uniqueId})`,
+    refs,
   );
 }
 
@@ -174,7 +199,13 @@ function evaluateOne(
       const description = `${spec.action}.req sent`;
       const call = findCall(frames, "sent", spec.action);
       return call
-        ? makeResult(spec, "passed", description)
+        ? makeResult(
+            spec,
+            "passed",
+            description,
+            undefined,
+            frameIndices(frames, call),
+          )
         : makeResult(
             spec,
             "failed",
@@ -195,7 +226,13 @@ function evaluateOne(
       const description = `${spec.action}.req received`;
       const call = findCall(frames, "received", spec.action);
       return call
-        ? makeResult(spec, "passed", description)
+        ? makeResult(
+            spec,
+            "passed",
+            description,
+            undefined,
+            frameIndices(frames, call),
+          )
         : makeResult(
             spec,
             "failed",
@@ -222,6 +259,7 @@ function evaluateOne(
             "failed",
             description,
             `unexpected ${direction} CALL found: ${call.raw}`,
+            frameIndices(frames, call),
           )
         : makeResult(spec, "passed", description);
     }
@@ -287,13 +325,15 @@ function evaluateOne(
           `no ${direction} CALL found for action=${spec.action} (occurrence ${occurrence})`,
         );
       }
+      const payloadRefs = frameIndices(frames, call);
       return deepPartialMatch(spec.payload, call.payload)
-        ? makeResult(spec, "passed", description)
+        ? makeResult(spec, "passed", description, undefined, payloadRefs)
         : makeResult(
             spec,
             "failed",
             description,
             `payload for ${spec.action} (uniqueId=${call.uniqueId}) did not match expected subset`,
+            payloadRefs,
           );
     }
 
@@ -318,13 +358,15 @@ function evaluateOne(
           `one or both frames not found (before=${before.action} found=${beforeIndex !== -1}, after=${after.action} found=${afterIndex !== -1})`,
         );
       }
+      const orderRefs = [beforeIndex, afterIndex];
       return beforeIndex < afterIndex
-        ? makeResult(spec, "passed", description)
+        ? makeResult(spec, "passed", description, undefined, orderRefs)
         : makeResult(
             spec,
             "failed",
             description,
             `before (frame ${beforeIndex}) did not precede after (frame ${afterIndex})`,
+            orderRefs,
           );
     }
 
@@ -351,16 +393,20 @@ function evaluateOne(
           `reference frame not found: ${before.action}`,
         );
       }
-      const found = frames
+      const afterRelative = frames
         .slice(lastBeforeIndex + 1)
-        .some((f) => matchesFrameRef(f, after));
-      return found
-        ? makeResult(spec, "passed", description)
+        .findIndex((f) => matchesFrameRef(f, after));
+      return afterRelative !== -1
+        ? makeResult(spec, "passed", description, undefined, [
+            lastBeforeIndex,
+            lastBeforeIndex + 1 + afterRelative,
+          ])
         : makeResult(
             spec,
             "failed",
             description,
             `${after.action} not found after frame ${lastBeforeIndex} (${before.action})`,
+            [lastBeforeIndex],
           );
     }
 
@@ -374,13 +420,19 @@ function evaluateOne(
         );
       }
       const description = `StatusNotification -> ${spec.targetStatus}`;
-      const matched = findAllCalls(frames, "sent", "StatusNotification").some(
+      const matched = findAllCalls(frames, "sent", "StatusNotification").find(
         (f) =>
           (f.payload as { status?: unknown } | null)?.status ===
           spec.targetStatus,
       );
       return matched
-        ? makeResult(spec, "passed", description)
+        ? makeResult(
+            spec,
+            "passed",
+            description,
+            undefined,
+            frameIndices(frames, matched),
+          )
         : makeResult(
             spec,
             "failed",
@@ -399,16 +451,19 @@ function evaluateOne(
         );
       }
       const description = `no unexpected: ${spec.actions.join(", ")}`;
-      const found = spec.actions.filter((action) =>
-        findCall(frames, "sent", action),
-      );
-      return found.length === 0
+      const foundFrames = spec.actions
+        .map((action) => findCall(frames, "sent", action))
+        .filter((call): call is CallFrame => call !== undefined);
+      return foundFrames.length === 0
         ? makeResult(spec, "passed", description)
         : makeResult(
             spec,
             "failed",
             description,
-            `unexpected sent CALL(s) found: ${found.join(", ")}`,
+            `unexpected sent CALL(s) found: ${foundFrames
+              .map((call) => call.action)
+              .join(", ")}`,
+            frameIndices(frames, ...foundFrames),
           );
     }
 

--- a/src/cp/application/verification/ScenarioAssertions.ts
+++ b/src/cp/application/verification/ScenarioAssertions.ts
@@ -451,18 +451,24 @@ function evaluateOne(
         );
       }
       const description = `no unexpected: ${spec.actions.join(", ")}`;
-      const foundFrames = spec.actions
-        .map((action) => findCall(frames, "sent", action))
-        .filter((call): call is CallFrame => call !== undefined);
+      // Every sent CALL for a forbidden action, not just the first per action —
+      // a repeated offender must reference all of its frames (#240).
+      const forbidden = new Set(spec.actions);
+      const foundFrames = frames.filter(
+        (frame): frame is CallFrame =>
+          frame.kind === "call" &&
+          frame.direction === "sent" &&
+          forbidden.has(frame.action),
+      );
       return foundFrames.length === 0
         ? makeResult(spec, "passed", description)
         : makeResult(
             spec,
             "failed",
             description,
-            `unexpected sent CALL(s) found: ${foundFrames
-              .map((call) => call.action)
-              .join(", ")}`,
+            `unexpected sent CALL(s) found: ${[
+              ...new Set(foundFrames.map((call) => call.action)),
+            ].join(", ")}`,
             frameIndices(frames, ...foundFrames),
           );
     }

--- a/src/cp/application/verification/__tests__/ScenarioAssertions.test.ts
+++ b/src/cp/application/verification/__tests__/ScenarioAssertions.test.ts
@@ -424,14 +424,15 @@ describe("frameRefs (#240)", () => {
     expect(r.frameRefs).toEqual([2, 6]);
   });
 
-  it("no_unexpected failure references each unexpected frame", () => {
+  it("no_unexpected failure references EVERY unexpected frame, incl. repeats", () => {
+    // buildTranscript sends StatusNotification twice (seq 2 and 5).
     const r = evalOne({
       id: "g",
       type: "no_unexpected",
       actions: ["Reset", "StatusNotification"],
     });
     expect(r.status).toBe("failed");
-    expect(r.frameRefs).toEqual([2]);
+    expect(r.frameRefs).toEqual([2, 5]);
   });
 });
 

--- a/src/cp/application/verification/__tests__/ScenarioAssertions.test.ts
+++ b/src/cp/application/verification/__tests__/ScenarioAssertions.test.ts
@@ -362,6 +362,79 @@ describe("evaluateAssertions", () => {
   });
 });
 
+// #240: each result points at the transcript frames (capture-order `seq`) it
+// matched, so a failed assertion links to the relevant messages. Indices below
+// follow buildTranscript()'s documented order (0=BootNotification sent, ...,
+// 8=MeterValues sent).
+describe("frameRefs (#240)", () => {
+  it("ocpp_sent pass references the matched sent frame", () => {
+    const r = evalOne({
+      id: "a",
+      type: "ocpp_sent",
+      action: "BootNotification",
+    });
+    expect(r.status).toBe("passed");
+    expect(r.frameRefs).toEqual([0]);
+  });
+
+  it("ocpp_received pass references the received frame", () => {
+    const r = evalOne({
+      id: "b",
+      type: "ocpp_received",
+      action: "RemoteStartTransaction",
+    });
+    expect(r.frameRefs).toEqual([3]);
+  });
+
+  it("a 'never sent' miss carries no frameRefs", () => {
+    const r = evalOne({ id: "c", type: "ocpp_sent", action: "Reset" });
+    expect(r.status).toBe("failed");
+    expect(r.frameRefs).toBeUndefined();
+  });
+
+  it("ocpp_absent failure references the offending frame", () => {
+    const r = evalOne({
+      id: "d",
+      type: "ocpp_absent",
+      action: "StatusNotification",
+    });
+    expect(r.status).toBe("failed");
+    expect(r.frameRefs).toEqual([2]);
+  });
+
+  it("response_status references both the call and its response", () => {
+    const r = evalOne({
+      id: "e",
+      type: "response_status",
+      action: "RemoteStartTransaction",
+      status: "Accepted",
+    });
+    expect(r.status).toBe("passed");
+    expect(r.frameRefs).toEqual([3, 4]);
+  });
+
+  it("message_order references the before and after frames", () => {
+    const r = evalOne({
+      id: "f",
+      type: "message_order",
+      before: { action: "StatusNotification" },
+      after: { action: "StartTransaction" },
+    });
+    expect(r.status).toBe("passed");
+    expect(r.frameRefs).toEqual([2, 6]);
+  });
+
+  it("no_unexpected failure references each unexpected frame", () => {
+    const r = evalOne({
+      id: "g",
+      type: "no_unexpected",
+      actions: ["Reset", "StatusNotification"],
+    });
+    expect(r.status).toBe("failed");
+    expect(r.frameRefs).toEqual([2]);
+  });
+});
+
 describe("computeVerdictSummary", () => {
   const makePassed = (
     severity: AssertionSeverity = "failure",


### PR DESCRIPTION
## Summary

Next observability slice for #240. The issue asked that "a completed run should provide a structured passed/failed report, with **each failed assertion linked to the relevant messages**." The verdict/report machinery (#179, #250) already carries per-assertion results and the correlated transcript, but nothing tied an assertion back to the specific frames it examined.

Each `AssertionResult` now carries **`frameRefs`** — the `seq` (capture-order index) of the transcript frame(s) the check is about:

- **pass**: the frame that satisfied it (e.g. the sent CALL for `ocpp_sent`, the call + its response for `response_status`).
- **failure**: the offending frame (the unexpected CALL for `ocpp_absent` / `no_unexpected`, the mismatched call/response for `response_status`, the before/after frames for `message_order`).

Consumers join `frameRefs` against the report's `transcript` entries (which share the same `seq`) to jump a failed assertion straight to the relevant messages. It's omitted when no frame is relevant — a "never sent" miss or a malformed spec — so those results stay clean.

The field is additive on `AssertionResult` (and therefore on the machine-readable `ScenarioRunResult.assertions`); the report `schemaVersion` is unchanged, and it flows through `finalizeScenarioRun` without any service change.

## Tests

`ScenarioAssertions.test.ts` gains a `frameRefs (#240)` block over the existing synthetic transcript: `ocpp_sent`/`ocpp_received` pass → the matched frame index; a never-sent miss → no `frameRefs`; `ocpp_absent` failure → the offending frame; `response_status` → call + response; `message_order` → before + after; `no_unexpected` failure → each unexpected frame. Full verification suite 199 pass, bun service/harness verdict tests 15 pass, lint + tsc clean. `docs/scenario-format.md` documents the field.

## Not included (later #240 slices)

New explicit wait node kinds (payload condition, connect/disconnect) and richer controls while waiting (extend timeout, retry step, continue manually) — separate, larger pieces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqs4cUg7sw2CVMfWsGD5Bp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assertion reports now include transcript frame references for matching results, helping users trace validations to specific communication frames.
  * References are provided for message, response status, ordering, payload, and unexpected-call assertions when applicable.

* **Bug Fixes**
  * “Message after” checks now reference the exact matching frame.
  * Unmatched or malformed assertions no longer include empty frame references.

* **Documentation**
  * Documented the new frame reference information in assertion reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->