### PR TITLE
build(docker): retry bun install so a flaky tarball does not lose a release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,25 @@ WORKDIR /app
 # Need every dep (including devDependencies: vite, plugins, tailwind).
 # --ignore-scripts skips husky/postinstall hooks.
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile --ignore-scripts
+# `bun install` reaches the network for every package, and a transient
+# tarball-extraction failure there fails the whole build:
+#
+#   error: Fail extracting tarball for "@swc/core-linux-arm64-gnu"
+#
+# That is what left v0.7.6 without a published image (#281) — the tag build
+# is a one-shot, so a hiccup that a re-run would have survived becomes a
+# release whose notes promise an image the registry does not have. Retry a
+# few times with a short backoff, and clear bun's cache between attempts so
+# a half-extracted entry is not reused. A genuine failure (a lockfile that
+# does not match, a package that does not exist) still fails, three times
+# and roughly 20 seconds slower.
+RUN for attempt in 1 2 3; do \
+      bun install --frozen-lockfile --ignore-scripts && break; \
+      [ "$attempt" = 3 ] && { echo "bun install failed 3 times; giving up"; exit 1; }; \
+      echo "bun install failed (attempt $attempt/3); retrying"; \
+      rm -rf /root/.bun/install/cache node_modules; \
+      sleep $((attempt * 5)); \
+    done
 
 # Source for the UI build: index.html + src/ + Vite/Tailwind/TS configs.
 COPY index.html ./
@@ -73,7 +91,14 @@ RUN bun run build
 FROM oven/bun:${BUN_VERSION}-alpine AS deps
 WORKDIR /app
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile --production --ignore-scripts
+# Same retry as the ui stage, and for the same reason (#281).
+RUN for attempt in 1 2 3; do \
+      bun install --frozen-lockfile --production --ignore-scripts && break; \
+      [ "$attempt" = 3 ] && { echo "bun install failed 3 times; giving up"; exit 1; }; \
+      echo "bun install failed (attempt $attempt/3); retrying"; \
+      rm -rf /root/.bun/install/cache node_modules; \
+      sleep $((attempt * 5)); \
+    done
 
 
 # ----- Stage 3: the runtime image -------------------------------------


### PR DESCRIPTION
Follow-up from #281.

The `v0.7.6` tag build failed on a transient tarball extraction:

```
error: Fail extracting tarball for "@swc/core-linux-arm64-gnu"
ERROR: process "/bin/sh -c bun install --frozen-lockfile --ignore-scripts" did not complete successfully: exit code: 1
```

A tag build is a one-shot, so that hiccup left GHCR without a `0.7.6` image while the release notes said it had one — visible only by querying the registry. (`0.7.1` is missing for what looks like the same reason.)

Both `bun install` steps in the Dockerfile now retry up to three times, clearing bun's install cache and `node_modules` between attempts so a half-extracted entry is not reused:

```dockerfile
RUN for attempt in 1 2 3; do \
      bun install --frozen-lockfile --ignore-scripts && break; \
      [ "$attempt" = 3 ] && { echo "bun install failed 3 times; giving up"; exit 1; }; \
      echo "bun install failed (attempt $attempt/3); retrying"; \
      rm -rf /root/.bun/install/cache node_modules; \
      sleep $((attempt * 5)); \
    done
```

A genuine failure — a lockfile that does not match, a package that does not exist — still fails the build, three attempts and about 15 seconds later.

## Verification

- `docker build --target deps` — succeeds (266 packages), so the loop does not change the working path.
- Failure path, with the install replaced by `false`: prints attempts 1 and 2, then `bun install failed 3 times; giving up`, and the build exits 1. It does not mask a persistent failure.
- Success path: breaks on the first attempt, prints nothing extra, and the next layer runs.

Images for both affected releases are already out: 0.7.6 came back from a re-run of the failed job, and 0.7.7 published normally. This is so the next one does not need a re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaGcGSwBtuTVJuGWbWFjMw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build and production dependency installation reliability by automatically retrying failed attempts up to three times.
  * Persistent failures now report an error after all retry attempts are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->