### PR TITLE
fix(scenario): close and report the run_scenario / RemoteStartTransaction race

### DIFF
--- a/src/cli/__tests__/service.scenarioArmedRace.bun.test.ts
+++ b/src/cli/__tests__/service.scenarioArmedRace.bun.test.ts
@@ -187,4 +187,26 @@ describe("CLIChargePointService.waitForScenarioArmed", () => {
       svc.waitForScenarioArmed("no-such-scenario", 50),
     ).resolves.toBeUndefined();
   });
+
+  it("removes a timed-out waiter from the map instead of leaking it", async () => {
+    const svc = newService();
+    // Long delay, no waiting node: every waiter below settles via timeout,
+    // never via resolveScenarioArmedWaiters. Before the cleanup fix each
+    // timed-out closure stayed in _armedWaitersByScenario for the scenario's
+    // whole lifetime.
+    const id = svc.loadScenario(1, longDelayNoTriggerScenario(1, 5));
+    svc.runScenario(1, id);
+
+    await svc.waitForScenarioArmed(id, 50);
+    await svc.waitForScenarioArmed(id, 50);
+
+    const waiters = (
+      svc as unknown as {
+        _armedWaitersByScenario: Map<string, Array<() => void>>;
+      }
+    )._armedWaitersByScenario;
+    expect(waiters.has(id)).toBe(false);
+
+    svc.stopScenario(1, id);
+  });
 });

