### PR TITLE
docs(security-profiles): link the measured profile-2-behind-a-TLS-edge write-up (#289)

### DIFF
--- a/docs/concepts/security-profiles.md
+++ b/docs/concepts/security-profiles.md
@@ -6,12 +6,13 @@ sources:
   - README.md (Security Profiles section, PR #97 / issue #94)
   - src/cli/
   - src/cp/infrastructure/transport/wsUrlWithBasic.ts (scheme rule, issue #277; TLS options, issue #289)
+  - https://gist.github.com/juherr/2c5ca12a562a07f7a0da7ccbbb46b160 (profile 2 behind a TLS-terminating edge, measured on 0.7.8; issue #289)
 related:
   - ../entities/cli.md
   - ../entities/csms-peers.md
   - access-control.md
   - scenario-format.md
-updated: 2026-09-04
+updated: 2026-09-12
 ---
 
 # OCPP 1.6 security profiles
@@ -132,6 +133,17 @@ The same reasoning covers the daemon's own
 
 **Configure the CSMS first, then switch the station over.** In the other
 order the station is locked out in between.
+
+The whole case — symptom, why the edge causes it, a three-probe procedure
+that proves which side is at fault, the ordering trap, and the two edge
+behaviours that bite afterwards (idle timeouts versus `HeartbeatInterval`;
+a publicly-issued certificate needing no `--tls-ca`) — is written up with
+measurements in [OCPP 1.6 security profile 2 against a CSMS behind a
+TLS-terminating edge](https://gist.github.com/juherr/2c5ca12a562a07f7a0da7ccbbb46b160)
+(juherr, 2026-09-03; simulator 0.7.8 against SteVe 3.14.1 behind Traefik
+and Cloudflare). The witness probe there — a profile-1 station with the same
+credentials answering `101` — is what rules the password out before the
+proxy is suspected.
 
 ## Examples (against SteVe)
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -854,3 +854,8 @@ other. Reworded on all three pages to say what is and is not watched (the
 [Control plane](concepts/control-plane.md#daemon-methods) and
 [Access control](concepts/access-control.md), which omitted `config`,
 `scenario-definitions` and `file-reload`.
+
+## [2026-09-12] ingest | The profile-2-behind-a-TLS-edge case has a measured write-up (#289)
+
+- [Security profiles](concepts/security-profiles.md#the-csms-gets-a-vote) now links juherr's gist — the full case the page's section summarises: `401` surfacing as `code=1002, Expected 101 status code`, why a TLS-terminating edge makes the CSMS refuse a correct profile-2 station, a three-probe procedure with a profile-1 witness station that rules the password out, the configure-CSMS-first ordering trap, and the two edge behaviours after the handshake (idle timeouts versus `HeartbeatInterval`; a public certificate needing no `--tls-ca`, which is this page's #289 point 1). Measured on 0.7.8 against SteVe 3.14.1 behind Traefik and Cloudflare; the author offered it CC-free in #289 on 2026-09-03.
+- Added to the page's `sources:` as an external document rather than summarised into a `sources/` page: the section already carries the contract sentences, and the gist is the evidence, not a new mechanism.


### PR DESCRIPTION
Refs #289. juherr wrote the whole case up as a public gist on 2026-09-03 (measured on 0.7.8 against SteVe 3.14.1 behind Traefik and Cloudflare) and offered it CC-free for linking. This adds the link to the section of [Security profiles](docs/concepts/security-profiles.md#the-csms-gets-a-vote) that already summarises the mechanism, lists it in the page's `sources:`, bumps `updated:`, and appends a `log.md` entry. Docs only; link check 0 problems.