### PR TITLE
feat(scenario): payload-conditioned CSMS-call waits and connection/disconnection wait nodes (#240)

### DIFF
--- a/docs/scenario-format.md
+++ b/docs/scenario-format.md
@@ -193,10 +193,11 @@ point's WebSocket reaches `event` (`"connected"` or `"disconnected"`).
   waiting for a future transition.
 - **Survives disconnect**: unlike every other wait node, `connectionTrigger`
   does **not** fail when the WebSocket drops — outlasting a disconnected span
-  is the point. A node with `event: "connected"` that starts while connected,
-  then sees the socket drop and reconnect, resolves on the reconnect rather
-  than erroring on the drop. Only the optional `timeout` (seconds; `0` /
-  absent = wait forever) can end the wait early, with a timeout error.
+  is the point. A node with `event: "connected"` that starts while
+  disconnected — say, right after a `"disconnected"` wait resolved — parks
+  across the disconnected span and resolves on the reconnect rather than
+  erroring. Only the optional `timeout` (seconds; `0` / absent = wait
+  forever) can end the wait early, with a timeout error.
 - This node only _observes_ the connection state — it never causes a
   disconnect itself. Simulating network drops is out of scope here (see
   issue #239).

--- a/docs/scenario-format.md
+++ b/docs/scenario-format.md
@@ -1,4 +1,4 @@
-# Scenario File Format (v1.0)
+# Scenario File Format (v1.1)
 
 A **node-graph JSON file** describing a scripted charge-point behavior: a
 directed graph of typed nodes (status changes, transactions, meter values,
@@ -16,8 +16,9 @@ that schema, not a replacement for it.
 
 ## Status & scope
 
-- **Version `1.0`** (`schemaVersion`).
-- Covers the full 22-node discriminated union the scenario engine supports
+- **Version `1.1`** (`schemaVersion`). Files stamped `1.0` remain valid — 1.x
+  is purely additive (see [Versioning](#versioning)).
+- Covers the full 23-node discriminated union the scenario engine supports
   (see [Node types](#node-types) below).
 - **Validation against this schema is advisory in this version**: the
   simulator warns (`console.warn` in the browser, stderr / server log on the
@@ -45,7 +46,7 @@ Mirrors the [OCPP trace format](./trace-format.md#versioning)'s rules:
 
 | Field                   | Type                                                                            | Required | Notes                                                                                                                                         |
 | ----------------------- | ------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `schemaVersion`         | string                                                                          | No       | e.g. `"1.0"`. Absent on files predating issue #214 — still valid.                                                                             |
+| `schemaVersion`         | string                                                                          | No       | e.g. `"1.1"` (current) or `"1.0"` (still valid — additive). Absent on files predating issue #214 — still valid.                               |
 | `id`                    | string                                                                          | Yes      | Stable scenario identifier.                                                                                                                   |
 | `templateId`            | string                                                                          | No       | Set automatically when a built-in template is instantiated; absent on hand-authored scenarios. See [Template instances](#template-instances). |
 | `name`                  | string                                                                          | Yes      |                                                                                                                                               |
@@ -74,7 +75,7 @@ Mirrors the [OCPP trace format](./trace-format.md#versioning)'s rules:
 ```
 
 Every node has `id` (string), `type` (the discriminator — a closed
-enum of the 22 values below), `position` (`{ x: number, y: number }`), and
+enum of the 23 values below), `position` (`{ x: number, y: number }`), and
 `data` (an object requiring at least `label: string`; the rest of `data`'s
 shape depends on `type`).
 
@@ -100,10 +101,11 @@ shape depends on `type`).
 | `unlockOutcome`      | `outcome` (`"Unlocked"` \| `"UnlockFailed"` \| `"NotSupported"`) |                                                                                                                                                                                       |
 | `configSet`          | `key`, `value`                                                   |                                                                                                                                                                                       |
 | `dataTransfer`       | `vendorId`                                                       | `messageId`, `data`                                                                                                                                                                   |
-| `csmsCallTrigger`    | `action`                                                         | `timeout`                                                                                                                                                                             |
+| `csmsCallTrigger`    | `action`                                                         | `timeout`, `payload`. See [note](#csmscalltrigger-payload-condition) below.                                                                                                           |
 | `responseOverride`   | `action`, `status`                                               | See [note](#responseoverride-notes) below.                                                                                                                                            |
 | `inboundPolicy`      | `action`, `policy` (`"answer"` \| `"callerror"` \| `"ignore"`)   | `errorCode`, `errorDescription`. See [note](#inboundpolicy-and-certificate-quirks-notes) below.                                                                                       |
 | `certQuirks`         | `mode` (`"set"` \| `"clear"`)                                    | `preset`, `csrKeyAlgorithm`, `csrPemLineEndings`, `requiredCertificateSignatureAlgorithms`, `hiddenConfigurationKeys`. See [note](#inboundpolicy-and-certificate-quirks-notes) below. |
+| `connectionTrigger`  | `event` (`"connected"` \| `"disconnected"`)                      | `timeout`. See [note](#connectiontrigger-notes) below.                                                                                                                                |
 
 `status` / `targetStatus` fields use the `OCPPStatus` enum: `Available`,
 `Preparing`, `Charging`, `SuspendedEVSE`, `SuspendedEV`, `Finishing`,
@@ -156,6 +158,48 @@ Explicit fields override preset values. Together with `inboundPolicy` and
 declarative `assertions` (e.g., `ocpp_absent`, `no_unexpected`), certificate
 quirks let you emulate certification-tool strictness to verify a CP's
 conformance.
+
+### `csmsCallTrigger` payload condition
+
+**Issue #240**: `csmsCallTrigger` accepts an optional `payload` object — a
+deep-partial subset the incoming CALL's payload must match (see
+`src/scenario/deepPartialMatch.ts`) for the wait to release. Only nested keys
+present in `payload` are checked; extra keys on the actual CALL are ignored.
+A CALL of the awaited `action` whose payload does **not** match keeps the
+wait parked — the non-matching frame is not consumed, so a later matching
+CALL of the same action can still resolve it. Omitting `payload` (the
+pre-#240 behavior) matches any payload.
+
+```json
+{
+  "id": "wait-hard-reset",
+  "type": "csmsCallTrigger",
+  "position": { "x": 0, "y": 0 },
+  "data": {
+    "label": "Wait for hard Reset",
+    "action": "Reset",
+    "payload": { "type": "Hard" }
+  }
+}
+```
+
+### `connectionTrigger` notes
+
+**Issue #240**: `connectionTrigger` parks the scenario until the charge
+point's WebSocket reaches `event` (`"connected"` or `"disconnected"`).
+
+- **Level-triggered**, like `statusTrigger`: if the connection is already in
+  the target state when the node starts, it resolves immediately rather than
+  waiting for a future transition.
+- **Survives disconnect**: unlike every other wait node, `connectionTrigger`
+  does **not** fail when the WebSocket drops — outlasting a disconnected span
+  is the point. A node with `event: "connected"` that starts while connected,
+  then sees the socket drop and reconnect, resolves on the reconnect rather
+  than erroring on the drop. Only the optional `timeout` (seconds; `0` /
+  absent = wait forever) can end the wait early, with a timeout error.
+- This node only _observes_ the connection state — it never causes a
+  disconnect itself. Simulating network drops is out of scope here (see
+  issue #239).
 
 ## Edge shape
 
@@ -244,6 +288,10 @@ next boot.
 
 ## Changelog
 
+- **v1.1**: Issue #240. Adds the `connectionTrigger` node type (waits for the
+  WebSocket to connect/disconnect) and an optional `payload` deep-partial
+  match condition on `csmsCallTrigger`. Both purely additive — files stamped
+  `schemaVersion: "1.0"`, or no `schemaVersion` at all, remain valid.
 - **v1.0**: Initial published schema (issue #214). Adds the optional
   `schemaVersion` field; documents the existing on-file shape used since the
   scenario editor's introduction. Later additive optional fields

--- a/schema/scenario.schema.json
+++ b/schema/scenario.schema.json
@@ -1,15 +1,15 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/shiv3/ocpp-cp-simulator/schema/scenario.schema.json",
-  "title": "ScenarioDefinition (scenario schema v1.0)",
-  "$comment": "Scenario file format v1.0 (issue #214). Mirrors src/cp/application/scenario/ScenarioTypes.ts. See docs/scenario-format.md for the field overview and versioning rules. This is a first published contract: it is STRICT on known fields (types, required-ness, closed-vocabulary enums) but PERMISSIVE on unknown keys at every object level (additionalProperties: true) — real editor exports carry xyflow UI fields (width/height/selected/style/...) that this schema deliberately does not reject. Validation against this schema is advisory only in this version: the simulator warns on a mismatch but never refuses to load a file.",
+  "title": "ScenarioDefinition (scenario schema v1.1)",
+  "$comment": "Scenario file format v1.1 (issue #214; connectionTrigger node and csmsCallTrigger payload condition added by issue #240). Mirrors src/cp/application/scenario/ScenarioTypes.ts. See docs/scenario-format.md for the field overview and versioning rules. This is a first published contract: it is STRICT on known fields (types, required-ness, closed-vocabulary enums) but PERMISSIVE on unknown keys at every object level (additionalProperties: true) — real editor exports carry xyflow UI fields (width/height/selected/style/...) that this schema deliberately does not reject. Validation against this schema is advisory only in this version: the simulator warns on a mismatch but never refuses to load a file.",
   "type": "object",
   "additionalProperties": true,
   "required": ["id", "name", "targetType", "nodes", "edges"],
   "properties": {
     "schemaVersion": {
       "type": "string",
-      "description": "Scenario schema version, e.g. \"1.0\". Optional: absent on files predating issue #214."
+      "description": "Scenario schema version, e.g. \"1.0\" or \"1.1\". Optional: absent on files predating issue #214. Not constrained to a single value — older schemaVersion strings (e.g. \"1.0\") remain valid since 1.x is purely additive."
     },
     "strictCompatibility": {
       "type": "boolean",
@@ -213,7 +213,8 @@
             "csmsCallTrigger",
             "responseOverride",
             "inboundPolicy",
-            "certQuirks"
+            "certQuirks",
+            "connectionTrigger"
           ]
         },
         "position": { "$ref": "#/$defs/position" },
@@ -351,6 +352,24 @@
                 "required": ["action"],
                 "properties": {
                   "action": { "type": "string" },
+                  "timeout": { "type": "number" },
+                  "payload": { "type": "object" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "connectionTrigger" } } },
+          "then": {
+            "properties": {
+              "data": {
+                "required": ["event"],
+                "properties": {
+                  "event": {
+                    "type": "string",
+                    "enum": ["connected", "disconnected"]
+                  },
                   "timeout": { "type": "number" }
                 }
               }

--- a/src/cli/exportK6/__tests__/interpreter.test.ts
+++ b/src/cli/exportK6/__tests__/interpreter.test.ts
@@ -405,6 +405,33 @@ describe("runScenario", () => {
     expect(events.length).toBe(0); // both calls were consumed by the re-arm loop
   });
 
+  it("csmsCallTrigger rejects a malformed payload condition like the CP runtime", async () => {
+    const host = new FakeHost();
+    host.waitForCsmsCall = async () => {
+      throw new Error("must not wait — the malformed condition fails first");
+    };
+    const s = scenario(
+      [
+        { id: "a", type: "start" },
+        {
+          id: "b",
+          type: "csmsCallTrigger",
+          data: { action: "Reset", payload: "Hard", timeout: 0 },
+        },
+        { id: "c", type: "end" },
+      ],
+      [
+        ["a", "b"],
+        ["b", "c"],
+      ],
+    );
+    const result = await runScenario(host, wire16, s);
+    expect(result.completed).toBe(false);
+    expect(result.error).toMatch(
+      /csmsCallTrigger\(Reset\): payload condition must be a JSON object/,
+    );
+  });
+
   it("errors when the scenario has no start node", async () => {
     const host = new FakeHost();
     const result = await runScenario(

--- a/src/cli/exportK6/__tests__/interpreter.test.ts
+++ b/src/cli/exportK6/__tests__/interpreter.test.ts
@@ -362,6 +362,49 @@ describe("runScenario", () => {
     expect(sent?.payload).toEqual({});
   });
 
+  it("csmsCallTrigger with a payload condition skips non-matching calls (#240)", async () => {
+    const host = new FakeHost();
+    const events: Array<{ action: string; payload: Record<string, unknown> }> =
+      [
+        {
+          action: "ChangeConfiguration",
+          payload: { key: "Other", value: "1" },
+        },
+        {
+          action: "ChangeConfiguration",
+          payload: { key: "HeartbeatInterval", value: "30" },
+        },
+      ];
+    // host.waitForCsmsCall hands back the next queued event each call.
+    host.waitForCsmsCall = async () => {
+      const evt = events.shift();
+      if (!evt) throw new Error("no more queued CSMS calls");
+      return evt;
+    };
+    const s = scenario(
+      [
+        { id: "a", type: "start" },
+        {
+          id: "b",
+          type: "csmsCallTrigger",
+          data: {
+            action: "ChangeConfiguration",
+            payload: { key: "HeartbeatInterval" },
+            timeout: 0,
+          },
+        },
+        { id: "c", type: "end" },
+      ],
+      [
+        ["a", "b"],
+        ["b", "c"],
+      ],
+    );
+    const result = await runScenario(host, wire16, s);
+    expect(result.completed).toBe(true);
+    expect(events.length).toBe(0); // both calls were consumed by the re-arm loop
+  });
+
   it("errors when the scenario has no start node", async () => {
     const host = new FakeHost();
     const result = await runScenario(

--- a/src/cli/exportK6/__tests__/runExportK6.test.ts
+++ b/src/cli/exportK6/__tests__/runExportK6.test.ts
@@ -136,6 +136,31 @@ describe("runExportK6", () => {
     expect(stderr.join("")).toMatch(/teleport/);
   });
 
+  it("fails on a connectionTrigger node (#240, not yet supported by export)", async () => {
+    const bad = {
+      ...VALID,
+      nodes: [
+        ...VALID.nodes,
+        {
+          id: "y",
+          type: "connectionTrigger",
+          position: { x: 0, y: 0 },
+          data: { label: "Y" },
+        },
+      ],
+    };
+    const code = await runExportK6({
+      scenarioFile: writeScenario(bad),
+      outDir: join(dir, "out"),
+      ocppVersion: "1.6",
+      force: false,
+    });
+    expect(code).toBe(1);
+    expect(stderr.join("")).toContain(
+      'unsupported node type "connectionTrigger"',
+    );
+  });
+
   it("fails on a missing start node", async () => {
     const bad = {
       ...VALID,

--- a/src/cli/exportK6/runtime/assertions.ts
+++ b/src/cli/exportK6/runtime/assertions.ts
@@ -55,8 +55,10 @@ function done(id: string, ok: boolean, detail: string): AssertionOutcome {
  * (extra keys in `actual` are ignored); arrays must be the same length and
  * are compared element-by-element -- pinning an array generally means the
  * whole array, not just a prefix.
+ *
+ * Kept in sync by src/scenario/__tests__/deepPartialMatch.test.ts.
  */
-function deepPartialMatch(subset: unknown, actual: unknown): boolean {
+export function deepPartialMatch(subset: unknown, actual: unknown): boolean {
   if (subset === actual) return true;
   if (
     typeof subset !== "object" ||

--- a/src/cli/exportK6/runtime/interpreter.ts
+++ b/src/cli/exportK6/runtime/interpreter.ts
@@ -2,6 +2,7 @@
 // Executes a ScenarioDefinition's node/edge graph against a ScenarioHost.
 // Semantics mirror src/cp/application/scenario/ScenarioExecutor.ts, reduced
 // to what a load-test CP needs (no pause/step/resume, no persistence).
+import { deepPartialMatch } from "./assertions";
 import {
   bool,
   num,
@@ -236,8 +237,20 @@ async function executeNode(
       const action = str(d.action);
       if (!action)
         throw new Error(`csmsCallTrigger node ${node.id} has no action`);
-      await host.waitForCsmsCall([action], timeoutMs());
-      return;
+      // #240: optional payload condition — re-arm the waiter until a call
+      // of the action arrives whose payload deep-partially matches.
+      const subset =
+        d.payload && typeof d.payload === "object" && !Array.isArray(d.payload)
+          ? (d.payload as Record<string, unknown>)
+          : null;
+      const tm = timeoutMs();
+      const deadline = tm === null ? null : Date.now() + tm;
+      for (;;) {
+        const remaining =
+          deadline === null ? null : Math.max(0, deadline - Date.now());
+        const evt = await host.waitForCsmsCall([action], remaining);
+        if (!subset || deepPartialMatch(subset, evt.payload)) return;
+      }
     }
     case "reserveNow":
       await notifyStatus("Reserved");

--- a/src/cli/exportK6/runtime/interpreter.ts
+++ b/src/cli/exportK6/runtime/interpreter.ts
@@ -238,11 +238,22 @@ async function executeNode(
       if (!action)
         throw new Error(`csmsCallTrigger node ${node.id} has no action`);
       // #240: optional payload condition — re-arm the waiter until a call
-      // of the action arrives whose payload deep-partially matches.
-      const subset =
-        d.payload && typeof d.payload === "object" && !Array.isArray(d.payload)
-          ? (d.payload as Record<string, unknown>)
-          : null;
+      // of the action arrives whose payload deep-partially matches. A
+      // malformed condition fails fast with the same message as the CP
+      // runtime (ScenarioExecutor.executeCsmsCallTrigger) so a hand-edited
+      // bundle scenario.json cannot silently run with a weaker condition
+      // than the author wrote.
+      if (
+        d.payload !== undefined &&
+        (typeof d.payload !== "object" ||
+          d.payload === null ||
+          Array.isArray(d.payload))
+      ) {
+        throw new Error(
+          `csmsCallTrigger(${action}): payload condition must be a JSON object`,
+        );
+      }
+      const subset = (d.payload as Record<string, unknown> | undefined) ?? null;
       const tm = timeoutMs();
       const deadline = tm === null ? null : Date.now() + tm;
       for (;;) {

--- a/src/cli/server/__tests__/connectionTriggerScenario.bun.test.ts
+++ b/src/cli/server/__tests__/connectionTriggerScenario.bun.test.ts
@@ -31,6 +31,18 @@ import { startMockCsms } from "../../../cp/infrastructure/transport/__tests__/mo
  * A short `delay` node after "wait connected" keeps the executor in
  * `_executors` across that window, which is what actually exercises the
  * one-scenario-at-a-time gate. See task-8-report.md.
+ *
+ * Fix round 1: a lone scenario A can't tell the cross-scenario active-check
+ * (service.ts:2161-2171) apart from `runScenario`'s own same-scenarioId
+ * reentrancy guard (service.ts:1099-1101, thrown and silently swallowed by
+ * the auto-start try/catch) — both inspect the same `_executors` entry for
+ * A, so either alone would keep `completed.runId` pinned to the original
+ * run. `scenarioB` is a second, distinct connect-triggered scenario loaded
+ * on the same connector (after A, so A remains the auto-start candidate
+ * that actually runs) purely as a bystander: it must never get a
+ * `scenario_status` while A is still live, which is the part of this test
+ * that actually depends on the connector-wide active-check rather than A's
+ * own single-scenario reentrancy path. See task-8-report.md fix round 1.
  */
 const CONNECTOR = 1;
 
@@ -78,6 +90,48 @@ const scenario = {
     { id: "e2", source: "wait-down", target: "wait-up" },
     { id: "e3", source: "wait-up", target: "hold-1" },
     { id: "e4", source: "hold-1", target: "end-1" },
+  ],
+  createdAt: "2026-08-03T00:00:00Z",
+  updatedAt: "2026-08-03T00:00:00Z",
+};
+
+/**
+ * A second, unrelated connect-triggered scenario on the same connector.
+ * Loaded after `scenario` so `scenario` remains the auto-start candidate
+ * that actually runs; this one exists purely to prove nothing else on the
+ * connector starts while `scenario`'s run is live — see fix round 1 in the
+ * header comment above.
+ */
+const scenarioB = {
+  id: "connection-trigger-bystander",
+  name: "Bystander connect-triggered scenario",
+  targetType: "connector",
+  targetId: CONNECTOR,
+  trigger: { type: "manual" },
+  enabled: true,
+  nodes: [
+    {
+      id: "b-start-1",
+      type: "start",
+      position: { x: 400, y: 0 },
+      data: { label: "Start", triggerOn: "connect" },
+    },
+    {
+      id: "b-sc-1",
+      type: "statusChange",
+      position: { x: 400, y: 1 },
+      data: { label: "Preparing", status: "Preparing" },
+    },
+    {
+      id: "b-end-1",
+      type: "end",
+      position: { x: 400, y: 2 },
+      data: { label: "End" },
+    },
+  ],
+  edges: [
+    { id: "be1", source: "b-start-1", target: "b-sc-1" },
+    { id: "be2", source: "b-sc-1", target: "b-end-1" },
   ],
   createdAt: "2026-08-03T00:00:00Z",
   updatedAt: "2026-08-03T00:00:00Z",
@@ -150,6 +204,22 @@ async function waitForScenarioState(
   throw new Error("timed out waiting for scenario state");
 }
 
+/** Single, non-polling `scenario_status` snapshot — null means the
+ *  scenario has never run (no live executor, no recorded terminal run). */
+async function getScenarioStatusOnce(
+  socket: Socket,
+  cpId: string,
+  scenarioId: string,
+): Promise<any> {
+  return (
+    await emitRpc(socket, {
+      cpId,
+      method: "scenario_status",
+      params: { connector: CONNECTOR, scenarioId },
+    })
+  ).result;
+}
+
 describe("connectionTrigger scenario over a real socket (#240)", () => {
   it("survives a disconnect/reconnect as one run and blocks the auto-start re-arm", async () => {
     const csms = startMockCsms();
@@ -181,6 +251,17 @@ describe("connectionTrigger scenario over a real socket (#240)", () => {
           })
         ).ok,
       ).toBe(true);
+      // Loaded after `scenario` so `scenario` stays the auto-start
+      // candidate that actually runs (see the header comment).
+      expect(
+        (
+          await emitRpc(socket, {
+            cpId,
+            method: "load_scenario",
+            params: { connector: CONNECTOR, scenario: scenarioB },
+          })
+        ).ok,
+      ).toBe(true);
 
       // Connect → auto-start → park on "wait disconnected" (CP is
       // connected, so the level check does not pass it through).
@@ -196,6 +277,11 @@ describe("connectionTrigger scenario over a real socket (#240)", () => {
       });
       const runId = parkedDown.runId;
       expect(runId).toBeTruthy();
+      // The bystander never got a look-in on the first connect either —
+      // "one scenario per connector per trigger" picked `scenario`, not it.
+      expect(
+        await getScenarioStatusOnce(socket, cpId, scenarioB.id),
+      ).toBeNull();
 
       // Drop the socket: wait-down resolves, wait-up parks — same run.
       expect(
@@ -221,6 +307,12 @@ describe("connectionTrigger scenario over a real socket (#240)", () => {
         (s) => s.state === "completed",
       );
       expect(completed.runId).toBe(runId);
+      // Across the whole disconnect/reconnect cycle — including the
+      // reconnect's connect-auto-start re-check while `scenario` was still
+      // live — the bystander never ran either.
+      expect(
+        await getScenarioStatusOnce(socket, cpId, scenarioB.id),
+      ).toBeNull();
     } finally {
       socket.disconnect();
     }

--- a/src/cli/server/__tests__/connectionTriggerScenario.bun.test.ts
+++ b/src/cli/server/__tests__/connectionTriggerScenario.bun.test.ts
@@ -1,0 +1,228 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- ack payloads are loosely typed in tests */
+import { afterEach, describe, expect, it } from "bun:test";
+import type { Socket } from "socket.io-client";
+
+import {
+  connectTestClient,
+  startTestServer,
+  type TestServer,
+} from "./socketHarness";
+import { startMockCsms } from "../../../cp/infrastructure/transport/__tests__/mockCsms";
+
+/**
+ * #240 connectionTrigger over a real socket: a connect-started run parks on
+ * "wait disconnected", survives the drop, parks on "wait connected", and
+ * finishes after the reconnect — as ONE run. The same test pins the
+ * reconnect auto-start skip (service.ts one-scenario-at-a-time): if the
+ * re-arm restarted the scenario, the runId would change.
+ *
+ * Deviation from the task-8 brief: a bare `wait-up -> end` graph raced the
+ * reconnect auto-start check and lost every time, deterministically, not
+ * flakily. `ChargePoint.connect()` fires the "connected" event synchronously
+ * off the raw WebSocket open, before BootNotification.req is even answered
+ * (see ChargePoint.ts connect()) — so "wait connected" always resolves and
+ * the run always reaches "end" (dropping out of `_executors`) well before
+ * BootNotification.conf comes back and `handleConnectAutoStart` re-checks
+ * the connector. By then `lastAutoStartedScenarioKey` has already been
+ * cleared by the mid-run disconnect's `teardownAfterClose`, so nothing
+ * blocks a second auto-start — this is the "reconnect auto-start SKIPPING
+ * the still-live run" property the test exists to pin, and the literal
+ * brief graph never lets the run still be live at the moment that matters.
+ * A short `delay` node after "wait connected" keeps the executor in
+ * `_executors` across that window, which is what actually exercises the
+ * one-scenario-at-a-time gate. See task-8-report.md.
+ */
+const CONNECTOR = 1;
+
+const scenario = {
+  id: "connection-trigger-scenario",
+  name: "Survive a reconnect via connection waits",
+  targetType: "connector",
+  targetId: CONNECTOR,
+  trigger: { type: "manual" },
+  enabled: true,
+  nodes: [
+    {
+      id: "start-1",
+      type: "start",
+      position: { x: 0, y: 0 },
+      data: { label: "Start", triggerOn: "connect" },
+    },
+    {
+      id: "wait-down",
+      type: "connectionTrigger",
+      position: { x: 0, y: 1 },
+      data: { label: "Wait disconnect", event: "disconnected", timeout: 0 },
+    },
+    {
+      id: "wait-up",
+      type: "connectionTrigger",
+      position: { x: 0, y: 2 },
+      data: { label: "Wait reconnect", event: "connected", timeout: 0 },
+    },
+    {
+      id: "hold-1",
+      type: "delay",
+      position: { x: 0, y: 3 },
+      data: { label: "Hold past boot-accept", delaySeconds: 0.3 },
+    },
+    {
+      id: "end-1",
+      type: "end",
+      position: { x: 0, y: 4 },
+      data: { label: "End" },
+    },
+  ],
+  edges: [
+    { id: "e1", source: "start-1", target: "wait-down" },
+    { id: "e2", source: "wait-down", target: "wait-up" },
+    { id: "e3", source: "wait-up", target: "hold-1" },
+    { id: "e4", source: "hold-1", target: "end-1" },
+  ],
+  createdAt: "2026-08-03T00:00:00Z",
+  updatedAt: "2026-08-03T00:00:00Z",
+};
+
+const servers: TestServer[] = [];
+const csmsList: ReturnType<typeof startMockCsms>[] = [];
+
+afterEach(async () => {
+  while (servers.length > 0) await servers.pop()?.close();
+  while (csmsList.length > 0) await csmsList.pop()?.stop();
+});
+
+function emitRpc(socket: Socket, request: unknown): Promise<any> {
+  return socket.timeout(5_000).emitWithAck("rpc", request);
+}
+
+/**
+ * Connect and answer the BootNotification so the CP reaches Available.
+ *
+ * mockCsms.waitForCall resolves against frames it has ALREADY received, so on
+ * the second connect it would hand back the first boot's messageId and we'd
+ * answer a dead request. Watch for a boot frame past the ones already seen.
+ */
+async function connectAndBoot(
+  socket: Socket,
+  cpId: string,
+  csms: ReturnType<typeof startMockCsms>,
+): Promise<void> {
+  const seenBefore = csms.received.length;
+  const connectAck = emitRpc(socket, { cpId, method: "connect", params: {} });
+
+  const deadline = Date.now() + 5_000;
+  let boot: { messageId: string } | null = null;
+  while (Date.now() < deadline && !boot) {
+    const frame = csms.received
+      .slice(seenBefore)
+      .find((f) => f[0] === 2 && f[2] === "BootNotification");
+    if (frame) boot = { messageId: frame[1] as string };
+    else await new Promise((r) => setTimeout(r, 20));
+  }
+  if (!boot) throw new Error("no new BootNotification after connect");
+
+  csms.replyCallResult(boot.messageId, {
+    currentTime: new Date(0).toISOString(),
+    interval: 300,
+    status: "Accepted",
+  });
+  await connectAck;
+}
+
+async function waitForScenarioState(
+  socket: Socket,
+  cpId: string,
+  predicate: (status: any) => boolean,
+  timeoutMs = 5_000,
+): Promise<any> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const status = (
+      await emitRpc(socket, {
+        cpId,
+        method: "scenario_status",
+        params: { connector: CONNECTOR, scenarioId: scenario.id },
+      })
+    ).result;
+    if (status && predicate(status)) return status;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error("timed out waiting for scenario state");
+}
+
+describe("connectionTrigger scenario over a real socket (#240)", () => {
+  it("survives a disconnect/reconnect as one run and blocks the auto-start re-arm", async () => {
+    const csms = startMockCsms();
+    csmsList.push(csms);
+    const server = await startTestServer();
+    servers.push(server);
+    const socket = await connectTestClient(server);
+    const cpId = "CPCONNTRIG";
+
+    try {
+      server.registry.create(
+        {
+          cpId,
+          wsUrl: csms.url,
+          connectors: 1,
+          vendor: "test",
+          model: "test",
+          basicAuth: null,
+        },
+        { seedDefault: false },
+      );
+
+      expect(
+        (
+          await emitRpc(socket, {
+            cpId,
+            method: "load_scenario",
+            params: { connector: CONNECTOR, scenario },
+          })
+        ).ok,
+      ).toBe(true);
+
+      // Connect → auto-start → park on "wait disconnected" (CP is
+      // connected, so the level check does not pass it through).
+      await connectAndBoot(socket, cpId, csms);
+      const parkedDown = await waitForScenarioState(
+        socket,
+        cpId,
+        (s) => s.state === "waiting" && s.currentNodeId === "wait-down",
+      );
+      expect(parkedDown.expectation).toMatchObject({
+        type: "connection",
+        event: "disconnected",
+      });
+      const runId = parkedDown.runId;
+      expect(runId).toBeTruthy();
+
+      // Drop the socket: wait-down resolves, wait-up parks — same run.
+      expect(
+        (await emitRpc(socket, { cpId, method: "disconnect", params: {} })).ok,
+      ).toBe(true);
+      const parkedUp = await waitForScenarioState(
+        socket,
+        cpId,
+        (s) => s.state === "waiting" && s.currentNodeId === "wait-up",
+      );
+      expect(parkedUp.expectation).toMatchObject({
+        type: "connection",
+        event: "connected",
+      });
+      expect(parkedUp.runId).toBe(runId);
+
+      // Reconnect: the run completes; the auto-start re-arm must NOT have
+      // started a second run (runId unchanged all the way to completed).
+      await connectAndBoot(socket, cpId, csms);
+      const completed = await waitForScenarioState(
+        socket,
+        cpId,
+        (s) => s.state === "completed",
+      );
+      expect(completed.runId).toBe(runId);
+    } finally {
+      socket.disconnect();
+    }
+  }, 30_000);
+});

--- a/src/cli/server/__tests__/connectionTriggerScenario.bun.test.ts
+++ b/src/cli/server/__tests__/connectionTriggerScenario.bun.test.ts
@@ -10,43 +10,49 @@ import {
 import { startMockCsms } from "../../../cp/infrastructure/transport/__tests__/mockCsms";
 
 /**
- * #240 connectionTrigger over a real socket: a connect-started run parks on
- * "wait disconnected", survives the drop, parks on "wait connected", and
- * finishes after the reconnect — as ONE run. The same test pins the
- * reconnect auto-start skip (service.ts one-scenario-at-a-time): if the
- * re-arm restarted the scenario, the runId would change.
+ * #240 connectionTrigger over a real socket: a run started via run_scenario
+ * parks on "wait disconnected", survives a disconnect/reconnect cycle,
+ * parks on "wait connected", and finishes after the reconnect — as ONE run
+ * (runId constant throughout). The same test pins the connector-wide
+ * one-scenario-at-a-time gate in tryAutoStartForConnector
+ * (service.ts:2161-2171): while scenario A's run is still live, the
+ * reconnect's connect-auto-start must NOT re-run bystander scenario B.
  *
- * Deviation from the task-8 brief: a bare `wait-up -> end` graph raced the
- * reconnect auto-start check and lost every time, deterministically, not
- * flakily. `ChargePoint.connect()` fires the "connected" event synchronously
- * off the raw WebSocket open, before BootNotification.req is even answered
- * (see ChargePoint.ts connect()) — so "wait connected" always resolves and
- * the run always reaches "end" (dropping out of `_executors`) well before
- * BootNotification.conf comes back and `handleConnectAutoStart` re-checks
- * the connector. By then `lastAutoStartedScenarioKey` has already been
- * cleared by the mid-run disconnect's `teardownAfterClose`, so nothing
- * blocks a second auto-start — this is the "reconnect auto-start SKIPPING
- * the still-live run" property the test exists to pin, and the literal
- * brief graph never lets the run still be live at the moment that matters.
- * A short `delay` node after "wait connected" keeps the executor in
- * `_executors` across that window, which is what actually exercises the
- * one-scenario-at-a-time gate. See task-8-report.md.
+ * Why B has to be a real, separate connect-triggered scenario, loaded
+ * FIRST: tryAutoStartForConnector iterates loaded scenarios in Map
+ * insertion order, and once a candidate passes its trigger-shape filters
+ * every outcome (start / blocked-by-active / blocked-by-dedup / caught
+ * exception from runScenario) ends in an unconditional `return` — it never
+ * falls through to try a later scenario. So whichever connect-triggered
+ * scenario is loaded FIRST permanently shadows every later one for
+ * auto-start purposes. B is loaded before A specifically so B — not A — is
+ * that first (and only) auto-start candidate; A is started manually via
+ * run_scenario and is otherwise inert as far as tryAutoStartForConnector is
+ * concerned (Map-order shadowed, it's never even examined).
  *
- * Fix round 1: a lone scenario A can't tell the cross-scenario active-check
- * (service.ts:2161-2171) apart from `runScenario`'s own same-scenarioId
- * reentrancy guard (service.ts:1099-1101, thrown and silently swallowed by
- * the auto-start try/catch) — both inspect the same `_executors` entry for
- * A, so either alone would keep `completed.runId` pinned to the original
- * run. `scenarioB` is a second, distinct connect-triggered scenario loaded
- * on the same connector (after A, so A remains the auto-start candidate
- * that actually runs) purely as a bystander: it must never get a
- * `scenario_status` while A is still live, which is the part of this test
- * that actually depends on the connector-wide active-check rather than A's
- * own single-scenario reentrancy path. See task-8-report.md fix round 1.
+ * That shadowing is what makes the final assertion discriminating: on the
+ * reconnect's boot-accept, B is the candidate examined, its dedup key has
+ * just been cleared by the disconnect's teardownAfterClose (so the dedup
+ * `return` doesn't block it), and B itself isn't running (so runScenario's
+ * own same-scenarioId reentrancy guard doesn't apply to B either) — the
+ * ONLY thing standing between B and a second run is the active-loop at
+ * 2161-2171 seeing A's still-live executor. A is deliberately held in a
+ * `delay` node for ~300ms past the socket reopening, well past the
+ * ~20-30ms BootNotification round trip, so it is still "active" at the
+ * exact moment that check runs. Delete that loop and B gets a second runId
+ * right here — a loud, specific failure, not a silently-swallowed one.
+ *
+ * This is the complement of scenarioRearmOnReconnect.bun.test.ts (#253):
+ * that test proves a connect-triggered scenario DOES re-arm after a
+ * reconnect when nothing else on the connector is running; this one proves
+ * it does NOT when something else still is.
+ *
+ * Test history: see task-8-report.md (original task-8 brief, plus two
+ * review fix rounds) for how this test's shape evolved and why.
  */
 const CONNECTOR = 1;
 
-const scenario = {
+const scenarioA = {
   id: "connection-trigger-scenario",
   name: "Survive a reconnect via connection waits",
   targetType: "connector",
@@ -58,6 +64,11 @@ const scenario = {
       id: "start-1",
       type: "start",
       position: { x: 0, y: 0 },
+      // triggerOn is irrelevant to how A itself gets started here (it's
+      // always started manually, via run_scenario) — spelled out anyway
+      // since Map-order shadowing depends on A having the same trigger
+      // shape B does, so A really would be a "connect" auto-start
+      // candidate if B didn't shadow it.
       data: { label: "Start", triggerOn: "connect" },
     },
     {
@@ -96,11 +107,10 @@ const scenario = {
 };
 
 /**
- * A second, unrelated connect-triggered scenario on the same connector.
- * Loaded after `scenario` so `scenario` remains the auto-start candidate
- * that actually runs; this one exists purely to prove nothing else on the
- * connector starts while `scenario`'s run is live — see fix round 1 in the
- * header comment above.
+ * A quick connect-triggered scenario, loaded BEFORE A so it — not A — is
+ * the Map-insertion-order auto-start candidate (see header comment). Node
+ * shape mirrors scenarioRearmOnReconnect.bun.test.ts's own scenario:
+ * start -> statusChange "Preparing" -> end, nothing that waits.
  */
 const scenarioB = {
   id: "connection-trigger-bystander",
@@ -195,7 +205,7 @@ async function waitForScenarioState(
       await emitRpc(socket, {
         cpId,
         method: "scenario_status",
-        params: { connector: CONNECTOR, scenarioId: scenario.id },
+        params: { connector: CONNECTOR, scenarioId: scenarioA.id },
       })
     ).result;
     if (status && predicate(status)) return status;
@@ -204,24 +214,35 @@ async function waitForScenarioState(
   throw new Error("timed out waiting for scenario state");
 }
 
-/** Single, non-polling `scenario_status` snapshot — null means the
- *  scenario has never run (no live executor, no recorded terminal run). */
-async function getScenarioStatusOnce(
+/** Poll scenario_report for `scenarioId` until a run whose id isn't
+ *  `previousRunId` shows up (adapted from scenarioRearmOnReconnect's
+ *  version, generalized to take the scenarioId explicitly since this file
+ *  tracks two scenarios' runs). */
+async function waitForRunAfter(
   socket: Socket,
   cpId: string,
   scenarioId: string,
-): Promise<any> {
-  return (
-    await emitRpc(socket, {
-      cpId,
-      method: "scenario_status",
-      params: { connector: CONNECTOR, scenarioId },
-    })
-  ).result;
+  previousRunId: string | null,
+  timeoutMs = 5_000,
+): Promise<string | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const report = (
+      await emitRpc(socket, {
+        cpId,
+        method: "scenario_report",
+        params: { connector: CONNECTOR, scenarioId },
+      })
+    ).result;
+    const runId = report?.runId ?? null;
+    if (runId && runId !== previousRunId) return runId;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return null;
 }
 
 describe("connectionTrigger scenario over a real socket (#240)", () => {
-  it("survives a disconnect/reconnect as one run and blocks the auto-start re-arm", async () => {
+  it("survives a disconnect/reconnect as one run and blocks the cross-scenario auto-start re-arm", async () => {
     const csms = startMockCsms();
     csmsList.push(csms);
     const server = await startTestServer();
@@ -242,17 +263,8 @@ describe("connectionTrigger scenario over a real socket (#240)", () => {
         { seedDefault: false },
       );
 
-      expect(
-        (
-          await emitRpc(socket, {
-            cpId,
-            method: "load_scenario",
-            params: { connector: CONNECTOR, scenario },
-          })
-        ).ok,
-      ).toBe(true);
-      // Loaded after `scenario` so `scenario` stays the auto-start
-      // candidate that actually runs (see the header comment).
+      // B loaded FIRST: Map insertion order makes it the sole connect-
+      // auto-start candidate (see header comment).
       expect(
         (
           await emitRpc(socket, {
@@ -262,10 +274,41 @@ describe("connectionTrigger scenario over a real socket (#240)", () => {
           })
         ).ok,
       ).toBe(true);
+      // A loaded SECOND: Map-order shadowed, so it never auto-starts even
+      // though its own Start node also opts into triggerOn "connect". A is
+      // started manually below.
+      expect(
+        (
+          await emitRpc(socket, {
+            cpId,
+            method: "load_scenario",
+            params: { connector: CONNECTOR, scenario: scenarioA },
+          })
+        ).ok,
+      ).toBe(true);
 
-      // Connect → auto-start → park on "wait disconnected" (CP is
-      // connected, so the level check does not pass it through).
+      // Connect → B is the only auto-start candidate → it runs to
+      // completion immediately (no waits in its graph).
       await connectAndBoot(socket, cpId, csms);
+      const bystanderRunId1 = await waitForRunAfter(
+        socket,
+        cpId,
+        scenarioB.id,
+        null,
+      );
+      expect(bystanderRunId1).not.toBeNull();
+
+      // Start A manually — it would never get picked by auto-start while
+      // B is loaded first.
+      expect(
+        (
+          await emitRpc(socket, {
+            cpId,
+            method: "run_scenario",
+            params: { connector: CONNECTOR, scenarioId: scenarioA.id },
+          })
+        ).ok,
+      ).toBe(true);
       const parkedDown = await waitForScenarioState(
         socket,
         cpId,
@@ -277,13 +320,12 @@ describe("connectionTrigger scenario over a real socket (#240)", () => {
       });
       const runId = parkedDown.runId;
       expect(runId).toBeTruthy();
-      // The bystander never got a look-in on the first connect either —
-      // "one scenario per connector per trigger" picked `scenario`, not it.
-      expect(
-        await getScenarioStatusOnce(socket, cpId, scenarioB.id),
-      ).toBeNull();
 
       // Drop the socket: wait-down resolves, wait-up parks — same run.
+      // teardownAfterClose also clears connector.lastAutoStartedScenarioKey
+      // here, re-arming B's dedup key exactly as the #253 rearm test
+      // expects for the idle case — this test complements it for the case
+      // where something else (A) is still live.
       expect(
         (await emitRpc(socket, { cpId, method: "disconnect", params: {} })).ok,
       ).toBe(true);
@@ -298,8 +340,11 @@ describe("connectionTrigger scenario over a real socket (#240)", () => {
       });
       expect(parkedUp.runId).toBe(runId);
 
-      // Reconnect: the run completes; the auto-start re-arm must NOT have
-      // started a second run (runId unchanged all the way to completed).
+      // Reconnect: the boot-accept re-fires connect-auto-start with B (not
+      // A) as the sole Map-order candidate. B's dedup key was just
+      // cleared, and B itself isn't running — the active-loop seeing A's
+      // still-live executor (parked in the delay node) is the only thing
+      // that can stop B from re-running here.
       await connectAndBoot(socket, cpId, csms);
       const completed = await waitForScenarioState(
         socket,
@@ -307,12 +352,19 @@ describe("connectionTrigger scenario over a real socket (#240)", () => {
         (s) => s.state === "completed",
       );
       expect(completed.runId).toBe(runId);
-      // Across the whole disconnect/reconnect cycle — including the
-      // reconnect's connect-auto-start re-check while `scenario` was still
-      // live — the bystander never ran either.
-      expect(
-        await getScenarioStatusOnce(socket, cpId, scenarioB.id),
-      ).toBeNull();
+
+      // Discriminating assertion: B is still on its first run. If
+      // service.ts:2161-2171's active-loop were deleted, B would have
+      // re-started on the reconnect's boot-accept and this would observe a
+      // new runId.
+      const bystanderReport = (
+        await emitRpc(socket, {
+          cpId,
+          method: "scenario_report",
+          params: { connector: CONNECTOR, scenarioId: scenarioB.id },
+        })
+      ).result;
+      expect(bystanderReport?.runId).toBe(bystanderRunId1);
     } finally {
       socket.disconnect();
     }

--- a/src/components/scenario/ScenarioEditor.tsx
+++ b/src/components/scenario/ScenarioEditor.tsx
@@ -91,6 +91,7 @@ import StatusNotificationNode from "./nodes/StatusNotificationNode";
 import UnlockOutcomeNode from "./nodes/UnlockOutcomeNode";
 import ConfigSetNode from "./nodes/ConfigSetNode";
 import DataTransferNode from "./nodes/DataTransferNode";
+import ConnectionTriggerNode from "./nodes/ConnectionTriggerNode";
 
 import {
   exportScenarioToJSON,
@@ -209,6 +210,7 @@ const nodeTypes: NodeTypes = {
   [ScenarioNodeType.UNLOCK_OUTCOME]: UnlockOutcomeNode,
   [ScenarioNodeType.CONFIG_SET]: ConfigSetNode,
   [ScenarioNodeType.DATA_TRANSFER]: DataTransferNode,
+  [ScenarioNodeType.CONNECTION_TRIGGER]: ConnectionTriggerNode,
   [ScenarioNodeType.START]: StartScenarioNode,
   [ScenarioNodeType.END]: EndScenarioNode,
 };
@@ -1985,6 +1987,11 @@ const ScenarioEditor: React.FC<ScenarioEditorProps> = ({
                 icon="📥"
               />
               <NodePaletteItem
+                type={ScenarioNodeType.CONNECTION_TRIGGER}
+                label="Connection"
+                icon="🔗"
+              />
+              <NodePaletteItem
                 type={ScenarioNodeType.RESPONSE_OVERRIDE}
                 label="Override"
                 icon="🚫"
@@ -2239,6 +2246,17 @@ function createNodeByType(
         type,
         position,
         data: { label: "Wait for CSMS Call", action: "Reset", timeout: 0 },
+      };
+    case ScenarioNodeType.CONNECTION_TRIGGER:
+      return {
+        id,
+        type,
+        position,
+        data: {
+          label: "Wait for Disconnect",
+          event: "disconnected",
+          timeout: 0,
+        },
       };
     case ScenarioNodeType.RESPONSE_OVERRIDE:
       return {

--- a/src/components/scenario/forms/ConnectionTriggerForm.tsx
+++ b/src/components/scenario/forms/ConnectionTriggerForm.tsx
@@ -1,0 +1,38 @@
+import { NumberField, SelectField, TextField } from "./FormFields";
+import type { NodeFormComponentProps, NodeFormData } from "./types";
+
+export default function ConnectionTriggerForm({
+  value,
+  onChange,
+}: NodeFormComponentProps<NodeFormData>) {
+  return (
+    <div className="space-y-3">
+      <TextField
+        label="Label"
+        value={(value.label as string | undefined) ?? ""}
+        onChange={(label) => onChange({ ...value, label })}
+      />
+      <SelectField
+        label="Event"
+        value={(value.event as string | undefined) ?? "disconnected"}
+        onChange={(event) => onChange({ ...value, event })}
+        options={[
+          { value: "disconnected", label: "Disconnected" },
+          { value: "connected", label: "Connected" },
+        ]}
+      />
+      <div>
+        <NumberField
+          label="Timeout (seconds)"
+          value={typeof value.timeout === "number" ? value.timeout : 0}
+          onChange={(timeout) => onChange({ ...value, timeout: timeout ?? 0 })}
+          min={0}
+        />
+        <p className="text-xs text-muted mt-1">
+          0 = No timeout. Resolves immediately if the charge point is already in
+          the selected state.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scenario/forms/CsmsCallTriggerForm.tsx
+++ b/src/components/scenario/forms/CsmsCallTriggerForm.tsx
@@ -1,6 +1,18 @@
-import { NumberField, SelectField, TextField } from "./FormFields";
+import {
+  NumberField,
+  SelectField,
+  TextareaField,
+  TextField,
+} from "./FormFields";
 import type { NodeFormComponentProps, NodeFormData } from "./types";
 import { CSMS_CALL_TRIGGER_ACTIONS } from "../../../cp/application/scenario/ScenarioTypes";
+
+function payloadText(payload: unknown): string {
+  if (payload === undefined) return "";
+  return typeof payload === "string"
+    ? payload
+    : JSON.stringify(payload || {}, null, 2);
+}
 
 export default function CsmsCallTriggerForm({
   value,
@@ -33,6 +45,23 @@ export default function CsmsCallTriggerForm({
         />
         <p className="text-xs text-muted mt-1">
           0 = No timeout (wait indefinitely for CSMS call)
+        </p>
+      </div>
+      <div>
+        <TextareaField
+          label="Payload condition (JSON, optional)"
+          value={payloadText(value.payload)}
+          onChange={(payload) => {
+            try {
+              onChange({ ...value, payload: JSON.parse(payload) });
+            } catch {
+              onChange({ ...value, payload });
+            }
+          }}
+          placeholder='{"key": "HeartbeatInterval"}'
+        />
+        <p className="text-xs text-muted mt-1">
+          Partial match against the incoming call payload. Empty = any payload.
         </p>
       </div>
     </div>

--- a/src/components/scenario/forms/nodeFormRegistry.ts
+++ b/src/components/scenario/forms/nodeFormRegistry.ts
@@ -115,6 +115,16 @@ function asCsmsCallTriggerAction(
     : "Reset";
 }
 
+/** #240: keep only a plain-object payload condition; anything else
+ *  (unparsed textarea string, array) is dropped on save. */
+function asPayloadCondition(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
 const RESPONSE_OVERRIDE_ACTIONS_SET = new Set<string>(
   RESPONSE_OVERRIDE_ACTIONS,
 );
@@ -625,6 +635,7 @@ function csmsCallTriggerNodeDataToForm(
     timeout: optionalNumber(
       (nodeData as Partial<CsmsCallTriggerNodeData>).timeout,
     ),
+    payload: (nodeData as Partial<CsmsCallTriggerNodeData>).payload,
   });
 }
 
@@ -635,6 +646,7 @@ function csmsCallTriggerFormToNodeData(
     ...baseFromForm(formData),
     action: asCsmsCallTriggerAction(formData.action),
     timeout: optionalNumber(formData.timeout),
+    payload: asPayloadCondition(formData.payload),
   }) as CsmsCallTriggerNodeData;
 }
 

--- a/src/components/scenario/forms/nodeFormRegistry.ts
+++ b/src/components/scenario/forms/nodeFormRegistry.ts
@@ -4,6 +4,7 @@ import {
   CERT_SIGNATURE_ALGORITHMS,
   type CertQuirksNodeData,
   type ConfigSetNodeData,
+  type ConnectionTriggerNodeData,
   type ConnectorPlugNodeData,
   CSMS_CALL_TRIGGER_ACTIONS,
   type CsmsCallTriggerNodeData,
@@ -35,6 +36,7 @@ import type { CurvePoint } from "../../../cp/domain/connector/MeterValueCurve";
 import CancelReservationForm from "./CancelReservationForm";
 import CertQuirksForm from "./CertQuirksForm";
 import ConfigSetForm from "./ConfigSetForm";
+import ConnectionTriggerForm from "./ConnectionTriggerForm";
 import ConnectorPlugForm from "./ConnectorPlugForm";
 import CsmsCallTriggerForm from "./CsmsCallTriggerForm";
 import DataTransferForm from "./DataTransferForm";
@@ -775,6 +777,36 @@ function certQuirksFormToNodeData(formData: NodeFormData): CertQuirksNodeData {
   }) as CertQuirksNodeData;
 }
 
+function asConnectionTriggerEvent(
+  value: unknown,
+): ConnectionTriggerNodeData["event"] {
+  return value === "connected" ? "connected" : "disconnected";
+}
+
+function connectionTriggerNodeDataToForm(
+  nodeData: ScenarioNodeData,
+): NodeFormData {
+  return compactDefined({
+    ...baseToForm(nodeData),
+    event: asConnectionTriggerEvent(
+      (nodeData as Partial<ConnectionTriggerNodeData>).event,
+    ),
+    timeout: optionalNumber(
+      (nodeData as Partial<ConnectionTriggerNodeData>).timeout,
+    ),
+  });
+}
+
+function connectionTriggerFormToNodeData(
+  formData: NodeFormData,
+): ConnectionTriggerNodeData {
+  return compactDefined({
+    ...baseFromForm(formData),
+    event: asConnectionTriggerEvent(formData.event),
+    timeout: optionalNumber(formData.timeout),
+  }) as ConnectionTriggerNodeData;
+}
+
 export const NODE_FORM_REGISTRY = {
   [ScenarioNodeType.STATUS_CHANGE]: {
     title: "Status Change",
@@ -907,6 +939,12 @@ export const NODE_FORM_REGISTRY = {
     Component: DataTransferForm,
     nodeDataToForm: dataTransferNodeDataToForm,
     formToNodeData: dataTransferFormToNodeData,
+  },
+  [ScenarioNodeType.CONNECTION_TRIGGER]: {
+    title: "Connection Trigger",
+    Component: ConnectionTriggerForm,
+    nodeDataToForm: connectionTriggerNodeDataToForm,
+    formToNodeData: connectionTriggerFormToNodeData,
   },
 } satisfies Record<ScenarioNodeType, NodeFormEntry>;
 

--- a/src/components/scenario/nodes/ConnectionTriggerNode.tsx
+++ b/src/components/scenario/nodes/ConnectionTriggerNode.tsx
@@ -1,0 +1,71 @@
+import React, { memo } from "react";
+import { Handle, Position, NodeProps, type Node } from "@xyflow/react";
+import { ConnectionTriggerNodeData } from "../../../cp/application/scenario/ScenarioTypes";
+
+// Mapped type (not `extends`) so the result is a fresh object type that
+// satisfies xyflow v12's `Node<Record<string, unknown>>` constraint — a
+// plain interface-extending intersection does not.
+type ConnectionTriggerNodeDataWithProgress = {
+  [K in keyof ConnectionTriggerNodeData]: ConnectionTriggerNodeData[K];
+} & {
+  progress?: {
+    remaining: number;
+    total: number;
+  };
+};
+
+type ConnectionTriggerFlowNode = Node<ConnectionTriggerNodeDataWithProgress>;
+
+const ConnectionTriggerNode: React.FC<NodeProps<ConnectionTriggerFlowNode>> = ({
+  data,
+  selected,
+}) => {
+  const progress = data.progress;
+  const progressPercent = progress
+    ? ((progress.total - progress.remaining) / progress.total) * 100
+    : 0;
+
+  return (
+    <div
+      className={`px-4 py-3 rounded-lg border-2 bg-cyan-50 dark:bg-cyan-900 min-w-[180px] ${
+        selected ? "border-blue-500" : "border-cyan-400 dark:border-cyan-600"
+      }`}
+    >
+      <Handle type="target" position={Position.Top} className="w-3 h-3" />
+
+      <div className="text-xs font-semibold text-cyan-700 dark:text-cyan-300 mb-1">
+        Connection Trigger
+      </div>
+      <div className="font-bold text-sm text-primary mb-1">{data.label}</div>
+      <div className="text-xs text-muted mb-1">Waits for: {data.event}</div>
+      {data.timeout !== undefined && data.timeout > 0 && (
+        <div className="text-xs text-muted">
+          Timeout: {data.timeout}s
+          {progress && progress.remaining > 0 && (
+            <span className="ml-1 text-cyan-700 dark:text-cyan-300 font-semibold">
+              ({progress.remaining.toFixed(1)}s left)
+            </span>
+          )}
+        </div>
+      )}
+      {(!data.timeout || data.timeout === 0) && (
+        <div className="text-xs text-muted">No timeout</div>
+      )}
+
+      {progress && progress.remaining > 0 && (
+        <div className="mt-2">
+          <div className="w-full h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-cyan-500 dark:bg-cyan-400 transition-all duration-100"
+              style={{ width: `${progressPercent}%` }}
+            ></div>
+          </div>
+        </div>
+      )}
+
+      <Handle type="source" position={Position.Bottom} className="w-3 h-3" />
+    </div>
+  );
+};
+
+export default memo(ConnectionTriggerNode);

--- a/src/console/lib/scenarioSteps.test.ts
+++ b/src/console/lib/scenarioSteps.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../../cp/application/scenario/ScenarioTypes";
 import { OCPPStatus } from "../../cp/domain/types/OcppTypes";
 import type { Edge } from "@xyflow/react";
+import { NODE_FORM_REGISTRY } from "../../components/scenario/forms/nodeFormRegistry";
 
 // --- fixtures ---------------------------------------------------------
 
@@ -619,6 +620,12 @@ describe("stepSummary", () => {
     expect(stepSummary(withoutTimeout)).toBe("wait Reset");
   });
 
+  it("marks a payload-conditioned csmsCallTrigger in the step summary", () => {
+    const n = createDefaultNode(ScenarioNodeType.CSMS_CALL_TRIGGER);
+    n.data = { ...n.data, action: "Reset", payload: { type: "Hard" } };
+    expect(stepSummary(n)).toBe("wait Reset · payload");
+  });
+
   it("falls back to the node label for unmodeled node types", () => {
     const n = node("a", ScenarioNodeType.START, { label: "My Start Label" });
     expect(stepSummary(n)).toBe("My Start Label");
@@ -647,5 +654,29 @@ describe("STEP_CATEGORIES", () => {
     expect(totalListed).toBe(allTypes.length);
     expect(counts.has(ScenarioNodeType.START)).toBe(false);
     expect(counts.has(ScenarioNodeType.END)).toBe(false);
+  });
+});
+
+// --- NODE_FORM_REGISTRY (csmsCallTrigger payload) -----------------------
+
+describe("NODE_FORM_REGISTRY csmsCallTrigger payload condition (#240)", () => {
+  it("csmsCallTrigger form converters round-trip a payload condition and drop junk", () => {
+    const entry = NODE_FORM_REGISTRY[ScenarioNodeType.CSMS_CALL_TRIGGER];
+    const nodeData = entry.formToNodeData({
+      label: "w",
+      action: "Reset",
+      timeout: 0,
+      payload: { type: "Hard" },
+    });
+    expect((nodeData as { payload?: unknown }).payload).toEqual({
+      type: "Hard",
+    });
+    // Unparsable textarea leftovers must not be persisted.
+    const dropped = entry.formToNodeData({
+      label: "w",
+      action: "Reset",
+      payload: "{not json",
+    });
+    expect((dropped as { payload?: unknown }).payload).toBeUndefined();
   });
 });

--- a/src/console/lib/scenarioSteps.ts
+++ b/src/console/lib/scenarioSteps.ts
@@ -4,6 +4,7 @@ import {
   type CancelReservationNodeData,
   type CertQuirksNodeData,
   type ConfigSetNodeData,
+  type ConnectionTriggerNodeData,
   type ConnectorPlugNodeData,
   type CsmsCallTriggerNodeData,
   type DataTransferNodeData,
@@ -467,6 +468,17 @@ export function createDefaultNode(type: ScenarioNodeType): ScenarioNode {
           mode: "set",
         } satisfies CertQuirksNodeData,
       };
+    case ScenarioNodeType.CONNECTION_TRIGGER:
+      return {
+        id,
+        type,
+        position,
+        data: {
+          label: "Wait for Disconnect",
+          event: "disconnected",
+          timeout: 0,
+        } satisfies ConnectionTriggerNodeData,
+      };
     case ScenarioNodeType.START:
       return {
         id,
@@ -575,6 +587,10 @@ export function stepSummary(node: ScenarioNode): string {
       const d = node.data as ReservationTriggerNodeData;
       return `wait ReserveNow${d.timeout ? ` · ${d.timeout}s` : ""}`;
     }
+    case ScenarioNodeType.CONNECTION_TRIGGER: {
+      const d = node.data as ConnectionTriggerNodeData;
+      return `wait ${d.event}${d.timeout ? ` · ${d.timeout}s` : ""}`;
+    }
     case ScenarioNodeType.RESERVE_NOW: {
       const d = node.data as ReserveNowNodeData;
       return `${d.idTag} · ${d.expiryMinutes}min`;
@@ -660,6 +676,7 @@ export const STEP_CATEGORIES: ReadonlyArray<{
       ScenarioNodeType.STATUS_TRIGGER,
       ScenarioNodeType.CSMS_CALL_TRIGGER,
       ScenarioNodeType.RESERVATION_TRIGGER,
+      ScenarioNodeType.CONNECTION_TRIGGER,
     ],
   },
   {

--- a/src/console/lib/scenarioSteps.ts
+++ b/src/console/lib/scenarioSteps.ts
@@ -569,7 +569,7 @@ export function stepSummary(node: ScenarioNode): string {
     }
     case ScenarioNodeType.CSMS_CALL_TRIGGER: {
       const d = node.data as CsmsCallTriggerNodeData;
-      return `wait ${d.action}${d.timeout ? ` · ${d.timeout}s` : ""}`;
+      return `wait ${d.action}${d.payload ? " · payload" : ""}${d.timeout ? ` · ${d.timeout}s` : ""}`;
     }
     case ScenarioNodeType.RESERVATION_TRIGGER: {
       const d = node.data as ReservationTriggerNodeData;

--- a/src/console/pages/cp/ActiveScenarioPanel.dom.test.tsx
+++ b/src/console/pages/cp/ActiveScenarioPanel.dom.test.tsx
@@ -354,6 +354,102 @@ describe("ActiveScenarioPanel", () => {
     expect(container.textContent).toContain("No timeout");
   });
 
+  it("shows connection expectation with its event name", async () => {
+    const cp = snapshot({
+      id: "CP-1",
+      status: OCPPStatus.Available,
+      connectors: [connector({ id: 1 })],
+    });
+
+    const listScenarios = vi.fn(async () => [
+      { scenarioId: "s1", name: "Test scenario", active: true },
+    ]);
+
+    const getScenarioStatus = vi.fn(
+      async (): Promise<ScenarioExecutionContext | null> => ({
+        scenarioId: "s1",
+        state: "waiting" as const,
+        mode: "oneshot" as const,
+        currentNodeId: "n2",
+        executedNodes: ["n1"],
+        loopCount: 0,
+        runId: "run-1",
+        expectation: {
+          type: "connection" as const,
+          event: "disconnected" as const,
+          nodeId: "wait-conn",
+        },
+        currentNodeStartedAt: Date.now(),
+      }),
+    );
+
+    const getScenario = vi.fn(async () => scenarioDefinitionFixture);
+
+    const service = createFakeChargePointService({
+      snapshots: [cp],
+      listScenarios,
+      getScenarioStatus,
+      getScenario,
+      getStateHistory: vi.fn(async () => []),
+    });
+
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+
+    expect(container.textContent).toContain("Waiting for");
+    expect(container.textContent).toContain("disconnected");
+  });
+
+  it("shows a payload marker for payload-conditioned call waits", async () => {
+    const cp = snapshot({
+      id: "CP-1",
+      status: OCPPStatus.Available,
+      connectors: [connector({ id: 1 })],
+    });
+
+    const listScenarios = vi.fn(async () => [
+      { scenarioId: "s1", name: "Test scenario", active: true },
+    ]);
+
+    const getScenarioStatus = vi.fn(
+      async (): Promise<ScenarioExecutionContext | null> => ({
+        scenarioId: "s1",
+        state: "waiting" as const,
+        mode: "oneshot" as const,
+        currentNodeId: "n2",
+        executedNodes: ["n1"],
+        loopCount: 0,
+        runId: "run-1",
+        expectation: {
+          type: "ocpp_call" as const,
+          direction: "CSMS_TO_CP" as const,
+          action: "ChangeConfiguration",
+          constraints: { payload: { key: "HeartbeatInterval" } },
+          nodeId: "wait-cfg",
+        },
+        currentNodeStartedAt: Date.now(),
+      }),
+    );
+
+    const getScenario = vi.fn(async () => scenarioDefinitionFixture);
+
+    const service = createFakeChargePointService({
+      snapshots: [cp],
+      listScenarios,
+      getScenarioStatus,
+      getScenario,
+      getStateHistory: vi.fn(async () => []),
+    });
+
+    const { container, root } = await renderConsole("/cp/CP-1", { service });
+    cleanup = () => unmount(root);
+    await flush();
+
+    expect(container.textContent).toContain("ChangeConfiguration");
+    expect(container.textContent).toContain("payload");
+  });
+
   it("parent re-renders do not retrigger scenario fetches; scenario events do (fetch-loop regression)", async () => {
     const cp = snapshot({
       id: "CP-1",

--- a/src/console/pages/cp/ActiveScenarioPanel.tsx
+++ b/src/console/pages/cp/ActiveScenarioPanel.tsx
@@ -87,10 +87,16 @@ const ActiveScenarioPanel: React.FC<ActiveScenarioPanelProps> = ({
           const remaining =
             remainingMs !== null ? formatElapsed(remainingMs) : null;
 
-          const expectationDescription =
+          const payloadConditioned = Boolean(
+            run.expectation?.constraints &&
+            (run.expectation.constraints as Record<string, unknown>).payload,
+          );
+          const expectationDescription = `${
             run.expectation?.action ??
             run.expectation?.targetStatus ??
-            run.expectation?.type;
+            run.expectation?.event ??
+            run.expectation?.type
+          }${payloadConditioned ? " (payload condition)" : ""}`;
 
           return (
             <div

--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -1722,11 +1722,25 @@ export class ScenarioExecutor {
   ): Promise<void> {
     if (!this.callbacks.onWaitForCsmsCall) return;
 
+    // #240: fail fast on a malformed hand-authored payload condition
+    // (same convention as the csmsCallTrigger transport fail-fast).
+    if (
+      data.payload !== undefined &&
+      (typeof data.payload !== "object" ||
+        data.payload === null ||
+        Array.isArray(data.payload))
+    ) {
+      throw new Error(
+        `csmsCallTrigger(${data.action}): payload condition must be a JSON object`,
+      );
+    }
+
     const timeout = Math.max(0, data.timeout || 0);
     if (!timeout || timeout === 0) {
       const waitPromise = this.callbacks.onWaitForCsmsCall(
         data.action,
         timeout,
+        data.payload,
       );
       try {
         await this.waitWithOptionalForceSkip(
@@ -1761,6 +1775,7 @@ export class ScenarioExecutor {
       const waitPromise = this.callbacks.onWaitForCsmsCall(
         data.action,
         timeout,
+        data.payload,
       );
       try {
         await this.waitWithOptionalForceSkip(

--- a/src/cp/application/scenario/ScenarioExecutor.ts
+++ b/src/cp/application/scenario/ScenarioExecutor.ts
@@ -27,6 +27,7 @@ import {
   CertQuirksNodeData,
   ConfigSetNodeData,
   DataTransferNodeData,
+  ConnectionTriggerNodeData,
   StartTransactionOptions,
   StopTransactionOptions,
   ScenarioExpectation,
@@ -677,6 +678,13 @@ export class ScenarioExecutor {
 
       case ScenarioNodeType.DATA_TRANSFER:
         await this.executeDataTransfer(node.data as DataTransferNodeData);
+        break;
+
+      case ScenarioNodeType.CONNECTION_TRIGGER:
+        await this.executeConnectionTrigger(
+          node.id,
+          node.data as ConnectionTriggerNodeData,
+        );
         break;
 
       default:
@@ -1712,45 +1720,32 @@ export class ScenarioExecutor {
   }
 
   /**
-   * Issue #110: park the scenario until the CSMS sends `data.action`.
-   * Mirror of executeRemoteStopTrigger; the CP core handler still runs,
-   * we only synchronize on arrival and log the payload.
+   * Run a trigger wait with the 100ms remaining-time progress events that
+   * timeout-bearing waiting nodes surface. Extracted from
+   * executeCsmsCallTrigger (#240) so connectionTrigger shares it instead of
+   * copying the interval bookkeeping a third time.
    */
-  private async executeCsmsCallTrigger(
+  private async runTriggerWait(
     nodeId: string,
-    data: CsmsCallTriggerNodeData,
+    timeoutSeconds: number,
+    startWait: () => Promise<unknown>,
+    onResolved?: (value: unknown) => void,
   ): Promise<void> {
-    if (!this.callbacks.onWaitForCsmsCall) return;
+    const timeout = Math.max(0, timeoutSeconds || 0);
 
-    // #240: fail fast on a malformed hand-authored payload condition
-    // (same convention as the csmsCallTrigger transport fail-fast).
-    if (
-      data.payload !== undefined &&
-      (typeof data.payload !== "object" ||
-        data.payload === null ||
-        Array.isArray(data.payload))
-    ) {
-      throw new Error(
-        `csmsCallTrigger(${data.action}): payload condition must be a JSON object`,
-      );
-    }
-
-    const timeout = Math.max(0, data.timeout || 0);
-    if (!timeout || timeout === 0) {
-      const waitPromise = this.callbacks.onWaitForCsmsCall(
-        data.action,
-        timeout,
-        data.payload,
-      );
+    const awaitOnce = async () => {
+      const waitPromise = startWait();
       try {
         await this.waitWithOptionalForceSkip(
-          waitPromise.then((res) => {
-            this.callbacks.log?.(`CSMS call received: ${res.action}`, "info");
-          }),
+          onResolved ? waitPromise.then(onResolved) : waitPromise,
         );
       } finally {
         cancelIfCancellable(waitPromise);
       }
+    };
+
+    if (!timeout) {
+      await awaitOnce();
       return;
     }
 
@@ -1772,20 +1767,7 @@ export class ScenarioExecutor {
     }, 100);
 
     try {
-      const waitPromise = this.callbacks.onWaitForCsmsCall(
-        data.action,
-        timeout,
-        data.payload,
-      );
-      try {
-        await this.waitWithOptionalForceSkip(
-          waitPromise.then((res) => {
-            this.callbacks.log?.(`CSMS call received: ${res.action}`, "info");
-          }),
-        );
-      } finally {
-        cancelIfCancellable(waitPromise);
-      }
+      await awaitOnce();
     } finally {
       clearInterval(progressInterval);
       this.callbacks.onNodeProgress?.(nodeId, 0, timeout);
@@ -1796,5 +1778,54 @@ export class ScenarioExecutor {
         total: timeout,
       });
     }
+  }
+
+  /**
+   * Issue #110: park the scenario until the CSMS sends `data.action`.
+   * Mirror of executeRemoteStopTrigger; the CP core handler still runs,
+   * we only synchronize on arrival and log the payload.
+   */
+  private async executeCsmsCallTrigger(
+    nodeId: string,
+    data: CsmsCallTriggerNodeData,
+  ): Promise<void> {
+    if (!this.callbacks.onWaitForCsmsCall) return;
+    if (
+      data.payload !== undefined &&
+      (typeof data.payload !== "object" ||
+        data.payload === null ||
+        Array.isArray(data.payload))
+    ) {
+      throw new Error(
+        `csmsCallTrigger(${data.action}): payload condition must be a JSON object`,
+      );
+    }
+    const timeout = Math.max(0, data.timeout || 0);
+    await this.runTriggerWait(
+      nodeId,
+      timeout,
+      () =>
+        this.callbacks.onWaitForCsmsCall!(data.action, timeout, data.payload),
+      (res) =>
+        this.callbacks.log?.(
+          `CSMS call received: ${(res as { action: string }).action}`,
+          "info",
+        ),
+    );
+  }
+
+  /** Issue #240: park until the WebSocket reaches data.event. */
+  private async executeConnectionTrigger(
+    nodeId: string,
+    data: ConnectionTriggerNodeData,
+  ): Promise<void> {
+    if (!this.callbacks.onWaitForConnection) return;
+    const timeout = Math.max(0, data.timeout || 0);
+    await this.runTriggerWait(
+      nodeId,
+      timeout,
+      () => this.callbacks.onWaitForConnection!(data.event, timeout),
+      () => this.callbacks.log?.(`Connection event: ${data.event}`, "info"),
+    );
   }
 }

--- a/src/cp/application/scenario/ScenarioExpectations.ts
+++ b/src/cp/application/scenario/ScenarioExpectations.ts
@@ -59,11 +59,23 @@ export function deriveExpectation(
 
     case ScenarioNodeType.CSMS_CALL_TRIGGER: {
       const data = node.data as CsmsCallTriggerNodeData;
+      // #240: surface the payload condition so scenario_status / the UI can
+      // show WHAT the wait is filtering on, not just the action.
+      const payloadConstraint =
+        data.payload &&
+        typeof data.payload === "object" &&
+        !Array.isArray(data.payload)
+          ? { payload: data.payload }
+          : undefined;
+      const merged =
+        constraints || payloadConstraint
+          ? { ...(constraints ?? {}), ...(payloadConstraint ?? {}) }
+          : undefined;
       return {
         type: "ocpp_call",
         direction: "CSMS_TO_CP",
         action: data.action,
-        constraints,
+        constraints: merged,
         timeoutMs: timeoutMs(data.timeout),
         nodeId: node.id,
       };

--- a/src/cp/application/scenario/ScenarioExpectations.ts
+++ b/src/cp/application/scenario/ScenarioExpectations.ts
@@ -1,5 +1,6 @@
 import {
   ScenarioNodeType,
+  type ConnectionTriggerNodeData,
   type CsmsCallTriggerNodeData,
   type ScenarioExpectation,
   type ScenarioNode,
@@ -101,6 +102,17 @@ export function deriveExpectation(
         timeoutMs: timeoutMs((node.data as { timeout?: number }).timeout),
         nodeId: node.id,
       };
+
+    case ScenarioNodeType.CONNECTION_TRIGGER: {
+      const data = node.data as ConnectionTriggerNodeData;
+      // Connection state is CP-scoped: no connectorId constraints.
+      return {
+        type: "connection",
+        event: data.event === "connected" ? "connected" : "disconnected",
+        timeoutMs: timeoutMs(data.timeout),
+        nodeId: node.id,
+      };
+    }
 
     default:
       return null;

--- a/src/cp/application/scenario/ScenarioRuntime.ts
+++ b/src/cp/application/scenario/ScenarioRuntime.ts
@@ -361,6 +361,56 @@ const waitForCsmsCall = (
   };
 };
 
+/** Issue #240: park until the WebSocket reaches `event`. Level-triggered —
+ *  if the charge point is already in the target state, resolve immediately
+ *  (same convention as waitForStatus / waitForReservation). Deliberately
+ *  does NOT subscribe the reject-on-disconnect handler the other waits use:
+ *  surviving the disconnected span is this wait's entire purpose. */
+const waitForConnection = (
+  chargePoint: ChargePoint,
+  event: "connected" | "disconnected",
+  timeout?: number,
+): CancellableWait<void> => {
+  const inTargetState = () =>
+    event === "connected"
+      ? chargePoint.isWebSocketConnected
+      : !chargePoint.isWebSocketConnected;
+
+  if (inTargetState()) {
+    return { promise: Promise.resolve(), cancel: () => {} };
+  }
+
+  let cleanupFn: (() => void) | null = null;
+
+  const promise = new Promise<void>((resolve, reject) => {
+    let timeoutId: NodeJS.Timeout | null = null;
+    let settled = false;
+
+    const handler = () => {
+      cleanup();
+      resolve();
+    };
+    const off = chargePoint.events.on(event, handler);
+
+    const cleanup = () => {
+      if (settled) return;
+      settled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+      off();
+    };
+    cleanupFn = cleanup;
+
+    if (timeout && timeout > 0) {
+      timeoutId = setTimeout(() => {
+        cleanup();
+        reject(new Error(`Timeout waiting for ${event} (${timeout}s)`));
+      }, timeout * 1000);
+    }
+  });
+
+  return { promise, cancel: () => cleanupFn?.() };
+};
+
 const waitForReservation = (
   chargePoint: ChargePoint,
   connector: Connector,
@@ -588,6 +638,9 @@ export const createScenarioExecutorCallbacks = (
       return cancellablePromise(
         waitForCsmsCall(chargePoint, action, timeout, payload),
       );
+    },
+    onWaitForConnection: (event, timeout) => {
+      return cancellablePromise(waitForConnection(chargePoint, event, timeout));
     },
     onWaitForStatus: async (targetStatus, timeout) =>
       waitForStatus(connector, targetStatus, timeout),

--- a/src/cp/application/scenario/ScenarioRuntime.ts
+++ b/src/cp/application/scenario/ScenarioRuntime.ts
@@ -2,6 +2,7 @@ import { ChargePoint } from "../../domain/charge-point/ChargePoint";
 import { Connector } from "../../domain/connector/Connector";
 import { OCPPStatus, ReservationStatus } from "../../domain/types/OcppTypes";
 import { LogType } from "../../shared/Logger";
+import { deepPartialMatch } from "../../../scenario/deepPartialMatch";
 import type {
   ScenarioExecutionContext,
   ScenarioExecutorCallbacks,
@@ -291,6 +292,7 @@ const waitForCsmsCall = (
   chargePoint: ChargePoint,
   action: string,
   timeout?: number,
+  payload?: Record<string, unknown>,
 ): CancellableWait<{ action: string; payload: unknown }> => {
   // Fail-fast if this transport can never receive CSMS-initiated calls.
   if (!chargePoint.canReceiveCsmsCall(action)) {
@@ -323,6 +325,9 @@ const waitForCsmsCall = (
 
       const handler = (data: { action: string; payload: unknown }) => {
         if (data.action !== action) return;
+        // #240: a right-action frame whose payload doesn't match the
+        // condition is NOT consumed — keep listening.
+        if (payload && !deepPartialMatch(payload, data.payload)) return;
         cleanup();
         resolve(data);
       };
@@ -339,7 +344,11 @@ const waitForCsmsCall = (
         timeoutId = setTimeout(() => {
           cleanup();
           reject(
-            new Error(`Timeout waiting for CSMS call ${action} (${timeout}s)`),
+            new Error(
+              `Timeout waiting for CSMS call ${action}${
+                payload ? " matching payload" : ""
+              } (${timeout}s)`,
+            ),
           );
         }, timeout * 1000);
       }
@@ -575,8 +584,10 @@ export const createScenarioExecutorCallbacks = (
         waitForRemoteStop(chargePoint, connector, timeout),
       );
     },
-    onWaitForCsmsCall: (action, timeout) => {
-      return cancellablePromise(waitForCsmsCall(chargePoint, action, timeout));
+    onWaitForCsmsCall: (action, timeout, payload) => {
+      return cancellablePromise(
+        waitForCsmsCall(chargePoint, action, timeout, payload),
+      );
     },
     onWaitForStatus: async (targetStatus, timeout) =>
       waitForStatus(connector, targetStatus, timeout),

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -77,6 +77,10 @@ export enum ScenarioNodeType {
   // signature algorithm requirements, hidden configuration keys). Used to
   // emulate certification-tool behaviors (e.g., OCTT strictness).
   CERT_QUIRKS = "certQuirks",
+  // Issue #240: park until the WebSocket connects or disconnects.
+  // Level-triggered (already in the target state → resolve immediately)
+  // and observe-only — causing disconnects is network simulation (#239).
+  CONNECTION_TRIGGER = "connectionTrigger",
 }
 
 /**
@@ -390,6 +394,20 @@ export interface DataTransferNodeData extends BaseNodeData {
 }
 
 /**
+ * Connection Trigger Node Data — waits for the charge point's WebSocket to
+ * reach `event`. Level-triggered like statusTrigger: if the connection is
+ * already in the target state the node resolves immediately. Unlike every
+ * other wait, this node does NOT fail on disconnect — surviving the
+ * disconnected span is its purpose (a "connected" wait spanning a reconnect
+ * is the canonical use). Issue #240.
+ */
+export interface ConnectionTriggerNodeData extends BaseNodeData {
+  event: "connected" | "disconnected";
+  /** Optional timeout in seconds. 0 (default) = wait forever. */
+  timeout?: number;
+}
+
+/**
  * Union type for all node data
  */
 export type ScenarioNodeData =
@@ -414,6 +432,7 @@ export type ScenarioNodeData =
   | ConfigSetNodeData
   | DataTransferNodeData
   | StartNodeData
+  | ConnectionTriggerNodeData
   | BaseNodeData;
 
 /**
@@ -619,13 +638,15 @@ export function isScenarioDefinitionShape(
  */
 export interface ScenarioExpectation {
   /** What kind of condition the parked node awaits. */
-  type: "ocpp_call" | "connector_status" | "reservation";
+  type: "ocpp_call" | "connector_status" | "reservation" | "connection";
   /** For ocpp_call / reservation: who must send the awaited CALL. */
   direction?: "CSMS_TO_CP" | "CP_TO_CSMS";
   /** For ocpp_call / reservation: the OCPP action awaited. */
   action?: string;
   /** For connector_status: the status the connector must reach. */
   targetStatus?: string;
+  /** For connection: the WebSocket state transition awaited (#240). */
+  event?: "connected" | "disconnected";
   /** Partial-match constraints on the awaited event (e.g. connectorId).
    *  Superset-matched, never exhaustive. */
   constraints?: Record<string, unknown>;
@@ -737,6 +758,12 @@ export interface ScenarioExecutorCallbacks {
     timeout?: number,
     payload?: Record<string, unknown>,
   ) => Promise<{ action: string; payload: unknown }>;
+  /** Issue #240: park until the WebSocket reaches `event`. Level-triggered;
+   *  never rejects on disconnect (only on timeout). */
+  onWaitForConnection?: (
+    event: "connected" | "disconnected",
+    timeout?: number,
+  ) => Promise<void>;
   onWaitForStatus?: (
     targetStatus: OCPPStatus,
     timeout?: number,

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -216,6 +216,11 @@ export interface CsmsCallTriggerNodeData extends BaseNodeData {
   action: string;
   /** Optional timeout in seconds. 0 (default) = wait forever. */
   timeout?: number;
+  /** #240: optional payload condition. The wait only releases on an
+   *  incoming CALL of `action` whose payload deep-partially matches this
+   *  subset (see src/scenario/deepPartialMatch.ts). Non-matching frames
+   *  are not consumed — the node keeps waiting. Absent = any payload. */
+  payload?: Record<string, unknown>;
 }
 
 /**
@@ -730,6 +735,7 @@ export interface ScenarioExecutorCallbacks {
   onWaitForCsmsCall?: (
     action: string,
     timeout?: number,
+    payload?: Record<string, unknown>,
   ) => Promise<{ action: string; payload: unknown }>;
   onWaitForStatus?: (
     targetStatus: OCPPStatus,

--- a/src/cp/application/scenario/ScenarioTypes.ts
+++ b/src/cp/application/scenario/ScenarioTypes.ts
@@ -460,7 +460,7 @@ export interface ScenarioTrigger {
  * See `schema/scenario.schema.json` (Draft 2020-12) and
  * `docs/scenario-format.md`.
  */
-export const SCENARIO_SCHEMA_VERSION = "1.0";
+export const SCENARIO_SCHEMA_VERSION = "1.1";
 
 /**
  * Scenario definition

--- a/src/cp/application/scenario/__tests__/ScenarioExpectations.test.ts
+++ b/src/cp/application/scenario/__tests__/ScenarioExpectations.test.ts
@@ -94,6 +94,45 @@ describe("deriveExpectation (#179)", () => {
     });
   });
 
+  it("includes the payload subset in csmsCallTrigger constraints (#240)", () => {
+    const exp = deriveExpectation(
+      node(ScenarioNodeType.CSMS_CALL_TRIGGER, {
+        label: "wait",
+        action: "ChangeConfiguration",
+        payload: { key: "HeartbeatInterval" },
+        timeout: 5,
+      } as ScenarioNodeData),
+      1,
+    );
+    expect(exp).toEqual({
+      type: "ocpp_call",
+      direction: "CSMS_TO_CP",
+      action: "ChangeConfiguration",
+      constraints: { connectorId: 1, payload: { key: "HeartbeatInterval" } },
+      timeoutMs: 5000,
+      nodeId: "csmsCallTrigger-1",
+    });
+  });
+
+  it("keeps csmsCallTrigger constraints payload-only when no connector is bound", () => {
+    const exp = deriveExpectation(
+      node(ScenarioNodeType.CSMS_CALL_TRIGGER, {
+        label: "wait",
+        action: "Reset",
+        payload: { type: "Hard" },
+      } as ScenarioNodeData),
+      undefined,
+    );
+    expect(exp).toEqual({
+      type: "ocpp_call",
+      direction: "CSMS_TO_CP",
+      action: "Reset",
+      constraints: { payload: { type: "Hard" } },
+      timeoutMs: undefined,
+      nodeId: "csmsCallTrigger-1",
+    });
+  });
+
   it("omits constraints when the connectorId is undefined", () => {
     const exp = deriveExpectation(
       node(ScenarioNodeType.REMOTE_START_TRIGGER, {

--- a/src/cp/application/scenario/__tests__/ScenarioExpectations.test.ts
+++ b/src/cp/application/scenario/__tests__/ScenarioExpectations.test.ts
@@ -143,6 +143,21 @@ describe("deriveExpectation (#179)", () => {
     expect(exp?.constraints).toBeUndefined();
   });
 
+  it("derives a connection expectation for connectionTrigger (#240)", () => {
+    const node = {
+      id: "n-conn",
+      type: ScenarioNodeType.CONNECTION_TRIGGER,
+      position: { x: 0, y: 0 },
+      data: { label: "wait", event: "disconnected", timeout: 10 },
+    } as ScenarioNode;
+    expect(deriveExpectation(node, 1)).toEqual({
+      type: "connection",
+      event: "disconnected",
+      timeoutMs: 10000,
+      nodeId: "n-conn",
+    });
+  });
+
   it.each([
     ScenarioNodeType.STATUS_CHANGE,
     ScenarioNodeType.TRANSACTION,

--- a/src/cp/application/scenario/__tests__/connectionTrigger.test.ts
+++ b/src/cp/application/scenario/__tests__/connectionTrigger.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+
+import { ScenarioExecutor } from "../ScenarioExecutor";
+import { createScenarioExecutorCallbacks } from "../ScenarioRuntime";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+import { ScenarioDefinition, ScenarioNodeType } from "../ScenarioTypes";
+
+function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+async function waitUntil(predicate: () => boolean, ms = 500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > ms) {
+      throw new Error("Timed out waiting for predicate");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function newChargePoint(id: string): ChargePoint {
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    "ws://127.0.0.1:9/",
+    null,
+    null,
+    null,
+    {},
+    [],
+    "OCPP-1.6J",
+    {},
+  );
+  cp.events.on("error", () => undefined);
+  return cp;
+}
+
+function connectionScenario(
+  event: "connected" | "disconnected",
+  timeoutSec = 0,
+): ScenarioDefinition {
+  const now = new Date().toISOString();
+  return {
+    id: `test-connection-trigger-${event}`,
+    name: `connectionTrigger ${event}`,
+    targetType: "connector",
+    targetId: 1,
+    trigger: { type: "manual" },
+    defaultExecutionMode: "oneshot",
+    enabled: true,
+    createdAt: now,
+    updatedAt: now,
+    nodes: [
+      {
+        id: "start-1",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "wait-conn",
+        type: ScenarioNodeType.CONNECTION_TRIGGER,
+        position: { x: 0, y: 100 },
+        data: { label: `Wait ${event}`, event, timeout: timeoutSec },
+      },
+      {
+        id: "end-1",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 200 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "start-1", target: "wait-conn" },
+      { id: "e2", source: "wait-conn", target: "end-1" },
+    ],
+  };
+}
+
+describe("connectionTrigger node (issue #240)", () => {
+  it("level-triggers: 'disconnected' resolves immediately on an unconnected CP", async () => {
+    const cp = newChargePoint("CP-CONN-LEVEL");
+    const connector = cp.getConnector(1)!;
+    const executor = new ScenarioExecutor(
+      connectionScenario("disconnected"),
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+    );
+    await timeout(executor.start(), 1000); // completes without any event
+  });
+
+  it("level-triggers: 'connected' resolves immediately when already connected", async () => {
+    const cp = newChargePoint("CP-CONN-LEVEL2");
+    // isWebSocketConnected is a prototype getter; shadow it with an own
+    // property (vi.spyOn on inherited accessors is flaky across versions).
+    Object.defineProperty(cp, "isWebSocketConnected", {
+      get: () => true,
+      configurable: true,
+    });
+    const connector = cp.getConnector(1)!;
+    const executor = new ScenarioExecutor(
+      connectionScenario("connected"),
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+    );
+    await timeout(executor.start(), 1000);
+  });
+
+  it("edge: parks for 'connected' and survives an intervening disconnected event", async () => {
+    const cp = newChargePoint("CP-CONN-EDGE");
+    const connector = cp.getConnector(1)!;
+    const executor = new ScenarioExecutor(
+      connectionScenario("connected"),
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+    );
+    const execution = executor.start();
+    try {
+      await waitUntil(() => cp.events.listenerCount("connected") > 0);
+
+      // The wait must NOT be killed by a disconnect — that is its point.
+      cp.events.emit("disconnected", { code: 1006, reason: "test" });
+      await new Promise((r) => setTimeout(r, 50));
+      let done = false;
+      void execution.then(() => (done = true));
+      await new Promise((r) => setTimeout(r, 0));
+      expect(done).toBe(false);
+
+      cp.events.emit("connected", undefined);
+      await timeout(execution, 1000);
+    } finally {
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      ).catch(() => undefined);
+    }
+  });
+
+  it("edge: parks for 'disconnected' while connected, releases on the event", async () => {
+    const cp = newChargePoint("CP-CONN-EDGE2");
+    Object.defineProperty(cp, "isWebSocketConnected", {
+      get: () => true,
+      configurable: true,
+    });
+    const connector = cp.getConnector(1)!;
+    const executor = new ScenarioExecutor(
+      connectionScenario("disconnected"),
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+    );
+    const execution = executor.start();
+    try {
+      await waitUntil(() => cp.events.listenerCount("disconnected") > 0);
+      cp.events.emit("disconnected", { code: 1000, reason: "bye" });
+      await timeout(execution, 1000);
+    } finally {
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      ).catch(() => undefined);
+    }
+  });
+
+  it("rejects when the timeout elapses", async () => {
+    const cp = newChargePoint("CP-CONN-TIMEOUT");
+    const connector = cp.getConnector(1)!;
+    const errors: Error[] = [];
+    const callbacks = {
+      ...createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+      onError: (e: Error) => errors.push(e),
+    };
+    const executor = new ScenarioExecutor(
+      connectionScenario("connected", 1),
+      callbacks,
+    );
+    await timeout(executor.start(), 3000);
+    expect(
+      errors.some((e) =>
+        /Timeout waiting for connected \(1s\)/.test(e.message),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/cp/application/scenario/__tests__/csmsCallTrigger.test.ts
+++ b/src/cp/application/scenario/__tests__/csmsCallTrigger.test.ts
@@ -140,3 +140,103 @@ describe("csmsCallTrigger node (issue #110)", () => {
     ).toBe(true);
   });
 });
+
+function payloadTriggerScenario(
+  action: string,
+  payload: Record<string, unknown> | unknown,
+  timeoutSec = 0,
+): ScenarioDefinition {
+  const base = triggerScenario(action, timeoutSec);
+  return {
+    ...base,
+    id: `${base.id}-payload`,
+    nodes: base.nodes.map((n) =>
+      n.id === "wait-call" ? { ...n, data: { ...n.data, payload } } : n,
+    ),
+  };
+}
+
+describe("csmsCallTrigger payload condition (issue #240)", () => {
+  it("ignores right-action calls whose payload does not match, releases on match", async () => {
+    const cp = newChargePoint("CP-TRIG-PAYLOAD");
+    const connector = cp.getConnector(1)!;
+    const executor = new ScenarioExecutor(
+      payloadTriggerScenario("ChangeConfiguration", {
+        key: "HeartbeatInterval",
+      }),
+      createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+    );
+    const execution = executor.start();
+    try {
+      await waitUntil(
+        () => cp.events.listenerCount("incomingCallReceived") > 0,
+      );
+
+      // Right action, wrong payload: must NOT release (and must keep listening).
+      cp.notifyIncomingCall("ChangeConfiguration", {
+        key: "MeterValueSampleInterval",
+        value: "5",
+      });
+      await new Promise((r) => setTimeout(r, 50));
+      let done = false;
+      void execution.then(() => (done = true));
+      await new Promise((r) => setTimeout(r, 0));
+      expect(done).toBe(false);
+
+      // Matching subset (extra keys ignored) releases the wait.
+      cp.notifyIncomingCall("ChangeConfiguration", {
+        key: "HeartbeatInterval",
+        value: "30",
+      });
+      await timeout(execution, 1000);
+    } finally {
+      executor.stop();
+      await timeout(
+        execution.catch(() => undefined),
+        500,
+      ).catch(() => undefined);
+    }
+  });
+
+  it("mentions the payload condition in the timeout error", async () => {
+    const cp = newChargePoint("CP-TRIG-PAYLOAD-TO");
+    const connector = cp.getConnector(1)!;
+    const errors: Error[] = [];
+    const callbacks = {
+      ...createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+      onError: (e: Error) => errors.push(e),
+    };
+    const executor = new ScenarioExecutor(
+      payloadTriggerScenario("ClearCache", { x: 1 }, 1),
+      callbacks,
+    );
+    await timeout(executor.start(), 3000);
+    expect(
+      errors.some((e) =>
+        /Timeout waiting for CSMS call ClearCache matching payload \(1s\)/.test(
+          e.message,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails fast when the payload condition is not a plain object", async () => {
+    const cp = newChargePoint("CP-TRIG-PAYLOAD-BAD");
+    const connector = cp.getConnector(1)!;
+    const errors: Error[] = [];
+    const callbacks = {
+      ...createScenarioExecutorCallbacks({ chargePoint: cp, connector }),
+      onError: (e: Error) => errors.push(e),
+    };
+    const executor = new ScenarioExecutor(
+      payloadTriggerScenario("Reset", ["not", "an", "object"]),
+      callbacks,
+    );
+    await timeout(executor.start(), 2000);
+    expect(
+      errors.some((e) =>
+        /payload condition must be a JSON object/.test(e.message),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/cp/application/verification/ScenarioAssertions.ts
+++ b/src/cp/application/verification/ScenarioAssertions.ts
@@ -31,37 +31,7 @@ import {
   redactSensitiveText,
   redactSensitiveValue,
 } from "../../shared/redaction";
-
-/**
- * Deep partial match used by `payload_match`: every key in `subset` must be
- * present in `actual` with a deep-equal value. Objects are matched as a
- * subset (extra keys in `actual` are ignored); arrays are compared
- * element-by-element and must be the same length -- an assertion author
- * pinning an array generally means the whole array, not just a prefix.
- */
-function deepPartialMatch(subset: unknown, actual: unknown): boolean {
-  if (subset === actual) return true;
-  if (
-    typeof subset !== "object" ||
-    subset === null ||
-    typeof actual !== "object" ||
-    actual === null
-  ) {
-    return false;
-  }
-  if (Array.isArray(subset)) {
-    if (!Array.isArray(actual) || subset.length !== actual.length) {
-      return false;
-    }
-    return subset.every((item, i) => deepPartialMatch(item, actual[i]));
-  }
-  if (Array.isArray(actual)) return false;
-  const subsetObj = subset as Record<string, unknown>;
-  const actualObj = actual as Record<string, unknown>;
-  return Object.keys(subsetObj).every((key) =>
-    deepPartialMatch(subsetObj[key], actualObj[key]),
-  );
-}
+import { deepPartialMatch } from "../../../scenario/deepPartialMatch";
 
 /** A frame "matches" a message_order/message_after reference when it's a
  *  CALL for the given action in the given direction (default "sent"). */

--- a/src/scenario/__tests__/deepPartialMatch.test.ts
+++ b/src/scenario/__tests__/deepPartialMatch.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { deepPartialMatch } from "../deepPartialMatch";
+import { deepPartialMatch as k6DeepPartialMatch } from "../../cli/exportK6/runtime/assertions";
+
+/** Shared vectors run against BOTH implementations: the k6 runtime cannot
+ *  import repo modules (purity gate), so its copy stays — this table is
+ *  what keeps the two from drifting. */
+const VECTORS: Array<{
+  name: string;
+  subset: unknown;
+  actual: unknown;
+  expected: boolean;
+}> = [
+  { name: "identical primitives", subset: 1, actual: 1, expected: true },
+  { name: "different primitives", subset: 1, actual: 2, expected: false },
+  { name: "primitive vs object", subset: 1, actual: { a: 1 }, expected: false },
+  {
+    name: "subset object",
+    subset: { a: 1 },
+    actual: { a: 1, b: 2 },
+    expected: true,
+  },
+  {
+    name: "missing key",
+    subset: { a: 1, c: 3 },
+    actual: { a: 1, b: 2 },
+    expected: false,
+  },
+  {
+    name: "nested subset",
+    subset: { a: { b: 2 } },
+    actual: { a: { b: 2, c: 3 } },
+    expected: true,
+  },
+  {
+    name: "nested mismatch",
+    subset: { a: { b: 9 } },
+    actual: { a: { b: 2 } },
+    expected: false,
+  },
+  { name: "array exact match", subset: [1, 2], actual: [1, 2], expected: true },
+  {
+    name: "array length mismatch (no prefix match)",
+    subset: [1],
+    actual: [1, 2],
+    expected: false,
+  },
+  {
+    name: "array element subset",
+    subset: [{ a: 1 }],
+    actual: [{ a: 1, b: 2 }],
+    expected: true,
+  },
+  { name: "array vs object", subset: [1], actual: { 0: 1 }, expected: false },
+  { name: "object vs array", subset: { a: 1 }, actual: [1], expected: false },
+  { name: "null equals null", subset: null, actual: null, expected: true },
+  { name: "null vs object", subset: null, actual: {}, expected: false },
+  {
+    name: "empty subset matches anything object",
+    subset: {},
+    actual: { x: 1 },
+    expected: true,
+  },
+];
+
+describe("deepPartialMatch (canonical + k6 runtime copy)", () => {
+  for (const impl of [
+    { label: "src/scenario", fn: deepPartialMatch },
+    { label: "exportK6 runtime", fn: k6DeepPartialMatch },
+  ]) {
+    for (const v of VECTORS) {
+      it(`${impl.label}: ${v.name}`, () => {
+        expect(impl.fn(v.subset, v.actual)).toBe(v.expected);
+      });
+    }
+  }
+});

--- a/src/scenario/__tests__/scenarioSchemaValidator.test.ts
+++ b/src/scenario/__tests__/scenarioSchemaValidator.test.ts
@@ -1,6 +1,36 @@
 import { describe, it, expect } from "vitest";
 import { validateScenarioSchema } from "../scenarioSchemaValidator";
 
+/** Minimal valid scenario wrapper for #240 wait-node cases; if the file
+ *  already has an equivalent builder, reuse that instead. */
+function waitNodeScenario(nodes: unknown[]): unknown {
+  return {
+    schemaVersion: "1.1",
+    id: "schema-240",
+    name: "schema 240",
+    targetType: "connector",
+    targetId: 1,
+    nodes: [
+      {
+        id: "start-1",
+        type: "start",
+        position: { x: 0, y: 0 },
+        data: { label: "S" },
+      },
+      ...nodes,
+      {
+        id: "end-1",
+        type: "end",
+        position: { x: 0, y: 9 },
+        data: { label: "E" },
+      },
+    ],
+    edges: [],
+    createdAt: "2026-08-03T00:00:00Z",
+    updatedAt: "2026-08-03T00:00:00Z",
+  };
+}
+
 function minimalScenario(): Record<string, unknown> {
   return {
     id: "s1",
@@ -120,5 +150,54 @@ describe("validateScenarioSchema", () => {
     const result = validateScenarioSchema(scenario);
     expect(result.valid).toBe(true);
     expect(result.errors).toEqual([]);
+  });
+
+  it("accepts a connectionTrigger node and a csmsCallTrigger payload condition (schema 1.1)", () => {
+    const result = validateScenarioSchema(
+      waitNodeScenario([
+        {
+          id: "n1",
+          type: "connectionTrigger",
+          position: { x: 0, y: 1 },
+          data: { label: "w", event: "disconnected", timeout: 0 },
+        },
+        {
+          id: "n2",
+          type: "csmsCallTrigger",
+          position: { x: 0, y: 2 },
+          data: { label: "w2", action: "Reset", payload: { type: "Hard" } },
+        },
+      ]),
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects a connectionTrigger with an unknown event", () => {
+    const result = validateScenarioSchema(
+      waitNodeScenario([
+        {
+          id: "n1",
+          type: "connectionTrigger",
+          position: { x: 0, y: 1 },
+          data: { label: "w", event: "rebooted" },
+        },
+      ]),
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a non-object csmsCallTrigger payload condition", () => {
+    const result = validateScenarioSchema(
+      waitNodeScenario([
+        {
+          id: "n1",
+          type: "csmsCallTrigger",
+          position: { x: 0, y: 1 },
+          data: { label: "w", action: "Reset", payload: "Hard" },
+        },
+      ]),
+    );
+    expect(result.valid).toBe(false);
   });
 });

--- a/src/scenario/deepPartialMatch.ts
+++ b/src/scenario/deepPartialMatch.ts
@@ -1,0 +1,36 @@
+/**
+ * Deep partial match shared by assertion `payload_match` checks and the
+ * #240 payload-conditioned csmsCallTrigger wait: every key in `subset` must
+ * be present in `actual` with a deep-equal value. Objects are matched as a
+ * subset (extra keys in `actual` are ignored); arrays are compared
+ * element-by-element and must be the same length — an author pinning an
+ * array generally means the whole array, not just a prefix.
+ *
+ * The k6 export runtime keeps its own copy in
+ * src/cli/exportK6/runtime/assertions.ts (the runtime purity gate forbids
+ * repo imports); src/scenario/__tests__/deepPartialMatch.test.ts runs a
+ * shared vector table against both to keep them from drifting.
+ */
+export function deepPartialMatch(subset: unknown, actual: unknown): boolean {
+  if (subset === actual) return true;
+  if (
+    typeof subset !== "object" ||
+    subset === null ||
+    typeof actual !== "object" ||
+    actual === null
+  ) {
+    return false;
+  }
+  if (Array.isArray(subset)) {
+    if (!Array.isArray(actual) || subset.length !== actual.length) {
+      return false;
+    }
+    return subset.every((item, i) => deepPartialMatch(item, actual[i]));
+  }
+  if (Array.isArray(actual)) return false;
+  const subsetObj = subset as Record<string, unknown>;
+  const actualObj = actual as Record<string, unknown>;
+  return Object.keys(subsetObj).every((key) =>
+    deepPartialMatch(subsetObj[key], actualObj[key]),
+  );
+}


### PR DESCRIPTION
## Summary

Implements the two explicit wait kinds still missing from #240:

- **Payload condition on `csmsCallTrigger`** — optional `payload` subset
  (deep partial match); right-action calls whose payload doesn't match are
  not consumed, the wait keeps listening. Surfaced in `scenario_status`
  expectations (`constraints.payload`), the editor form, the step summary,
  and the k6 export runtime (same semantics via a waiter re-arm loop).
- **New `connectionTrigger` node** — waits for the WebSocket to reach
  `connected`/`disconnected`. Level-triggered (already-holding state
  resolves immediately, like statusTrigger) and deliberately exempt from
  the reject-on-disconnect wiring other waits use, so a run can span a
  reconnect. Observe-only; forcing disconnects stays #239 scope.
  Rejected by the k6 exporter's allowlist with a named error (Phase 1).

Also promotes `deepPartialMatch` to `src/scenario/deepPartialMatch.ts` (the
k6 runtime keeps its purity-gated copy, pinned by a shared-vector
consistency test) and bumps the scenario schema to 1.1 (additive).

## Tests

- vitest: matcher consistency vectors; payload wait match/skip/timeout/
  malformed-condition; connectionTrigger level/edge/survival/timeout;
  expectation derivation; k6 interpreter re-arm loop; exporter rejection;
  schema validator; ActiveScenarioPanel + form dom tests.
- bun (real socket + mock CSMS): a run parks on wait-disconnected, survives
  the drop, parks on wait-connected, completes after reconnect as ONE run —
  with a bystander connect-triggered scenario pinning that the reconnect
  auto-start's one-scenario-at-a-time gate blocks a second run while the
  first is live (the busy-case complement of the #253 rearm test).

Closes nothing; #240 remains open for while-waiting controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connection triggers for connected or disconnected states with configurable timeouts.
  * Added optional payload conditions for CSMS call triggers using deep partial matching.
  * Added editor, forms, summaries, and active-scenario display support for both capabilities.
  * Updated the scenario format and schema to version 1.1, while preserving version 1.0 and unversioned compatibility.
* **Bug Fixes**
  * Improved CSMS call filtering so only payload-matching calls advance execution.
* **Tests**
  * Added coverage for connection events, payload matching, validation, timeouts, reconnection behavior, and editor displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->