--- a/src/cli/__tests__/service.scenarioArmedRace.bun.test.ts
+++ b/src/cli/__tests__/service.scenarioArmedRace.bun.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "bun:test";
+import { Database as BunSqliteDatabase } from "bun:sqlite";
+import { CLIChargePointService } from "../service";
+import { BunSqliteDatabase as BunDb } from "../../cp/domain/persistence/BunSqliteDatabase";
+import { runMigrations } from "../../cp/domain/persistence/schema";
+import {
+  ScenarioDefinition,
+  ScenarioNodeType,
+} from "../../cp/application/scenario/ScenarioTypes";
+
+/**
+ * Opt-in companion to the run_scenario / RemoteStartTransaction race fix
+ * (see remoteStartRace.test.ts for the visibility half): a caller that
+ * passes `awaitArmed` doesn't get the RPC response back until the run has
+ * either parked on its first expectation (armed) or ended without ever
+ * parking, closing the race entirely instead of just reporting it.
+ */
+function newService(): CLIChargePointService {
+  const raw = new BunSqliteDatabase(":memory:");
+  const db = new BunDb(raw);
+  runMigrations(db);
+  return new CLIChargePointService(
+    {
+      cpId: "test-cp",
+      wsUrl: "ws://127.0.0.1:65534/never",
+      connectors: 1,
+      vendor: "v",
+      model: "m",
+    },
+    db,
+  );
+}
+
+/** start -> delay(delaySeconds) -> remoteStartTrigger -> end. Mirrors the
+ *  reported graph shape (delay/plug-in nodes before the trigger). */
+function delayedRemoteStartScenario(
+  connectorId: number,
+  delaySeconds: number,
+): ScenarioDefinition {
+  return {
+    id: `delayed-remote-start-${connectorId}`,
+    name: "Delayed Remote Start",
+    targetType: "connector",
+    targetId: connectorId,
+    nodes: [
+      {
+        id: "start-1",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "delay-1",
+        type: ScenarioNodeType.DELAY,
+        position: { x: 0, y: 1 },
+        data: { label: "Delay", delaySeconds },
+      },
+      {
+        id: "trigger-remote-start",
+        type: ScenarioNodeType.REMOTE_START_TRIGGER,
+        position: { x: 0, y: 2 },
+        data: { label: "Wait RemoteStart", timeout: 0 },
+      },
+      {
+        id: "end-1",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 3 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "start-1", target: "delay-1" },
+      { id: "e2", source: "delay-1", target: "trigger-remote-start" },
+      { id: "e3", source: "trigger-remote-start", target: "end-1" },
+    ],
+    createdAt: "2026-08-16T00:00:00Z",
+    updatedAt: "2026-08-16T00:00:00Z",
+  };
+}
+
+/** start -> delay(delaySeconds) -> end. No waiting node at all — exercises
+ *  waitForScenarioArmed's bound (a scenario with nothing to arm on must not
+ *  hang the caller for the full delay). */
+function longDelayNoTriggerScenario(
+  connectorId: number,
+  delaySeconds: number,
+): ScenarioDefinition {
+  return {
+    id: `long-delay-no-trigger-${connectorId}`,
+    name: "Long Delay, No Trigger",
+    targetType: "connector",
+    targetId: connectorId,
+    nodes: [
+      {
+        id: "start-1",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "delay-1",
+        type: ScenarioNodeType.DELAY,
+        position: { x: 0, y: 1 },
+        data: { label: "Delay", delaySeconds },
+      },
+      {
+        id: "end-1",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 2 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e1", source: "start-1", target: "delay-1" },
+      { id: "e2", source: "delay-1", target: "end-1" },
+    ],
+    createdAt: "2026-08-16T00:00:00Z",
+    updatedAt: "2026-08-16T00:00:00Z",
+  };
+}
+
+describe("CLIChargePointService.waitForScenarioArmed", () => {
+  it("blocks until the trigger node arms, not just until run_scenario returns", async () => {
+    const svc = newService();
+    const id = svc.loadScenario(1, delayedRemoteStartScenario(1, 0.3));
+
+    const before = Date.now();
+    svc.runScenario(1, id);
+    // Fire-and-forget contract is unchanged: runScenario itself is still
+    // synchronous void and returns immediately.
+    expect(Date.now() - before).toBeLessThan(50);
+
+    await svc.waitForScenarioArmed(id);
+    const elapsed = Date.now() - before;
+
+    // Must not have resolved before the delay node let the executor reach
+    // the trigger — that's exactly the race this closes.
+    expect(elapsed).toBeGreaterThanOrEqual(280);
+    const status = svc.getScenarioStatus(1, id);
+    expect(status!.state).toBe("waiting");
+    expect(status!.expectation).toMatchObject({
+      action: "RemoteStartTransaction",
+    });
+
+    svc.stopScenario(1, id);
+  });
+
+  it("resolves immediately if the run is already armed by the time it's called", async () => {
+    const svc = newService();
+    const id = svc.loadScenario(1, delayedRemoteStartScenario(1, 0.05));
+    svc.runScenario(1, id);
+
+    // Let it actually arm first.
+    for (let i = 0; i < 100; i++) {
+      if (svc.getScenarioStatus(1, id)?.state === "waiting") break;
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    expect(svc.getScenarioStatus(1, id)!.state).toBe("waiting");
+
+    const before = Date.now();
+    await svc.waitForScenarioArmed(id);
+    expect(Date.now() - before).toBeLessThan(20);
+
+    svc.stopScenario(1, id);
+  });
+
+  it("is bounded by maxWaitMs when the run has no near-term expectation", async () => {
+    const svc = newService();
+    // 5s delay and no waiting node at all — without a bound this would hang
+    // the RPC caller for the whole delay.
+    const id = svc.loadScenario(1, longDelayNoTriggerScenario(1, 5));
+
+    const before = Date.now();
+    svc.runScenario(1, id);
+    await svc.waitForScenarioArmed(id, 100);
+    const elapsed = Date.now() - before;
+
+    expect(elapsed).toBeGreaterThanOrEqual(90);
+    expect(elapsed).toBeLessThan(1000);
+
+    svc.stopScenario(1, id);
+  });
+
+  it("resolves immediately for an unknown/already-finished scenarioId (never rejects)", async () => {
+    const svc = newService();
+    await expect(
+      svc.waitForScenarioArmed("no-such-scenario", 50),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/cli/server/RegistryChargePointService.ts
+++ b/src/cli/server/RegistryChargePointService.ts
@@ -521,9 +521,17 @@ export class RegistryChargePointService implements ChargePointService {
     id: string,
     connectorId: number,
     scenarioId: string,
-    options?: { strict?: boolean },
+    options?: { strict?: boolean; awaitArmed?: boolean },
   ): Promise<void> {
-    this.requireService(id).runScenario(connectorId, scenarioId, options);
+    const service = this.requireService(id);
+    service.runScenario(connectorId, scenarioId, options);
+    // Opt-in (see run_scenario's `awaitArmed` param / methods.ts): don't
+    // answer the RPC until the run has armed or ended. See
+    // CLIChargePointService.waitForScenarioArmed for why this closes the
+    // run_scenario / CSMS-command race.
+    if (options?.awaitArmed) {
+      await service.waitForScenarioArmed(scenarioId);
+    }
   }
 
   async runScenarioFile(

--- a/src/cli/server/__tests__/RegistryChargePointService.test.ts
+++ b/src/cli/server/__tests__/RegistryChargePointService.test.ts
@@ -623,6 +623,47 @@ describe("RegistryChargePointService", () => {
     await expect(service.getScenarioTemplates()).resolves.not.toHaveLength(0);
     await expect(service.resetAllState()).resolves.toBeUndefined();
   });
+
+  it("run_scenario's awaitArmed option blocks the RPC response until the trigger node arms", async () => {
+    const { registry, service } = createFacade();
+    registry.create(
+      {
+        cpId: "cp-await-armed",
+        wsUrl: "ws://example.test/ocpp",
+        connectors: 1,
+        vendor: "FacadeVendor",
+        model: "FacadeModel",
+        basicAuth: null,
+      },
+      { seedDefault: false },
+    );
+
+    const scenarioId = await service.loadScenario(
+      "cp-await-armed",
+      1,
+      delayedRemoteStartScenario("scenario-await-armed", 1, 0.2),
+    );
+
+    const before = Date.now();
+    await service.runScenario("cp-await-armed", 1, scenarioId.scenarioId, {
+      awaitArmed: true,
+    });
+    const elapsed = Date.now() - before;
+
+    // Must have actually waited for the delay node to let the executor
+    // reach the trigger — not returned the instant runScenario fired
+    // (the race this closes: a caller sending the CSMS-initiated call
+    // right after this resolves can no longer beat the scenario to it).
+    expect(elapsed).toBeGreaterThanOrEqual(180);
+    const status = await service.getScenarioStatus(
+      "cp-await-armed",
+      1,
+      scenarioId.scenarioId,
+    );
+    expect(status!.state).toBe("waiting");
+
+    await service.stopScenario("cp-await-armed", 1, scenarioId.scenarioId);
+  });
 });
 
 function createFacade(): {
@@ -758,6 +799,55 @@ function parkedScenario(
     trigger: { type: "manual" },
     defaultExecutionMode: "oneshot",
     evSettings,
+  };
+}
+
+/**
+ * Start -> Delay(delaySeconds) -> RemoteStartTrigger -> End. Mirrors the
+ * run_scenario / RemoteStartTransaction race's graph shape: the trigger
+ * only arms after the preceding node(s) run, so runScenario's fire-and-
+ * forget return does not mean the scenario is listening yet.
+ */
+function delayedRemoteStartScenario(
+  id: string,
+  connectorId: number,
+  delaySeconds: number,
+): ScenarioDefinition {
+  return {
+    ...scenarioDefinition(id, connectorId),
+    nodes: [
+      {
+        id: "start",
+        type: ScenarioNodeType.START,
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+      {
+        id: "delay",
+        type: ScenarioNodeType.DELAY,
+        position: { x: 0, y: 100 },
+        data: { label: "Delay", delaySeconds },
+      },
+      {
+        id: "trigger",
+        type: ScenarioNodeType.REMOTE_START_TRIGGER,
+        position: { x: 0, y: 200 },
+        data: { label: "Wait RemoteStart", timeout: 0 },
+      },
+      {
+        id: "end",
+        type: ScenarioNodeType.END,
+        position: { x: 0, y: 300 },
+        data: { label: "End" },
+      },
+    ],
+    edges: [
+      { id: "e-start", source: "start", target: "delay" },
+      { id: "e-delay", source: "delay", target: "trigger" },
+      { id: "e-trigger", source: "trigger", target: "end" },
+    ],
+    trigger: { type: "manual" },
+    defaultExecutionMode: "oneshot",
   };
 }
 

--- a/src/cli/server/socketServer.ts
+++ b/src/cli/server/socketServer.ts
@@ -1337,12 +1337,18 @@ async function dispatchFacadeCpCommand(
         params.strict === undefined
           ? undefined
           : requireBoolean(params, "strict");
+      const awaitArmed =
+        params.awaitArmed === undefined
+          ? undefined
+          : requireBoolean(params, "awaitArmed");
       await runFacadeOperation(() =>
         chargePointService.runScenario(
           id,
           requirePositiveInt(params, "connector"),
           requireString(params, "scenarioId"),
-          strict !== undefined ? { strict } : undefined,
+          strict !== undefined || awaitArmed !== undefined
+            ? { strict, awaitArmed }
+            : undefined,
         ),
       );
       return handled(undefined);

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -1359,6 +1359,19 @@ export class CLIChargePointService {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
+        // Drop this resolver from the map so a timed-out waiter doesn't
+        // linger for the scenario's whole lifetime. resolveScenarioArmedWaiters
+        // clears the entry wholesale on arming, but a long-running scenario
+        // that never arms would otherwise accumulate one stale closure per
+        // timed-out call.
+        const waiters = this._armedWaitersByScenario.get(scenarioId);
+        if (waiters) {
+          const index = waiters.indexOf(done);
+          if (index !== -1) waiters.splice(index, 1);
+          if (waiters.length === 0) {
+            this._armedWaitersByScenario.delete(scenarioId);
+          }
+        }
         resolve();
       };
       const waiters = this._armedWaitersByScenario.get(scenarioId) ?? [];

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -261,6 +261,12 @@ export class CLIChargePointService {
     { readonly definition: ScenarioDefinition; readonly connectorId: number }
   > = new Map();
   private readonly _executors: Map<string, ScenarioExecutor> = new Map();
+  // Resolvers for waitForScenarioArmed(scenarioId), keyed like _executors.
+  // Populated only when a caller actually opts in (run_scenario's
+  // awaitArmed); resolved and cleared by the onStateChange hook in
+  // runScenario the moment the run reaches "waiting" or a terminal state.
+  private readonly _armedWaitersByScenario: Map<string, Array<() => void>> =
+    new Map();
   // #179: stable per-run id for the currently-executing scenario, so status
   // and lifecycle events can be correlated to a specific run. Keyed like
   // _executors (by scenarioId) and cleared alongside it.
@@ -1149,6 +1155,21 @@ export class CLIChargePointService {
               data: { connectorId, scenarioId, runId },
             });
           }
+          // Resolve any pending waitForScenarioArmed() caller once the run
+          // either parks on its first expectation ("waiting" — e.g. a
+          // RemoteStartTransaction trigger has armed) or ends without ever
+          // parking ("completed"/"error", or "idle" via a manual stop). A
+          // caller that opted in (run_scenario's awaitArmed) is unblocked
+          // the instant the scenario is actually listening, closing the
+          // race with a CSMS command sent right after run_scenario returns.
+          if (
+            context.state === "waiting" ||
+            context.state === "completed" ||
+            context.state === "error" ||
+            context.state === "idle"
+          ) {
+            this.resolveScenarioArmedWaiters(scenarioId);
+          }
         },
         onNodeExecute: (nodeId) => {
           this.emit({
@@ -1290,6 +1311,60 @@ export class CLIChargePointService {
         // clears it, which is the case that can be non-null.
         null,
       );
+    });
+  }
+
+  /** Resolve (and clear) any pending waitForScenarioArmed() callers for
+   *  `scenarioId`. Called from runScenario's onStateChange hook. */
+  private resolveScenarioArmedWaiters(scenarioId: string): void {
+    const waiters = this._armedWaitersByScenario.get(scenarioId);
+    if (!waiters) return;
+    this._armedWaitersByScenario.delete(scenarioId);
+    waiters.forEach((resolve) => resolve());
+  }
+
+  /**
+   * Opt-in companion to runScenario (see run_scenario's `awaitArmed` param):
+   * resolves once the named run has either parked on its first expectation
+   * ("waiting" — e.g. a RemoteStartTrigger node armed
+   * registerScenarioHandler) or ended without ever parking. Without this, a
+   * caller that fires the CSMS-initiated command a scenario is meant to
+   * intercept immediately after run_scenario returns can race the trigger
+   * node's arming and have the command silently handled outside the
+   * scenario (see ScenarioRuntime.waitForRemoteStart/waitForRemoteStop).
+   *
+   * Resolves immediately if the run has already reached such a state by the
+   * time this is called (e.g. an already-armed trigger, or a scenario with
+   * no waiting nodes that finished before this was awaited), and is bounded
+   * by `maxWaitMs` so a scenario whose first node is a long delay can't hang
+   * the caller — it just resolves at the bound, same as not having awaited
+   * at all. Never rejects.
+   */
+  waitForScenarioArmed(scenarioId: string, maxWaitMs = 15_000): Promise<void> {
+    const executor = this._executors.get(scenarioId);
+    const state = executor?.getContext().state;
+    if (
+      !executor ||
+      state === "waiting" ||
+      state === "completed" ||
+      state === "error" ||
+      state === "idle"
+    ) {
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve) => {
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const waiters = this._armedWaitersByScenario.get(scenarioId) ?? [];
+      waiters.push(done);
+      this._armedWaitersByScenario.set(scenarioId, waiters);
+      const timer = setTimeout(done, maxWaitMs);
     });
   }
 

--- a/src/cp/application/scenario/ScenarioRuntime.ts
+++ b/src/cp/application/scenario/ScenarioRuntime.ts
@@ -37,7 +37,7 @@ const buildLogger = (
   chargePoint: ChargePoint,
   connector: Connector,
   hooks?: ScenarioRuntimeHooks,
-): ScenarioExecutorCallbacks["log"] => {
+): NonNullable<ScenarioExecutorCallbacks["log"]> => {
   return (rawMessage, level = "info") => {
     const message = `[connector ${connector.id}] ${rawMessage}`;
     switch (level) {
@@ -115,7 +115,9 @@ const cancellablePromise = <T>({
 const waitForRemoteStart = (
   chargePoint: ChargePoint,
   connector: Connector,
-  timeout?: number,
+  timeout: number | undefined,
+  log: NonNullable<ScenarioExecutorCallbacks["log"]>,
+  runStartedAt: number,
 ): CancellableWait<{ tagId: string; remoteStartId?: number }> => {
   // §4.9 S3: fail-fast if the charge point cannot receive RemoteStartTransaction
   if (!chargePoint.canReceiveCsmsCall("RemoteStartTransaction")) {
@@ -136,6 +138,29 @@ const waitForRemoteStart = (
 
   // Register so the handler emits remoteStartReceived instead of starting a transaction
   chargePoint.registerScenarioHandler(connector.id);
+
+  // Make the run_scenario / RemoteStartTransaction race visible: if this
+  // exact call already arrived (during this run) and was handled OUTSIDE
+  // the scenario before this trigger node could arm — see
+  // RemoteStartTransactionHandler / handleRequestStartTransactionV201's
+  // isScenarioHandled branches — it already started a real transaction
+  // directly and will not be redelivered. Without this warning the node
+  // just parks silently until its timeout (or forever), which is exactly
+  // what made the original bypass take hours to trace.
+  const missedAt = chargePoint.takeDefaultHandledRemoteStart(
+    connector.id,
+    runStartedAt,
+  );
+  if (missedAt !== null) {
+    log(
+      `RemoteStartTransaction arrived ${Math.max(0, Date.now() - missedAt)}ms ` +
+        "before this node armed and was handled OUTSIDE this scenario (a " +
+        "transaction was started directly). This node is now waiting for a " +
+        "RemoteStartTransaction that will likely never come — probably a " +
+        "race between run_scenario and the command that triggered this run.",
+      "warn",
+    );
+  }
 
   let cleanupFn: (() => void) | null = null;
 
@@ -203,7 +228,9 @@ const waitForRemoteStart = (
 const waitForRemoteStop = (
   chargePoint: ChargePoint,
   connector: Connector,
-  timeout?: number,
+  timeout: number | undefined,
+  log: NonNullable<ScenarioExecutorCallbacks["log"]>,
+  runStartedAt: number,
 ): CancellableWait<{
   transactionId: number;
   reason: string;
@@ -227,6 +254,22 @@ const waitForRemoteStop = (
   }
 
   chargePoint.registerScenarioStopHandler(connector.id);
+
+  // Mirror of waitForRemoteStart's bypass check, for the stop side.
+  const missedAt = chargePoint.takeDefaultHandledRemoteStop(
+    connector.id,
+    runStartedAt,
+  );
+  if (missedAt !== null) {
+    log(
+      `RemoteStopTransaction arrived ${Math.max(0, Date.now() - missedAt)}ms ` +
+        "before this node armed and was handled OUTSIDE this scenario (the " +
+        "transaction was stopped directly). This node is now waiting for a " +
+        "RemoteStopTransaction that will likely never come — probably a " +
+        "race between run_scenario and the command that triggered this run.",
+      "warn",
+    );
+  }
 
   let cleanupFn: (() => void) | null = null;
 
@@ -529,6 +572,12 @@ export const createScenarioExecutorCallbacks = (
   params: ScenarioRuntimeParams,
 ): ScenarioExecutorCallbacks => {
   const { chargePoint, connector, hooks } = params;
+  const log = buildLogger(chargePoint, connector, hooks);
+  // Anchors the "did a CSMS call bypass this scenario before it could arm?"
+  // check in waitForRemoteStart/waitForRemoteStop: only a bypass that
+  // happened during THIS run is worth warning about, not a stale one from
+  // an earlier, unrelated run on the same connector.
+  const runStartedAt = Date.now();
 
   const callbacks: ScenarioExecutorCallbacks & {
     onGetTransactionMeterStart: () => number | null;
@@ -626,12 +675,12 @@ export const createScenarioExecutorCallbacks = (
     },
     onWaitForRemoteStart: (timeout) => {
       return cancellablePromise(
-        waitForRemoteStart(chargePoint, connector, timeout),
+        waitForRemoteStart(chargePoint, connector, timeout, log, runStartedAt),
       );
     },
     onWaitForRemoteStop: (timeout) => {
       return cancellablePromise(
-        waitForRemoteStop(chargePoint, connector, timeout),
+        waitForRemoteStop(chargePoint, connector, timeout, log, runStartedAt),
       );
     },
     onWaitForCsmsCall: (action, timeout, payload) => {
@@ -685,7 +734,7 @@ export const createScenarioExecutorCallbacks = (
     onNodeExecute: hooks?.onNodeExecute,
     onNodeProgress: hooks?.onNodeProgress,
     onError: hooks?.onError,
-    log: buildLogger(chargePoint, connector, hooks),
+    log,
     // §4.9: connectorId === -1 sentinel means "use the scenario's bound
     // connector"; otherwise the node specified an explicit target (0 for
     // CP main controller, >0 for another connector).

--- a/src/cp/application/scenario/__tests__/ScenarioRuntime.soap-capability.test.ts
+++ b/src/cp/application/scenario/__tests__/ScenarioRuntime.soap-capability.test.ts
@@ -42,6 +42,8 @@ function createMockChargePoint(overrides?: Partial<ChargePoint>): ChargePoint {
     unregisterScenarioHandler: vi.fn(),
     registerScenarioStopHandler: vi.fn(),
     unregisterScenarioStopHandler: vi.fn(),
+    takeDefaultHandledRemoteStart: vi.fn().mockReturnValue(null),
+    takeDefaultHandledRemoteStop: vi.fn().mockReturnValue(null),
     events: {
       on: vi.fn(),
       off: vi.fn(),

--- a/src/cp/application/scenario/__tests__/remoteStartRace.test.ts
+++ b/src/cp/application/scenario/__tests__/remoteStartRace.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import { createScenarioExecutorCallbacks } from "../ScenarioRuntime";
+import { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { DefaultBootNotification } from "../../../domain/types/OcppTypes";
+import { RemoteStartTransactionHandler } from "../../../infrastructure/transport/handlers/call/RemoteStartTransactionHandler";
+import { RemoteStopTransactionHandler } from "../../../infrastructure/transport/handlers/call/RemoteStopTransactionHandler";
+import type { HandlerContext } from "../../../infrastructure/transport/handlers/MessageHandlerRegistry";
+
+/**
+ * A client that calls run_scenario and immediately fires the
+ * RemoteStartTransaction/RemoteStopTransaction the scenario is meant to
+ * intercept can race the trigger node's arming: ScenarioRuntime only calls
+ * ChargePoint.registerScenarioHandler when the executor actually reaches the
+ * trigger node (e.g. after preceding delay/plug-in nodes), not when
+ * run_scenario is called. Until then RemoteStartTransactionHandler /
+ * RemoteStopTransactionHandler / handleRequestStartTransactionV201 /
+ * handleRequestStopTransactionV201 take their default branch and start/stop
+ * a REAL transaction outside the scenario, silently. The scenario then
+ * parks at the trigger node waiting for a call that will never come again.
+ *
+ * These tests reproduce the race directly: call the real handler while
+ * unarmed (the bypass), then arm the trigger node the way ScenarioRuntime
+ * does, and assert the bypass is now reported via the scenario's log.
+ */
+function newChargePoint(id: string): ChargePoint {
+  // wsUrl points at an unused local port — no real transport connection is
+  // ever attempted, matching the pattern used by cert16RemoteStart.test.ts.
+  const cp = new ChargePoint(
+    id,
+    DefaultBootNotification,
+    1,
+    "ws://127.0.0.1:9/",
+    null,
+    null,
+  );
+  cp.events.on("error", () => undefined);
+  return cp;
+}
+
+describe("run_scenario / RemoteStartTransaction race — bypass visibility", () => {
+  it("warns when RemoteStartTransaction bypasses the scenario before the trigger node arms", async () => {
+    const cp = newChargePoint("CP-RACE-START");
+    const connector = cp.getConnector(1)!;
+    const logs: Array<{ message: string; level?: string }> = [];
+
+    // run_scenario's callbacks are built the instant the run starts (this
+    // is what anchors runStartedAt) — well before the executor's delay/
+    // plug-in nodes let it reach the trigger node and actually arm.
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector,
+      hooks: { log: (message, level) => logs.push({ message, level }) },
+    });
+
+    // The race: a RemoteStartTransaction arrives (and is handled by the
+    // DEFAULT path, starting a real transaction) BEFORE the scenario's
+    // trigger node has had a chance to call registerScenarioHandler.
+    expect(cp.isScenarioHandled(1)).toBe(false);
+    new RemoteStartTransactionHandler().handle(
+      { idTag: "RACE-TAG", connectorId: 1 },
+      { chargePoint: cp, logger: cp.logger } satisfies HandlerContext,
+    );
+    expect(connector.transaction).not.toBeNull();
+
+    // The scenario now reaches its trigger node and arms — exactly what
+    // ScenarioRuntime.waitForRemoteStart does via onWaitForRemoteStart.
+    const wait = callbacks.onWaitForRemoteStart!(0);
+
+    const warning = logs.find(
+      (l) => l.level === "warn" && l.message.includes("RemoteStartTransaction"),
+    );
+    expect(warning).toBeDefined();
+    expect(warning!.message).toMatch(/handled OUTSIDE this scenario/);
+    expect(warning!.message).toMatch(/race between run_scenario/);
+
+    wait.cancel?.();
+  });
+
+  it("does NOT warn when the trigger node armed before RemoteStartTransaction arrived (normal order)", async () => {
+    const cp = newChargePoint("CP-RACE-START-OK");
+    const connector = cp.getConnector(1)!;
+    const logs: Array<{ message: string; level?: string }> = [];
+
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector,
+      hooks: { log: (message, level) => logs.push({ message, level }) },
+    });
+    const wait = callbacks.onWaitForRemoteStart!(0);
+    expect(cp.isScenarioHandled(1)).toBe(true);
+
+    new RemoteStartTransactionHandler().handle(
+      { idTag: "NORMAL-TAG", connectorId: 1 },
+      { chargePoint: cp, logger: cp.logger } satisfies HandlerContext,
+    );
+
+    const result = await wait;
+    expect(typeof result === "string" ? result : result.tagId).toBe(
+      "NORMAL-TAG",
+    );
+    expect(
+      logs.some((l) => l.level === "warn" && l.message.includes("race")),
+    ).toBe(false);
+  });
+
+  it("does NOT warn about a bypass that predates this run (stale/unrelated)", async () => {
+    const cp = newChargePoint("CP-RACE-START-STALE");
+    const connector = cp.getConnector(1)!;
+    const logs: Array<{ message: string; level?: string }> = [];
+
+    // A RemoteStartTransaction is bypassed well before anything about a new
+    // scenario run exists yet — e.g. a leftover from a previous, unrelated
+    // run on this same connector.
+    new RemoteStartTransactionHandler().handle(
+      { idTag: "OLD-TAG", connectorId: 1 },
+      { chargePoint: cp, logger: cp.logger } satisfies HandlerContext,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Only now does the (new, unrelated) run's callbacks get built and its
+    // trigger node arm — createScenarioExecutorCallbacks captures its own
+    // runStartedAt at this point, strictly after the stale bypass above.
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector,
+      hooks: { log: (message, level) => logs.push({ message, level }) },
+    });
+    const wait = callbacks.onWaitForRemoteStart!(0);
+
+    expect(
+      logs.some((l) => l.level === "warn" && l.message.includes("race")),
+    ).toBe(false);
+
+    wait.cancel?.();
+  });
+
+  it("warns when RemoteStopTransaction bypasses the scenario before the trigger node arms", async () => {
+    const cp = newChargePoint("CP-RACE-STOP");
+    const connector = cp.getConnector(1)!;
+    const logs: Array<{ message: string; level?: string }> = [];
+
+    await cp.startTransaction("RACE-TAG", 1, undefined, undefined, {
+      triggerReason: "RemoteStart",
+    });
+    const txId = connector.transaction!.id;
+
+    // See the RemoteStart test above: callbacks (and runStartedAt) must
+    // exist before the bypass, mirroring run_scenario building them at run
+    // start, well before the trigger node actually arms.
+    const callbacks = createScenarioExecutorCallbacks({
+      chargePoint: cp,
+      connector,
+      hooks: { log: (message, level) => logs.push({ message, level }) },
+    });
+
+    expect(cp.isScenarioStopHandled(1)).toBe(false);
+    new RemoteStopTransactionHandler().handle({ transactionId: txId }, {
+      chargePoint: cp,
+      logger: cp.logger,
+    } satisfies HandlerContext);
+    expect(connector.transaction).toBeNull();
+
+    const wait = callbacks.onWaitForRemoteStop!(0);
+
+    const warning = logs.find(
+      (l) => l.level === "warn" && l.message.includes("RemoteStopTransaction"),
+    );
+    expect(warning).toBeDefined();
+    expect(warning!.message).toMatch(/handled OUTSIDE this scenario/);
+
+    wait.cancel?.();
+  });
+});

--- a/src/cp/domain/charge-point/ChargePoint.ts
+++ b/src/cp/domain/charge-point/ChargePoint.ts
@@ -161,6 +161,22 @@ export class ChargePoint {
   // itself — the scenario is parked on a RemoteStopTrigger node and will
   // resume into its own Transaction Stop step.
   private readonly _scenarioStopHandledConnectors: Set<number> = new Set();
+  // Diagnostic-only, paired with _scenarioHandledConnectors: whenever
+  // RemoteStartTransaction lands via the DEFAULT path (no scenario armed on
+  // this connector yet), the timestamp is recorded here. A scenario that
+  // arms afterwards (registerScenarioHandler) consults this to detect that
+  // it just missed a call that arrived while it was still walking toward
+  // the trigger node — the "run_scenario raced RemoteStartTransaction"
+  // footgun: the CSMS command silently starts a real transaction outside
+  // the scenario, and the scenario then parks forever waiting for a call
+  // that already happened. Consumed (deleted) on read via
+  // takeDefaultHandledRemoteStart, so a warning never fires twice and a
+  // stale/unrelated bypass can't leak into a later, unconnected run.
+  private readonly _lastDefaultHandledRemoteStart: Map<number, number> =
+    new Map();
+  // Mirror of the above for the RemoteStopTransaction / stop-side bypass.
+  private readonly _lastDefaultHandledRemoteStop: Map<number, number> =
+    new Map();
   /** One-shot canned `{ status }` responses per incoming action,
    *  armed by a scenario responseOverride node (issue #110). */
   private readonly _responseOverrides = new Map<string, string>();
@@ -664,6 +680,28 @@ export class ChargePoint {
     });
   }
 
+  /** Record that RemoteStartTransaction for `connectorId` was just handled
+   *  by the default (non-scenario) path — i.e. isScenarioHandled(connectorId)
+   *  was false at delivery time. See _lastDefaultHandledRemoteStart. */
+  noteDefaultHandledRemoteStart(connectorId: number): void {
+    this._lastDefaultHandledRemoteStart.set(connectorId, Date.now());
+  }
+
+  /** Consume (and remove) the timestamp recorded by
+   *  noteDefaultHandledRemoteStart for `connectorId`, if any exists at or
+   *  after `sinceMs`. Returns that epoch-ms timestamp, or null if there is
+   *  none — or it predates `sinceMs`, i.e. it's a stale bypass from before
+   *  the caller's own run started and therefore unrelated to it. Always
+   *  deletes the entry so a stale record can't linger indefinitely. */
+  takeDefaultHandledRemoteStart(
+    connectorId: number,
+    sinceMs: number,
+  ): number | null {
+    const ts = this._lastDefaultHandledRemoteStart.get(connectorId);
+    this._lastDefaultHandledRemoteStart.delete(connectorId);
+    return ts !== undefined && ts >= sinceMs ? ts : null;
+  }
+
   /**
    * Counterpart of registerScenarioHandler for the stop side: a
    * RemoteStopTrigger scenario node registers here so the next
@@ -685,6 +723,21 @@ export class ChargePoint {
 
   notifyRemoteStopReceived(connectorId: number, transactionId: number): void {
     this._events.emit("remoteStopReceived", { connectorId, transactionId });
+  }
+
+  /** Mirror of noteDefaultHandledRemoteStart for the stop side. */
+  noteDefaultHandledRemoteStop(connectorId: number): void {
+    this._lastDefaultHandledRemoteStop.set(connectorId, Date.now());
+  }
+
+  /** Mirror of takeDefaultHandledRemoteStart for the stop side. */
+  takeDefaultHandledRemoteStop(
+    connectorId: number,
+    sinceMs: number,
+  ): number | null {
+    const ts = this._lastDefaultHandledRemoteStop.get(connectorId);
+    this._lastDefaultHandledRemoteStop.delete(connectorId);
+    return ts !== undefined && ts >= sinceMs ? ts : null;
   }
 
   notifyIncomingCall(action: string, payload: unknown): void {
@@ -1288,6 +1341,8 @@ export class ChargePoint {
     this._signedFirmwareUpdateInFlight = false;
     this._scenarioHandledConnectors.clear();
     this._scenarioStopHandledConnectors.clear();
+    this._lastDefaultHandledRemoteStart.clear();
+    this._lastDefaultHandledRemoteStop.clear();
     // Issue #110: stale response overrides must not survive a
     // disconnect — they would silently answer the next real CSMS call.
     this._responseOverrides.clear();

--- a/src/cp/infrastructure/transport/handlers/call/RemoteStartTransactionHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/RemoteStartTransactionHandler.ts
@@ -47,6 +47,11 @@ export class RemoteStartTransactionHandler implements CallHandler<
       // Scenario is waiting for RemoteStart - let it handle the transaction flow
       context.chargePoint.notifyRemoteStartReceived(resolvedConnectorId, idTag);
     } else {
+      // Not scenario-handled: note it so a scenario that arms on this
+      // connector shortly after can tell it raced this exact call and warn
+      // instead of silently parking forever (see
+      // ScenarioRuntime.waitForRemoteStart).
+      context.chargePoint.noteDefaultHandledRemoteStart(resolvedConnectorId);
       // triggerReason: "RemoteStart" marks this as CSMS-initiated so
       // ChargePoint.startTransaction's #181 local-authorize gate doesn't
       // double-authorize on top of the AuthorizeRemoteTxRequests handling

--- a/src/cp/infrastructure/transport/handlers/call/RemoteStopTransactionHandler.ts
+++ b/src/cp/infrastructure/transport/handlers/call/RemoteStopTransactionHandler.ts
@@ -25,6 +25,11 @@ export class RemoteStopTransactionHandler implements CallHandler<
       context.chargePoint.notifyRemoteStopReceived(connector.id, transactionId);
       return { status: "Accepted" };
     }
+    // Not scenario-handled: note it so a scenario that arms
+    // registerScenarioStopHandler on this connector shortly after can tell
+    // it raced this exact call and warn instead of silently parking forever
+    // (see ScenarioRuntime.waitForRemoteStop).
+    context.chargePoint.noteDefaultHandledRemoteStop(connector.id);
     context.chargePoint.updateConnectorStatus(
       connector.id,
       OCPPStatus.SuspendedEVSE,

--- a/src/cp/infrastructure/transport/v201/transactionControlV201.ts
+++ b/src/cp/infrastructure/transport/v201/transactionControlV201.ts
@@ -43,6 +43,11 @@ export function handleRequestStartTransactionV201(
           req.remoteStartId,
         );
       } else {
+        // Not scenario-handled: note it so a scenario that arms on this
+        // connector shortly after can tell it raced this exact call and
+        // warn instead of silently parking forever (see
+        // ScenarioRuntime.waitForRemoteStart).
+        ctx.chargePoint.noteDefaultHandledRemoteStart(connectorId);
         ctx.chargePoint.startTransaction(
           idTag,
           connectorId,
@@ -84,6 +89,11 @@ export function handleRequestStopTransactionV201(
       if (ctx.chargePoint.isScenarioStopHandled(connector.id)) {
         ctx.chargePoint.notifyRemoteStopReceived(connector.id, txId);
       } else {
+        // Not scenario-handled: note it so a scenario that arms
+        // registerScenarioStopHandler on this connector shortly after can
+        // tell it raced this exact call and warn instead of silently
+        // parking forever (see ScenarioRuntime.waitForRemoteStop).
+        ctx.chargePoint.noteDefaultHandledRemoteStop(connector.id);
         ctx.chargePoint.stopTransaction(connector.id, "Remote", {
           triggerReason: "RemoteStop",
         });

--- a/src/protocol/methods.ts
+++ b/src/protocol/methods.ts
@@ -239,6 +239,14 @@ export const METHODS = {
       connector: CONN_POS,
       scenarioId: STR_64K,
       strict: z.boolean().optional(),
+      // Opt-in: block the RPC response until the run has either parked on
+      // its first expectation (armed — e.g. a RemoteStartTransaction
+      // trigger) or ended without ever parking, instead of returning the
+      // instant the run is kicked off. Closes the run_scenario /
+      // CSMS-command race for a caller that fires the CSMS-initiated call
+      // right after run_scenario returns and needs to know the scenario is
+      // actually listening first — see CLIChargePointService.waitForScenarioArmed.
+      awaitArmed: z.boolean().optional(),
     }),
     result: ANY,
   },


### PR DESCRIPTION
Found while driving this simulator from an automated charging-test runner. A charge appeared to run normally for its full 12 minutes but emitted **zero MeterValues**, so the system under test billed ¥0. It took hours to trace because nothing anywhere reported that anything had gone wrong.

## The race

`ScenarioRuntime` calls `chargePoint.registerScenarioHandler()` only when the executor **reaches** the RemoteStart/RemoteStop trigger node — not when `run_scenario` is called, which returns almost immediately (`CLIChargePointService.runScenario` is fire-and-forget).

For a scenario shaped `start → delay-2s → plug-in → delay-1s → trigger-remote-start → tx-start → meter-auto`, that leaves a **~3 second window**. A client that calls `run_scenario` and then immediately sends `RemoteStartTransaction` beats the trigger to arming. `RemoteStartTransactionHandler` (and its RemoteStop / v201 twins) sees `isScenarioHandled() === false`, takes the default path, and starts a **real transaction outside the scenario**.

The consequences are all silent:
- the transaction runs and the CP reports `Charging` for the full duration
- the scenario's `meter-auto` node never executes, so **no MeterValues are emitted**
- the scenario parks at the trigger node forever, waiting for a call that already happened and is never redelivered
- `list_scenarios` keeps reporting `active: true`

Reproduced live on a staging deployment: 5 of 8 concurrent test charges hit it, and it reproduced solo too — the connector's meter did not move once across 11 minutes of `Charging`.

Investigated all five trigger/expectation node types. **Only RemoteStart/RemoteStop have this window** — `csmsCallTrigger` is observe-only by design, `reservationTrigger`/`connectionTrigger` are level-triggered so no call is lost, and `statusTrigger` isn't CSMS-driven.

## The fix, in two parts

**1. Visibility (default behavior unchanged).** `ChargePoint` timestamps a default-handled RemoteStart/RemoteStop per connector. When the trigger node later arms, it consumes that timestamp — bounded by the run's own start time, so a stale bypass from an earlier unrelated run cannot false-positive — and logs a warning naming the race instead of parking silently.

This is checked **at arm time rather than at bypass time on purpose**: at bypass time the executor is still inside a preceding delay/plug-in node, `deriveExpectation` is null, and a check there would have logged nothing for the very incident that motivated this change.

**2. Closing the window (opt-in).** `run_scenario` gains an `awaitArmed` option (bounded, 15s) that resolves only once the executor has reached its first expectation-bearing node. Callers that opt in cannot race. **Default behavior is unchanged**, so existing users are unaffected.

**Not implemented: pre-arming expectations at scenario start.** It was evaluated and rejected — it would change default behavior for every existing scenario, which is too large a blast radius for this problem.

## Tests

New: `remoteStartRace.test.ts` (4 cases, vitest, real `ChargePoint` and real handlers) and `service.scenarioArmedRace.bun.test.ts` (4 cases, bun, real `CLIChargePointService`), plus one case appended to `RegistryChargePointService.test.ts`. All were demonstrated failing without the fix and passing with it.

`bun run test:bun` (the CI script): 424 pass / 0 fail. Scoped vitest sweep of the affected areas: 2753 tests, all pass. Scoped eslint/prettier on all touched files: clean.

## Pre-existing issues, untouched

- Repo-wide `bun run test:vitest` / `bun run lint` fail only because of leftover untracked `.claude/worktrees/*` agent sessions (multiple `tsconfigRootDir`s, duplicate React copies) — unrelated to this diff and not mine to delete
- `toolkitMeterAnomaly.test.ts` fails on a clean tree too (verified via stash)
- One pre-existing non-gated `tsc` error class in `RemoteStopTransactionHandler.ts` (ambient OCPP types unresolvable under standalone `tsc`, which isn't part of this repo's toolchain or CI) gains one more instance

## Follow-ups deliberately left

- `run_scenario_file` / `run_scenario_template` have the same shape and would want the same `awaitArmed` treatment
- no dedicated v201 unit test (the v201 path is covered indirectly)
- Local/browser mode gets the visibility half for free, but not `awaitArmed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvQAUu3ExbAnp3mmwJvZsE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to wait until a scenario is armed before completing a scenario run.
  * Added bounded waiting with immediate completion for already armed, completed, or unknown scenarios.
* **Bug Fixes**
  * Improved detection and warning of remote start or stop requests that occur before a scenario trigger is ready.
  * Prevented stale requests from being incorrectly associated with later scenario runs.
* **Tests**
  * Added coverage for delayed triggers, timeouts, completed scenarios, and remote transaction race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->