### PR TITLE
docs(roadmap): sequence the fleet, load and observability work (#295-#302)

### DIFF
--- a/docs/analyses/choosing-an-interface.md
+++ b/docs/analyses/choosing-an-interface.md
@@ -13,7 +13,8 @@ related:
   - ../entities/docker-image.md
   - ../entities/mcp-endpoint.md
   - ../concepts/local-vs-remote-mode.md
-updated: 2026-09-03
+  - fleet-load-and-observability-roadmap.md
+updated: 2026-09-04
 ---
 
 # Choosing an interface

--- a/docs/analyses/fleet-load-and-observability-roadmap.md
+++ b/docs/analyses/fleet-load-and-observability-roadmap.md
@@ -13,6 +13,7 @@ related:
   - ../concepts/control-plane.md
   - ../entities/daemon.md
   - choosing-an-interface.md
+  - ../sources/github-issues.md
 updated: 2026-09-04
 ---
 
@@ -33,6 +34,9 @@ dependency. Every item carries the files and RPCs it touches, its acceptance
 criteria and a size. Per the [ingest rule](../../CLAUDE.md), the PR that ships
 an item updates its row here — status and issue number — in the same commit, so
 this page stays true as work lands.
+
+Issue provenance for every row below is indexed in
+[GitHub issues](../sources/github-issues.md).
 
 **Size key:** S = a few files, one RPC. M = a new subsystem behind an existing
 seam. L = crosses persistence, UI and the scenario schema, or changes the
@@ -90,16 +94,27 @@ cp.create_many {
 Partial success is the honest result: one bad CSMS URL should not roll back 199
 good CPs. Creation stays sequential so registry events fire in id order.
 
-**Touches.** `src/protocol/methods.ts` (`cpParamsBaseSchema` is already
-factored out — reuse it, do not restate it), `src/cli/server/socketServer.ts`
-(`dispatchRpcCore`), `src/cli/server/CPRegistry.ts`, and a CLI flag pair
-(`--cp-count`, `--cp-id-pattern`) in `src/cli/main.ts`.
+**Derive the schema — but from the right one.** `cpParamsBaseSchema` is not
+it: it requires `cpId` (which bulk creation generates) and it does _not_ carry
+`basicAuth`, which `createParamsSchema` adds by `.extend()`. So the bulk schema
+is `createParamsSchema.omit({ cpId: true }).extend({ count, idPattern, startIndex })`.
+
+One loose end to close while here: `autoConnect` is declared in no schema —
+`createCp` reads it straight off the raw params
+(`rawParamsAsRecord(rawParams).autoConnect`). Bulk creation should declare it
+rather than copy that.
+
+**Touches.** `src/protocol/methods.ts`, `src/cli/server/socketServer.ts`
+(`dispatchRpcCore`), `src/cli/server/CPRegistry.ts`, a curated tool in
+`src/cli/server/mcp/tools.ts`, and a CLI flag pair (`--cp-count`,
+`--cp-id-pattern`) in `src/cli/main.ts`.
 
 **Acceptance.**
 
-- The MCP tool is _derived_ from the zod schema, not restated — this is the
-  lesson from #284 and the reason `cp_create` and `cp.create` stopped
-  disagreeing.
+- A `cp_create_many` tool is registered in `src/cli/server/mcp/tools.ts` — the
+  curated tools are registered by hand there, so adding the method to `METHODS`
+  alone would only reach it through the generic `call_method` — and its schema
+  is _derived_, not restated (the lesson from #284).
 - A documented, enforced `count` ceiling (`src/protocol/limits.ts`), and a row
   in [Control plane](../concepts/control-plane.md).
 - e2e against gocpp: create 20 CPs, all reach BootNotification Accepted.
@@ -110,18 +125,39 @@ factored out — reuse it, do not restate it), `src/cli/server/socketServer.ts`
 
 **Shape.** `wsUrl` accepts `string | string[]`, plus
 `urlDistribution: "round-robin" | "random" | "cp-affinity"` (default
-`round-robin`). `cp-affinity` hashes the `cpId` so a CP keeps its URL across
-restarts — that is the one policy that makes a reconnect deterministic.
+`round-robin`).
 
-**Touches.** `cpParamsBaseSchema`, and URL selection in
+**Failover semantics — state it, do not imply it.** `round-robin` and `random`
+move to another URL on every reconnect attempt. `cp-affinity` hashes the `cpId`
+to a **primary** and is sticky: it retries that primary and only falls over
+after a configured number of consecutive failures, returning to it as soon as it
+is reachable again. "Sticky" and "always rotates" are contradictory, and
+choosing between them silently is how an acceptance test ends up asserting the
+opposite of the implementation.
+
+**Scope it to OCPP-J, and resolve before persisting.** `wsUrl` is a `string`
+well past the schema: `buildBaseUrl(wsUrl: string, cpId: string)` in
+`src/cli/service.ts`, the `ChargePoint` init options, the status snapshot, and
+`charge_points.ws_url TEXT NOT NULL` in `src/cp/domain/persistence/schema.ts`.
+So:
+
+- The list is an **OCPP-J** concept. SOAP takes `centralSystemUrl` and has no
+  reconnect loop to rotate; reject an array there rather than half-supporting it.
+- Keep the list in the CP's config and resolve one URL at connect time. What is
+  persisted and reported in the snapshot stays a single string, so neither the
+  DB schema nor the restore path changes.
+
+**Touches.** `cpParamsBaseSchema` in `src/protocol/methods.ts`, the resolution
+step in `src/cli/service.ts`, and URL selection in
 `src/cp/infrastructure/transport/OCPPWebSocket.ts` beside the existing
-exponential-backoff logic (~L820). Reconnect rotates to the next URL, so a
-dead node drains rather than blocking a CP forever.
+exponential-backoff logic (~L820).
 
-**Acceptance.** Reconnect after a forced disconnect lands on a different URL
-under `round-robin` and the same URL under `cp-affinity`; covered by a unit
-test, reusing [network simulation](../concepts/network-simulation.md) to force
-the disconnect.
+**Acceptance.** After a forced disconnect (reusing
+[network simulation](../concepts/network-simulation.md)) `round-robin` lands on
+the next URL while `cp-affinity` retries its primary; after the configured
+number of consecutive failures `cp-affinity` moves on, and returns to the
+primary once it is reachable. A SOAP CP rejects an array `wsUrl` with a clear
+error. The persisted `ws_url` and the status snapshot are unchanged in shape.
 
 ### 1c. CP blueprints
 
@@ -205,11 +241,18 @@ field, so this is a separate tap, not a trace consumer.
 **Access control — decide explicitly.** `/v1/healthz` is deliberately
 unauthenticated so container probes work. `/metrics` is different: it exposes
 fleet size and traffic shape. Default it **behind the existing Basic Auth
-gate**, with a documented opt-out flag for a trusted network, and add the row to
-the policy table in [Access control](../concepts/access-control.md).
+gate** — `--web-console-basic-auth-user` / `--web-console-basic-auth-pass`,
+which already covers static assets, the Socket.IO handshake, `POST /mcp` and
+the SOAP callback, and from which only the health path is exempt.
+(`--basic-auth-user/pass` is the CSMS-facing credential and unrelated;
+`--http-basic-auth-user/pass` is what `analyze --from-daemon` uses to
+authenticate _to_ a daemon.) Add a documented opt-out flag for a trusted
+network, and add the row to the policy table in
+[Access control](../concepts/access-control.md#basic-auth-gate).
 
 **Acceptance.** A scrape parses under `promtool check metrics`; the endpoint
-returns 401 under `--basic-auth` without credentials; counters survive a CP
+returns 401 under `--web-console-basic-auth-user/pass` without credentials and
+`/v1/healthz` stays exempt; counters survive a CP
 reconnect.
 
 ## Phase 3 — Background load

--- a/docs/analyses/fleet-load-and-observability-roadmap.md
+++ b/docs/analyses/fleet-load-and-observability-roadmap.md
@@ -1,0 +1,399 @@
+---
+title: Fleet, load and observability roadmap
+type: analysis
+summary: Sequenced plan for the capabilities this simulator does not yet have — bulk CP creation and blueprints, a metrics endpoint, seeded background traffic with an idTag pool, a charging-curve EV model, a measured scale ceiling, and file hot-reload — with the files and RPCs each phase touches, acceptance criteria, and dependencies.
+sources:
+  - src/protocol/methods.ts
+  - src/cli/server/socketServer.ts
+  - src/cli/server/httpServer.ts
+  - src/cp/domain/connector/EVSettings.ts
+  - src/cp/domain/connector/MeterValueBuilder.ts
+  - src/cp/infrastructure/transport/network-sim/SeededRng.ts
+related:
+  - ../concepts/control-plane.md
+  - ../entities/daemon.md
+  - choosing-an-interface.md
+updated: 2026-09-04
+---
+
+# Fleet, load and observability roadmap
+
+This project can script one charge point precisely and say whether the CSMS
+behaved. What it cannot do is stand up a _fleet_, run plausible traffic against
+a CSMS for an hour, and hand back numbers. That is one coherent body of missing
+work, and this page sequences it.
+
+Everything here is motivated by what the project is for — AI-agent testing, CI
+automation and CSMS development. Nothing on this list is here to fill out a
+feature matrix; each item exists because a concrete CI or CSMS-development task
+is currently impossible or has to be scripted by hand outside the daemon.
+
+**How to use this page.** Each phase is shippable on its own and ordered by
+dependency. Every item carries the files and RPCs it touches, its acceptance
+criteria and a size. Per the [ingest rule](../../CLAUDE.md), the PR that ships
+an item updates its row here — status and issue number — in the same commit, so
+this page stays true as work lands.
+
+**Size key:** S = a few files, one RPC. M = a new subsystem behind an existing
+seam. L = crosses persistence, UI and the scenario schema, or changes the
+runtime model.
+
+## Status at a glance
+
+| #   | Phase                                                        | Size | Depends on | Status      | Issue |
+| --- | ------------------------------------------------------------ | ---- | ---------- | ----------- | ----- |
+| 1a  | [Bulk CP creation](#1a-bulk-cp-creation)                     | S    | —          | planned     | #295  |
+| 1b  | [Multiple supervision URLs](#1b-multiple-supervision-urls)   | S    | —          | planned     | #296  |
+| 1c  | [CP blueprints](#1c-cp-blueprints)                           | M    | 1a         | planned     | #297  |
+| 1d  | [Built-in vendor blueprints](#1d-built-in-vendor-blueprints) | S    | 1c         | planned     | #297  |
+| 2   | [Metrics endpoint](#phase-2--metrics-endpoint)               | M    | —          | planned     | #298  |
+| 3a  | [idTag pool](#3a-idtag-pool)                                 | S    | —          | planned     | #299  |
+| 3b  | [Seeded background traffic](#3b-seeded-background-traffic)   | M    | 3a         | planned     | #300  |
+| 4a  | [Charging-curve EV model](#4a-charging-curve-ev-model)       | L    | —          | planned     | #301  |
+| 4b  | [Signed meter values](#4b-signed-meter-values-optional)      | M    | 4a         | not filed   | —     |
+| 5a  | [Measured scale ceiling](#5a-measured-scale-ceiling)         | S    | 1a, 2      | planned     | #302  |
+| 5b  | [Worker model](#5b-worker-model-conditional)                 | L    | 5a         | conditional | #302  |
+| 6   | [File hot-reload](#phase-6--file-hot-reload)                 | S    | 1c, 3a     | not filed   | —     |
+
+Two items are **not filed** as issues yet — 4b and 6 are the two whose payoff
+is narrowest, and neither blocks anything else.
+
+Two items are deliberately not unconditional. **5b** is gated on the number
+that **5a** produces — building a worker model before knowing where the single
+event loop actually breaks is speculative. **4b** serves only CSMS
+implementations that validate German calibration-law (Eichrecht) meter data,
+which few do.
+
+## Phase 1 — Fleet shape
+
+Today [`cp.create`](../concepts/control-plane.md#cpcreate-parameters) creates
+exactly one CP from an explicit `cpId`. Everything fleet-shaped starts here.
+
+### 1a. Bulk CP creation
+
+**Goal.** One RPC creates N charge points that share a parameter block and
+differ only by generated id.
+
+**Shape.** Add `cp.create_many` rather than overloading `cp.create` — the
+single-CP call returns one CP object and callers depend on that shape.
+
+```
+cp.create_many {
+  count: number,              // 1..limit
+  idPattern: string,          // e.g. "CP{n:03}" → CP001, CP002, …
+  startIndex?: number,        // default 1
+  ...cpParamsBase             // every existing cp.create field, shared
+}
+→ { created: string[], failed: { cpId, reason }[] }
+```
+
+Partial success is the honest result: one bad CSMS URL should not roll back 199
+good CPs. Creation stays sequential so registry events fire in id order.
+
+**Touches.** `src/protocol/methods.ts` (`cpParamsBaseSchema` is already
+factored out — reuse it, do not restate it), `src/cli/server/socketServer.ts`
+(`dispatchRpcCore`), `src/cli/server/CPRegistry.ts`, and a CLI flag pair
+(`--cp-count`, `--cp-id-pattern`) in `src/cli/main.ts`.
+
+**Acceptance.**
+
+- The MCP tool is _derived_ from the zod schema, not restated — this is the
+  lesson from #284 and the reason `cp_create` and `cp.create` stopped
+  disagreeing.
+- A documented, enforced `count` ceiling (`src/protocol/limits.ts`), and a row
+  in [Control plane](../concepts/control-plane.md).
+- e2e against gocpp: create 20 CPs, all reach BootNotification Accepted.
+
+### 1b. Multiple supervision URLs
+
+**Goal.** Point a fleet at a load-balanced CSMS.
+
+**Shape.** `wsUrl` accepts `string | string[]`, plus
+`urlDistribution: "round-robin" | "random" | "cp-affinity"` (default
+`round-robin`). `cp-affinity` hashes the `cpId` so a CP keeps its URL across
+restarts — that is the one policy that makes a reconnect deterministic.
+
+**Touches.** `cpParamsBaseSchema`, and URL selection in
+`src/cp/infrastructure/transport/OCPPWebSocket.ts` beside the existing
+exponential-backoff logic (~L820). Reconnect rotates to the next URL, so a
+dead node drains rather than blocking a CP forever.
+
+**Acceptance.** Reconnect after a forced disconnect lands on a different URL
+under `round-robin` and the same URL under `cp-affinity`; covered by a unit
+test, reusing [network simulation](../concepts/network-simulation.md) to force
+the disconnect.
+
+### 1c. CP blueprints
+
+**Goal.** Name a CP configuration once, instantiate it many times. A
+blueprint is a _hardware_ description (what this charge point is), where a
+scenario is a _behaviour_ description (what it does) — the two compose.
+
+**Shape.** Persist and address blueprints exactly like scenario definitions
+already are (`scenario.definitions.*`):
+
+```
+blueprint.list   {}                       → Blueprint[]
+blueprint.save   { blueprint }            → { id }
+blueprint.delete { id }                   → {}
+cp.create_many   { blueprintId, count, idPattern, overrides? }
+```
+
+A blueprint holds the `cp.create` parameter block plus connector count,
+`vendor` / `model` / firmware / serial prefixes, default EV settings, an
+optional startup scenario template id, and (after 3b) an auto-traffic config.
+
+**Touches.** `src/protocol/methods.ts`, `src/cli/server/socketServer.ts`,
+`src/cp/domain/persistence/schema.ts` (new table + migration — see
+[State persistence](../concepts/state-persistence.md)), and a browser editor
+alongside the scenario editor.
+
+**Acceptance.** A blueprint round-trips through `--state-db` and survives a
+daemon restart; `cp.create_many { blueprintId }` produces CPs indistinguishable
+from the equivalent explicit call.
+
+### 1d. Built-in vendor blueprints
+
+**Goal.** `blueprint.list` returns useful defaults with no setup, the way
+[scenario templates](../entities/scenario-templates.md) do today.
+
+**Shape.** Ship a handful of realistic hardware profiles (AC 3-phase 22 kW, DC
+50 kW, DC 150 kW+, single-connector, multi-connector) as read-only built-ins,
+mirroring the instance semantics scenario templates already use: loading one
+copies it, edits never mutate the built-in.
+
+**Touches.** A new `src/utils/blueprints/` directory with a README that is the
+authoritative id ↔ hardware mapping, exactly as `src/utils/scenarios/README.md`
+is for cert16.
+
+## Phase 2 — Metrics endpoint
+
+**Goal.** A CI job or a Grafana board can answer "how many CPs are connected,
+how many transactions are live, and what is p95 BootNotification round-trip?"
+without parsing logs.
+
+**Shape.** `GET /metrics`, Prometheus text exposition, hand-rolled — the format
+is a few lines and this avoids a Bun-compatibility question on `prom-client`.
+
+Series to start with:
+
+| Metric                              | Type      | Labels                           |
+| ----------------------------------- | --------- | -------------------------------- |
+| `ocppcp_charge_points`              | gauge     | `state`                          |
+| `ocppcp_connectors`                 | gauge     | `status`                         |
+| `ocppcp_transactions_active`        | gauge     | —                                |
+| `ocppcp_ocpp_messages_total`        | counter   | `action`, `direction`, `outcome` |
+| `ocppcp_ocpp_call_duration_seconds` | histogram | `action`                         |
+| `ocppcp_rpc_requests_total`         | counter   | `method`, `outcome`              |
+| `ocppcp_ws_reconnects_total`        | counter   | —                                |
+
+**Cardinality.** Label by `action` and `direction`; **do not** label by `cpId` —
+that is unbounded by construction once phase 1 lands. Per-CP numbers stay in
+`cp.list` and the event stream.
+
+**Latency source.** Both message handlers already track in-flight CALLs —
+`_requests` / `_serialInFlight` in
+`src/cp/infrastructure/transport/OCPPMessageHandler.ts` and `_pendingRequests`
+in `OCPPMessageHandlerV201.ts`. Observe the histogram where those entries are
+resolved. The [trace record](../concepts/trace-format.md) carries no duration
+field, so this is a separate tap, not a trace consumer.
+
+**Touches.** A route in `src/cli/server/httpServer.ts` beside the health probe
+(~L483/565), a counter registry in `src/cli/server/`, and a CLI flag
+(`--metrics` / `--no-metrics`).
+
+**Access control — decide explicitly.** `/v1/healthz` is deliberately
+unauthenticated so container probes work. `/metrics` is different: it exposes
+fleet size and traffic shape. Default it **behind the existing Basic Auth
+gate**, with a documented opt-out flag for a trusted network, and add the row to
+the policy table in [Access control](../concepts/access-control.md).
+
+**Acceptance.** A scrape parses under `promtool check metrics`; the endpoint
+returns 401 under `--basic-auth` without credentials; counters survive a CP
+reconnect.
+
+## Phase 3 — Background load
+
+Scenarios are deterministic graphs that end in a verdict, and they should stay
+that way. "Run plausible traffic for an hour" is a different thing and needs a
+different seam.
+
+### 3a. idTag pool
+
+**Goal.** Draw an idTag from a pool instead of hard-coding one.
+
+**Shape.** A per-CP (or per-blueprint) pool — an inline list or a file path —
+plus `distribution: "round-robin" | "random" | "connector-affinity"`. Random
+draws come from the seeded RNG (below), so a seeded run replays exactly.
+
+**Touches.** `src/protocol/methods.ts`, `CPRegistry`, and a `tagId` resolution
+hook in the transaction path so both scenarios and auto-traffic can say "next
+tag from the pool".
+
+### 3b. Seeded background traffic
+
+**Goal.** Endless plausible charging sessions in the background, so a CSMS
+can be observed under continuous load — and **reproducible**, so a CI failure
+under load can be replayed exactly.
+
+**Design: this is a connector runtime behavior, not a scenario node.** The
+precedent already exists in the codebase: auto-meter is a per-connector
+behavior configured by RPC (`set_auto_meter_config`), persisted under
+`connector_settings.auto_meter.*`, and independent of whether a scenario is
+running (`AutoMeterValueConfig` in
+`src/cp/domain/connector/Connector.ts`). Auto-traffic mirrors it exactly:
+
+```
+cp command:  set_auto_traffic_config { connector, config }
+             get_auto_traffic_config { connector }
+daemon:      connector_settings.auto_traffic.get / .save
+```
+
+```
+AutoTrafficConfig {
+  enabled: boolean,
+  seed: number,                    // reproducibility
+  minDurationSec, maxDurationSec: number,
+  minGapSec, maxGapSec: number,
+  probabilityOfStart: number,      // 0..1, gate per attempt
+  requireAuthorize: boolean,
+  stopAfterSec?: number,
+}
+```
+
+Reuse `deriveSeed32` / the PRNG in
+`src/cp/infrastructure/transport/network-sim/SeededRng.ts` — the same mechanism
+that already makes [network simulation](../concepts/network-simulation.md)
+replayable — deriving each connector's stream from `seed:cpId:connectorId` so
+CPs do not correlate.
+
+**Counters.** Expose per-connector attempted / started / rejected / skipped
+authorize, start and stop counts on connector status; they are also what phase
+2 scrapes.
+
+**Interaction with scenarios — state the rule.** A scenario taking control of a
+connector suspends auto-traffic for that connector and resumes it on scenario
+end. A run's verdict must never depend on background traffic.
+
+**Acceptance.** Two runs with the same seed produce identical transaction start
+times and idTags; an e2e against gocpp runs 3 CPs for 60 s and asserts the
+session count falls in the expected band.
+
+## Phase 4 — Meter realism
+
+### 4a. Charging-curve EV model
+
+**Goal.** MeterValues that a CSMS's load or billing logic can be validated
+against. Today `MeterValueBuilder` derives everything from a flat auto-meter
+rate with fixed 230 V / 25 °C / 50 Hz constants and no phase model.
+
+**Shape.** Extend `EVSettings`
+(`src/cp/domain/connector/EVSettings.ts`, currently `modelName`,
+`batteryCapacityKwh`, `maxChargingPowerKw`, `initialSoc`, `targetSoc`):
+
+```
+chargingCurve?: { socPercent: number, powerFraction: number }[]  // piecewise linear, sorted
+rampShape?: "linear" | "sigmoid"
+currentType?: "AC" | "DC"
+phases?: 1 | 3
+voltageV?: number
+powerFactor?: number        // AC only
+```
+
+`MeterValueBuilder` then derives `Power.Active.Import` from the curve at the
+current SoC, `Current.Import` from `P / (V × phases × powerFactor)`, and emits
+per-phase values when `phases: 3` — so `P`, `I`, `V`, `SoC` and the energy
+register finally agree with each other.
+
+**Composition rule — state it in code and docs.** Effective power is
+**`min(curve-derived power, ChargingScheduleResolver limit)`**. The smart
+charging cap already works
+(`src/cp/domain/connector/ChargingScheduleResolver.ts` →
+`Connector.resolveEffectiveLimitWatts`) and must keep winning; the curve only
+lowers demand, never raises it above a profile.
+
+**This is the fan-out item.** It reaches `EVSettings.ts`,
+`MeterValueBuilder.ts`, the `evSettings` block in the
+[scenario format](../concepts/scenario-format.md) — which needs a **schema
+version bump and a changelog entry** — `schema/scenario.schema.json`,
+[state persistence](../concepts/state-persistence.md), the browser EV settings
+UI, and `EvSettingsJson` in `src/cli/exportK6/runtime/types.ts`. Decide up
+front: **the k6 export ignores the curve in v1** and keeps its flat rate,
+rather than porting the model into the k6 runtime.
+
+**Acceptance.** Old scenarios without a curve produce byte-identical
+MeterValues (the curve is opt-in); a curved DC session shows power tapering
+above the knee SoC; a SetChargingProfile below the curve still caps.
+
+### 4b. Signed meter values (optional)
+
+**Goal.** Serve CSMS implementations that validate German calibration-law
+(Eichrecht) meter data.
+
+**Shape.** The vendor-specific 1.6 configuration keys the ecosystem has
+settled on — `SigningMethod`, `MeterPublicKey[ConnectorID]`, `SampledDataSign*`,
+`AlignedDataSign*` — plus an OCMF-shaped payload emitted as
+`format: "SignedData"`. The
+`format: "SignedData"` enum member already exists in
+`src/cp/domain/connector/MeterValueBuilder.ts`; nothing generates it.
+
+**Do this only on demand.** It is niche, it is the one item with no CI or
+agent-testing payoff, and signing keys add a key-management surface.
+
+## Phase 5 — Scale
+
+### 5a. Measured scale ceiling
+
+**Goal.** Replace "no documented per-process limit" in
+[Daemon → Limits](../entities/daemon.md#limits--roadmap) with a number.
+
+**Shape.** A benchmark script (`scripts/bench/`) that uses 1a to create N CPs
+against gocpp, drives heartbeats and transactions, and reads phase 2's
+histograms to find where per-CP overhead starts distorting timing. Report the
+knee for a stated machine.
+
+**Acceptance.** The number, the method, and the machine are all in
+`daemon.md`. This is the cheapest item on this page and it is what makes 5b a
+decision rather than a guess.
+
+### 5b. Worker model (conditional)
+
+**Goal.** Push past the single-event-loop ceiling, if 5a shows the ceiling is
+too low for real use.
+
+**Shape.** Bun `Worker` threads, CPs sharded across them, the Socket.IO control
+plane staying on the main thread and forwarding commands. The hard parts are
+real and should be scoped before any code: `@socket.io/bun-engine` on the main
+thread only, SQLite access from multiple threads
+(`src/cp/domain/persistence/BunSqliteDatabase.ts` — one writer, or route all
+writes through the main thread), and keeping the event stream ordered per CP.
+
+**Decide after 5a.** If the ceiling is comfortably above what CI jobs ask for,
+`export-k6` already covers the case where load must come from outside the
+daemon, and this phase should be dropped rather than built.
+
+## Phase 6 — File hot-reload
+
+**Goal.** Edit a blueprint, scenario or idTag file and have running CPs pick it
+up without a restart.
+
+**Shape.** `fs.watch` with debounce on the files 1c and 3a make loadable, a
+`--watch` flag to opt in, and an explicit rule for what a reload does to a CP
+mid-transaction (answer: nothing — new settings apply to the next session).
+
+**Last on purpose.** Only meaningful once blueprints and idTag pools are
+file-loadable, and this project's agent-driven workflows go through RPCs rather
+than files — so this serves the human editing a file by hand, which is the
+narrower audience.
+
+## What is explicitly not planned
+
+- **Config-file-first operation.** The control plane is this project's
+  primary interface. A config-file hierarchy that could also create and
+  configure CPs would be a competing source of truth, and agent-driven and
+  file-driven state would drift apart.
+- **A performance-statistics storage backend** (MongoDB / ORM). Phase 2 exposes
+  live metrics for a scraper to store; this project should not own a
+  time-series store.
+- **Dropping determinism.** Every random behavior added here is seeded, so a CI
+  failure can be replayed.

--- a/docs/analyses/fleet-load-and-observability-roadmap.md
+++ b/docs/analyses/fleet-load-and-observability-roadmap.md
@@ -130,8 +130,9 @@ rather than copy that.
 **Failover semantics — state it, do not imply it.** `round-robin` and `random`
 move to another URL on every reconnect attempt. `cp-affinity` hashes the `cpId`
 to a **primary** and is sticky: it retries that primary and only falls over
-after a configured number of consecutive failures, returning to it as soon as it
-is reachable again. "Sticky" and "always rotates" are contradictory, and
+after **three** consecutive failures — a fixed implementation constant
+(`DEFAULT_AFFINITY_FAILOVER_THRESHOLD`), not a per-charge-point field — and
+returns to the primary as soon as it is reachable again. "Sticky" and "always rotates" are contradictory, and
 choosing between them silently is how an acceptance test ends up asserting the
 opposite of the implementation.
 
@@ -143,9 +144,14 @@ So:
 
 - The list is an **OCPP-J** concept. SOAP takes `centralSystemUrl` and has no
   reconnect loop to rotate; reject an array there rather than half-supporting it.
-- Keep the list in the CP's config and resolve one URL at connect time. What is
-  persisted and reported in the snapshot stays a single string, so neither the
-  DB schema nor the restore path changes.
+- Resolve one URL at connect time, so the status snapshot and every log line
+  keep reporting a single string.
+- **Persist the list.** `charge_points` holds only `ws_url`, and
+  `CPRegistry.restoreFromDatabase` restores only that, so a charge point
+  created with a list would come back from `--state-db` with failover silently
+  disabled — the one thing the list exists to provide. The list and the policy
+  need columns of their own and a schema bump; `ws_url` keeps its meaning, so
+  no existing reader changes.
 
 **Touches.** `cpParamsBaseSchema` in `src/protocol/methods.ts`, the resolution
 step in `src/cli/service.ts`, and URL selection in
@@ -155,8 +161,8 @@ exponential-backoff logic (~L820).
 **Acceptance.** After a forced disconnect (reusing
 [network simulation](../concepts/network-simulation.md)) `round-robin` lands on
 the next URL while `cp-affinity` retries its primary; after the configured
-number of consecutive failures `cp-affinity` moves on, and returns to the
-primary once it is reachable. A SOAP CP rejects an array `wsUrl` with a clear
+three consecutive failures `cp-affinity` moves on, and returns to the primary
+once it is reachable. A SOAP CP rejects an array `wsUrl` with a clear
 error. The persisted `ws_url` and the status snapshot are unchanged in shape.
 
 ### 1c. CP blueprints
@@ -223,7 +229,8 @@ Series to start with:
 | `ocppcp_rpc_requests_total`         | counter   | `method`, `outcome`              |
 | `ocppcp_ws_reconnects_total`        | counter   | —                                |
 
-**Cardinality.** Label by `action` and `direction`; **do not** label by `cpId` —
+**Cardinality.** Use only the bounded labels in the table above — `action`,
+`direction`, `state`, `status`, `method`, `outcome` — and **never** `cpId` —
 that is unbounded by construction once phase 1 lands. Per-CP numbers stay in
 `cp.list` and the event stream.
 
@@ -311,16 +318,22 @@ replayable — deriving each connector's stream from `seed:cpId:connectorId` so
 CPs do not correlate.
 
 **Counters.** Expose per-connector attempted / started / rejected / skipped
-authorize, start and stop counts on connector status; they are also what phase
-2 scrapes.
+authorize, start and stop counts on connector status — that is the assertion
+surface. Phase 2 scrapes them **aggregated**, as
+`ocppcp_auto_traffic_sessions_total{outcome}` and
+`ocppcp_auto_traffic_skipped_total{reason}`: per-connector series would need a
+`cpId` label, which the cardinality rule forbids.
 
 **Interaction with scenarios — state the rule.** A scenario taking control of a
 connector suspends auto-traffic for that connector and resumes it on scenario
 end. A run's verdict must never depend on background traffic.
 
-**Acceptance.** Two runs with the same seed produce identical transaction start
-times and idTags; an e2e against gocpp runs 3 CPs for 60 s and asserts the
-session count falls in the expected band.
+**Acceptance.** Two runs with the same seed produce the identical _sequence_ of
+drawn gaps, durations and idTags. The seed fixes the draws, not the clock — the
+timer path is `setTimeout` / `Date.now()`, so wall-clock timestamps still vary
+between runs. Assert on the logical offsets the generator computed, or on
+observed times within a stated tolerance; never on exact timestamps. Plus an
+e2e against gocpp: 3 CPs for 60 s, session count within the expected band.
 
 ## Phase 4 — Meter realism
 
@@ -344,9 +357,11 @@ powerFactor?: number        // AC only
 ```
 
 `MeterValueBuilder` then derives `Power.Active.Import` from the curve at the
-current SoC, `Current.Import` from `P / (V × phases × powerFactor)`, and emits
-per-phase values when `phases: 3` — so `P`, `I`, `V`, `SoC` and the energy
-register finally agree with each other.
+current SoC and current from the type-appropriate relation — DC has no
+reactive component, so `I = P / V`; AC is `I = P / (V × phases × powerFactor)`
+with `voltageV` read as **phase-to-neutral** — and emits per-phase values when
+`phases: 3`. `P`, `I`, `V`, `SoC` and the energy register then agree with each
+other rather than being independently plausible.
 
 **Composition rule — state it in code and docs.** Effective power is
 **`min(curve-derived power, ChargingScheduleResolver limit)`**. The smart

--- a/docs/concepts/control-plane.md
+++ b/docs/concepts/control-plane.md
@@ -14,6 +14,7 @@ related:
   - log-format.md
   - state-persistence.md
   - ../analyses/rest-to-socketio-migration.md
+  - ../analyses/fleet-load-and-observability-roadmap.md
 updated: 2026-09-04
 ---
 

--- a/docs/entities/daemon.md
+++ b/docs/entities/daemon.md
@@ -14,7 +14,8 @@ related:
   - ../concepts/access-control.md
   - ../concepts/state-persistence.md
   - ../concepts/log-format.md
-updated: 2026-09-03
+  - ../analyses/fleet-load-and-observability-roadmap.md
+updated: 2026-09-04
 ---
 
 # Daemon (server mode)
@@ -161,3 +162,6 @@ see [Docker image](docker-image.md).
   Unix-domain socket control listener.
 - Future: bearer token auth or mTLS can be added at the HTTP/socket boundary
   without changing CP command method names.
+- Planned: fleet-scale creation, a metrics endpoint, seeded background traffic
+  and a measured per-process ceiling are sequenced in
+  [Fleet, load and observability roadmap](../analyses/fleet-load-and-observability-roadmap.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 title: Index
 type: index
 summary: Catalog of every page in the wiki with a one-line summary, by category. Read this first when answering a question.
-updated: 2026-09-03
+updated: 2026-09-04
 ---
 
 # Index
@@ -59,12 +59,13 @@ Start at [Overview](overview.md). Conventions for pages are in
 
 ## Analyses (`analyses/`)
 
-| Page                                                                 | Summary                                                                                      |
-| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| [Choosing an interface](analyses/choosing-an-interface.md)           | Use-case → interface table and a feature-coverage matrix across web / desktop / daemon / CLI |
-| [Driving from an AI agent](analyses/driving-from-an-ai-agent.md)     | Feature checklist, minimal setup, MCP vs CLI vs socket.io-client, assertion patterns         |
-| [REST → Socket.IO migration](analyses/rest-to-socketio-migration.md) | Endpoint-by-endpoint mapping from the removed REST / WebSocket / Unix-socket control surface |
-| [Testing strategy](analyses/testing-strategy.md)                     | Vitest vs Bun test, merged coverage, and the e2e / steve-verify / Testcontainers layers      |
+| Page                                                                                      | Summary                                                                                                                                                                   |
+| ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Choosing an interface](analyses/choosing-an-interface.md)                                | Use-case → interface table and a feature-coverage matrix across web / desktop / daemon / CLI                                                                              |
+| [Driving from an AI agent](analyses/driving-from-an-ai-agent.md)                          | Feature checklist, minimal setup, MCP vs CLI vs socket.io-client, assertion patterns                                                                                      |
+| [REST → Socket.IO migration](analyses/rest-to-socketio-migration.md)                      | Endpoint-by-endpoint mapping from the removed REST / WebSocket / Unix-socket control surface                                                                              |
+| [Testing strategy](analyses/testing-strategy.md)                                          | Vitest vs Bun test, merged coverage, and the e2e / steve-verify / Testcontainers layers                                                                                   |
+| [Fleet, load and observability roadmap](analyses/fleet-load-and-observability-roadmap.md) | Sequenced plan for fleet-scale work: bulk create and blueprints, `/metrics`, seeded background traffic, charging-curve meter values, a measured scale ceiling, hot-reload |
 
 ## Raw assets kept under `docs/`
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -115,3 +115,9 @@ knowledge first entered the documentation, not wiki operations.
 
 - [OCPP versions & transports](concepts/ocpp-versions-and-transports.md#inbound-cscp-request-validation): new section. A CS→CP request on a 1.6-S charge point is validated against its vendored schema and a malformed one gets a Fault naming the missing element, where six operations previously answered a plausible OCPP status and one leaked a JavaScript TypeError. Records the 1.6-S scope and why coercion stays on every dialect.
 - [GitHub issues](sources/github-issues.md): #285 row.
+
+## [2026-09-04] query | Sequencing the fleet-scale, load and observability work
+
+- [Fleet, load and observability roadmap](analyses/fleet-load-and-observability-roadmap.md): new page. Twelve items in six dependency-ordered phases — bulk CP creation and blueprints, multiple supervision URLs, a `/metrics` endpoint, an idTag pool and seeded background traffic, a charging-curve EV model, a measured scale ceiling, file hot-reload — each with the files and RPCs it touches, acceptance criteria and a size. Two design calls recorded: background traffic is a per-connector runtime behavior configured by RPC (mirroring `AutoMeterValueConfig` / `connector_settings.auto_meter.*`), not a scenario node type, because scenarios are deterministic and end in a verdict; and the worker/thread model is conditional on the ceiling phase 5a measures rather than assumed. `/metrics` defaults behind the Basic Auth gate (unlike `/v1/healthz`) and never labels by `cpId`. The charging-curve EV model needs a scenario-format version bump, and effective power is `min(curve, ChargingScheduleResolver limit)`. Records what is explicitly not planned: config-file-first operation, a performance-statistics storage backend, and any unseeded randomness.
+- [Index](index.md): analyses row.
+- [Daemon](entities/daemon.md#limits--roadmap): the Limits section points at the roadmap; `related:` both ways.

--- a/docs/sources/github-issues.md
+++ b/docs/sources/github-issues.md
@@ -6,6 +6,7 @@ sources:
   - https://github.com/shiv3/ocpp-cp-simulator/issues
 related:
   - ../log.md
+  - ../analyses/fleet-load-and-observability-roadmap.md
 updated: 2026-09-04
 ---
 
@@ -47,5 +48,13 @@ All under https://github.com/shiv3/ocpp-cp-simulator unless noted.
 | #286                                             | `connect_failed` for a refused handshake; a misplaced `cpId` is `invalid_params`                       | [Control plane](../concepts/control-plane.md#rpc)                                                                                          |
 | #288                                             | A refused WebSocket upgrade logs the HTTP status behind it                                             | [Log format](../concepts/log-format.md#websocket-handshake-failures)                                                                       |
 | #289                                             | `--tls-ca` is optional and replaces the default roots; the CSMS can refuse a correct profile-2 station | [Security profiles](../concepts/security-profiles.md#--tls-ca-is-optional-and-it-replaces-rather-than-adds)                                |
+| #295                                             | Bulk CP creation (`cp.create_many`) — a fleet from one call                                            | [Fleet, load and observability roadmap](../analyses/fleet-load-and-observability-roadmap.md)                                               |
+| #296                                             | Multiple supervision URLs with a distribution and failover policy                                      | [Fleet, load and observability roadmap](../analyses/fleet-load-and-observability-roadmap.md)                                               |
+| #297                                             | CP blueprints — a named, reusable hardware description                                                 | [Fleet, load and observability roadmap](../analyses/fleet-load-and-observability-roadmap.md)                                               |
+| #298                                             | Prometheus `/metrics` on the daemon                                                                    | [Fleet, load and observability roadmap](../analyses/fleet-load-and-observability-roadmap.md)                                               |
+| #299                                             | idTag pool with a distribution policy                                                                  | [Fleet, load and observability roadmap](../analyses/fleet-load-and-observability-roadmap.md)                                               |
+| #300                                             | Seeded background traffic as a per-connector runtime behaviour                                         | [Fleet, load and observability roadmap](../analyses/fleet-load-and-observability-roadmap.md)                                               |
+| #301                                             | Charging-curve EV model behind MeterValues                                                             | [Fleet, load and observability roadmap](../analyses/fleet-load-and-observability-roadmap.md)                                               |
+| #302                                             | Measured per-daemon charge-point ceiling                                                               | [Fleet, load and observability roadmap](../analyses/fleet-load-and-observability-roadmap.md)                                               |
 | steve-community/steve #2068, #2069, #2070, #2074 | SteVe REST API gaps                                                                                    | [steve-verify](steve-verify-readme.md), [CSMS peers](../entities/csms-peers.md)                                                            |
 | steve-community/steve #2093                      | OCTT certificate behaviors                                                                             | [Scenario format](../concepts/scenario-format.md#inboundpolicy-and-certificate-quirks-notes)                                               |


### PR DESCRIPTION
## Summary

The daemon can script one charge point precisely; it cannot stand up a fleet, run plausible traffic for an hour, and hand back numbers. That is one coherent body of missing work, and it was tracked nowhere. This adds the page that sequences it, and files the issues it points at (#295–#302).

Twelve items in six dependency-ordered phases, each with the files and RPCs it touches, acceptance criteria, a size and the issue tracking it. Two items (signed meter values, file hot-reload) are deliberately **not filed** — narrowest payoff, and neither blocks anything else.

## Two design calls recorded here rather than re-litigated per PR

**Background traffic is not a scenario node type.** Scenarios are deterministic graphs that terminate in a verdict (#179); a non-terminating random construct does not belong inside the thing whose value is that it terminates with an answer. It becomes a per-connector runtime behaviour configured by RPC, mirroring `AutoMeterValueConfig` / `connector_settings.auto_meter.*` — a shape that already exists in the codebase.

**The worker/thread model is conditional on measurement.** Phase 5a measures where a single Bun event loop actually degrades; 5b is a decision taken after that number exists, not before. Building it on a hunch is how that change gets too large to review.

Also states what is explicitly *not* planned: config-file-first operation (the control plane is the source of truth; a second one would let agent-driven and file-driven state drift), a performance-statistics storage backend, and any unseeded randomness.

## Review

`codex review --base main` raised seven findings on the first commit; all seven were verified against the code and fixed in a2801e7. The substantive ones:

- The page said to reuse `cpParamsBaseSchema` for bulk creation. It cannot be: the base **requires** `cpId` (which bulk creation generates) and does **not** carry `basicAuth`, which `createParamsSchema` adds by `.extend()`. Now derives from `createParamsSchema.omit({ cpId: true })`. Codex also surfaced that `autoConnect` is declared in no schema today and is read straight off raw params — noted as a loose end for #295 to close.
- Array `wsUrl` was under-scoped. `wsUrl` is a `string` well past the schema — `buildBaseUrl`, the `ChargePoint` init options, the status snapshot, `charge_points.ws_url TEXT NOT NULL`. The page now scopes arrays to OCPP-J, rejects them for SOAP, and resolves one URL before anything is persisted, so neither the DB schema nor the restore path changes.
- `cp-affinity` contradicted itself: the prose said reconnect always rotates, the acceptance criterion required the same URL. Now sticky with an explicit failover threshold — the behaviour a test can actually assert.
- The metrics acceptance named a `--basic-auth` flag that does not exist. `--basic-auth-user/pass` is the CSMS-facing credential and `--http-basic-auth-user/pass` is what `analyze --from-daemon` uses; the gate covering daemon HTTP is `--web-console-basic-auth-*`.
- Provenance and reciprocal wiki links per `conventions.md` / `CLAUDE.md`.

## Checks

`bun run lint`, `bun run format:check`, wiki link lint (0 problems). Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014udBrUFZpA5WqirTnCzMGH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a roadmap covering fleet creation, blueprints, metrics, seeded background traffic, EV charging models, scaling measurements, and file hot-reload.
  - Documented phased dependencies, acceptance criteria, authentication and persistence constraints, deterministic behavior, and excluded capabilities.
  - Updated related-document links, analysis indexes, daemon guidance, documentation timestamps, and the documentation log.
  - Added references to related issues covering bulk creation, supervision URLs, Prometheus metrics, idTag pools, background traffic, charging models, and capacity limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->