### PR TITLE
fix(desktop): unbreak the Tauri sidecar build, and make CI compile it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,18 @@ jobs:
       - name: Format check
         run: bun run format:check
 
+      # The desktop release compiles the CLI into a Tauri sidecar with
+      # `bun build --compile`, and that is the ONLY thing here that resolves
+      # every import: the runtime elides type-only ones, so a wrong path in
+      # an `import type` (or in a value import used only as a type) is
+      # invisible to lint and to both test runners. Three such imports in
+      # MessageHandlerRegistry.ts broke the v0.7.6 and v0.7.7 desktop builds
+      # and were noticed only after the releases were out (#281). Compiling
+      # for the host target takes seconds and fails the same way the release
+      # would, on the pull request instead of on the tag.
+      - name: CLI sidecar compiles (release smoke)
+        run: bun build --compile --outfile=/tmp/ocpp-cp-sim-smoke src/cli/main.ts
+
       - name: Unit tests (vitest)
         run: bun run test:vitest
 

--- a/src/cp/infrastructure/transport/handlers/MessageHandlerRegistry.ts
+++ b/src/cp/infrastructure/transport/handlers/MessageHandlerRegistry.ts
@@ -50,9 +50,9 @@ import type {
   UpdateFirmwareRequestV16,
   UpdateFirmwareResponseV16,
 } from "../../../../ocpp";
-import { OCPPAction } from "../../../../domain/types/OcppTypes";
-import type { ChargePoint } from "../../../../domain/charge-point/ChargePoint";
-import { Logger } from "../../../../shared/Logger";
+import { OCPPAction } from "../../../domain/types/OcppTypes";
+import type { ChargePoint } from "../../../domain/charge-point/ChargePoint";
+import { Logger } from "../../../shared/Logger";
 import type { HandlerOutcome } from "../network-sim/ResponseEffectQueue";
 
 /**


### PR DESCRIPTION
The desktop app has shipped no binaries since v0.7.5. The `Release Desktop App` runs for **v0.7.6** and **v0.7.7** both failed, on all four targets, at the `Build CLI sidecar (Bun --compile)` step:

```
53 | import { OCPPAction } from "../../../../domain/types/OcppTypes";
error: Could not resolve: "../../../../domain/types/OcppTypes"
    at src/cp/infrastructure/transport/handlers/MessageHandlerRegistry.ts:53:28
55 | import { Logger } from "../../../../shared/Logger";
error: Could not resolve: "../../../../shared/Logger"
```

## The bug

`MessageHandlerRegistry.ts` sits in `src/cp/infrastructure/transport/handlers/`, so `../../../../` is `src/` — and there is no `src/domain` or `src/shared`. The modules are at `src/cp/domain/` and `src/cp/shared/`, three levels up. The sibling handlers in `handlers/call/` are one directory deeper, which is why the same four-dot spelling is correct in them and wrong here.

Three imports, fixed to `../../../`.

## Why nothing caught it

`Logger` is used only as a type annotation and `OCPPAction` only in type positions, so the transpiler elides both imports and neither test runner ever resolves them — `bun run` of the same file works fine. There is no `tsc --noEmit` in CI. The bundler resolves every import record whether or not it will be elided, so the one thing that failed was `bun build --compile`, and that runs only in the sidecar step of a `vX.Y.Z` tag build.

That is the same shape as #281: a release pipeline failing after the release is published, where the gap is invisible until someone looks at the registry — or, here, at the release assets.

## The guard

`bun build --compile` for the host target is now a CI step, before the unit tests. It takes about 0.2 s on a warm checkout, and it resolves exactly what the runtime elides.

I verified it fails for the right reason: restoring one of the three imports to its old depth turns the step red (exit 1); with all three correct it bundles 1 247 modules and the produced binary answers `--help`.

## Verification

- `bun build --compile` — 1 247 modules, and `/tmp/ocpp-cp-sim-smoke --help` prints the usage.
- `bun run test:vitest` — 193 files, 2 200 tests passed.
- `bun run test:bun` — 425 passed, 1 skipped.
- `bun run lint`, `bun run format:check` — clean.

I also swept every relative import under `src/` for the same class of defect. These three were the only reachable ones. `src/v1/main.tsx` imports `./App.tsx` where the file is `V1App.tsx`, but that entry point is referenced by nothing (no HTML input, no importer) — dead code, left alone here rather than widening this PR.

**v0.7.6 and v0.7.7 still have no desktop assets.** Their tags predate this commit, so re-running those workflows would fail again; the assets need a release cut after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaGcGSwBtuTVJuGWbWFjMw
